### PR TITLE
Constant-time note commitment

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,8 +29,8 @@ blake2b_simd = "1"
 ff = "0.12"
 fpe = "0.5"
 group = { version = "0.12.1", features = ["wnaf-memuse"] }
-halo2_gadgets = "0.2"
-halo2_proofs = "0.2"
+halo2_gadgets = {git = "https://github.com/QED-it/halo2", branch = "add_sinsemilla_functionalities"}
+halo2_proofs = {git = "https://github.com/QED-it/halo2", branch = "add_sinsemilla_functionalities"}
 hex = "0.4"
 lazy_static = "1"
 memuse = { version = "0.2.1", features = ["nonempty"] }
@@ -52,7 +52,7 @@ plotters = { version = "0.3.0", optional = true }
 
 [dev-dependencies]
 criterion = "0.3"
-halo2_gadgets = { version = "0.2", features = ["test-dependencies"] }
+halo2_gadgets = { git = "https://github.com/QED-it/halo2", branch = "add_sinsemilla_functionalities", features = ["test-dependencies"] }
 hex = "0.4"
 proptest = "1.0.0"
 zcash_note_encryption = { version = "0.2", features = ["pre-zip-212"] }


### PR DESCRIPTION
We would like to have a constant-time evaluation of the note commitment for both ZEC and ZSA.
ZEC_note_commitment=Extract_P(SinsemillaHashToPoint(zec_personalization, common_bits) + [rcm]R_zec)
ZSA_note_commitment=Extract_P(SinsemillaHashToPoint(zsa_personalization, common_bits || asset) + [rcm]R_zsa)