### PR TITLE
Do not create split notes with native asset

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -171,6 +171,7 @@ impl SpendInfo {
     /// fvk to generate a different nullifier. In addition, the split_flag is raised.
     ///
     /// Defined in [Transfer and Burn of Zcash Shielded Assets ZIP-0226 § Split Notes (DRAFT PR)][TransferZSA].
+    ///
     /// [TransferZSA]: https://qed-it.github.io/zips/zip-0226.html#split-notes
     fn create_split_spend(&self, rng: &mut impl RngCore) -> Self {
         let note = self.note;

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -445,6 +445,25 @@ impl Builder {
         i64::try_from(value_balance).and_then(|i| V::try_from(i).map_err(|_| value::OverflowError))
     }
 
+    fn spend_info_extension(
+        first_spend: Option<SpendInfo>,
+        asset: AssetBase,
+        mut rng: impl RngCore,
+    ) -> SpendInfo {
+        if asset.is_native().into() {
+            // For native asset, extends with dummy notes
+            SpendInfo::dummy(asset, &mut rng)
+        } else {
+            // For ZSA asset, extends with
+            // - dummy notes if first spend is empty
+            // - split notes otherwise.
+            first_spend.map_or_else(
+                || SpendInfo::dummy(asset, &mut rng),
+                |s| s.create_split_spend(),
+            )
+        }
+    }
+
     /// Builds a bundle containing the given spent notes and recipients.
     ///
     /// The returned bundle will have no proof or signatures; these can be applied with

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -478,23 +478,6 @@ impl Builder {
         for (asset, (mut spends, mut recipients)) in
             partition_by_asset(&self.spends, &self.recipients, &mut rng)
         {
-            fn pad_spend(
-                spend: Option<&SpendInfo>,
-                asset: AssetBase,
-                mut rng: impl RngCore,
-            ) -> SpendInfo {
-                if asset.is_native().into() {
-                    // For native asset, extends with dummy notes
-                    SpendInfo::dummy(asset, &mut rng)
-                } else {
-                    // For ZSA asset, extends with
-                    // - dummy notes if first spend is empty
-                    // - split notes otherwise.
-                    let dummy = SpendInfo::dummy(asset, &mut rng);
-                    spend.map_or_else(|| dummy, |s| s.create_split_spend(&mut rng))
-                }
-            }
-
             let num_spends = spends.len();
             let num_recipients = recipients.len();
             let num_actions = [num_spends, num_recipients, MIN_ACTIONS]
@@ -608,6 +591,20 @@ fn partition_by_asset(
     }
 
     hm
+}
+
+/// Returns a dummy/split notes to extend the spends.
+fn pad_spend(spend: Option<&SpendInfo>, asset: AssetBase, mut rng: impl RngCore) -> SpendInfo {
+    if asset.is_native().into() {
+        // For native asset, extends with dummy notes
+        SpendInfo::dummy(asset, &mut rng)
+    } else {
+        // For ZSA asset, extends with
+        // - dummy notes if first spend is empty
+        // - split notes otherwise.
+        let dummy = SpendInfo::dummy(asset, &mut rng);
+        spend.map_or_else(|| dummy, |s| s.create_split_spend(&mut rng))
+    }
 }
 
 /// Marker trait representing bundle signatures in the process of being created.

--- a/tests/zsa.rs
+++ b/tests/zsa.rs
@@ -261,7 +261,24 @@ fn build_and_verify_bundle(
     // Verify the shielded bundle, currently without the proof.
     verify_bundle(&shielded_bundle, &keys.vk, true);
     assert_eq!(shielded_bundle.actions().len(), expected_num_actions);
+    assert!(verify_unique_spent_nullifiers(&shielded_bundle));
     Ok(())
+}
+
+fn verify_unique_spent_nullifiers(bundle: &Bundle<Authorized, i64>) -> bool {
+    let spent_nullifiers = bundle
+        .actions()
+        .iter()
+        .map(|action| *action.nullifier())
+        .collect::<Vec<_>>();
+    for (i, nullifier) in spent_nullifiers.iter().enumerate() {
+        for other_nullifier in spent_nullifiers[i + 1..].iter() {
+            if *nullifier == *other_nullifier {
+                return false;
+            }
+        }
+    }
+    true
 }
 
 /// Issue several ZSA and native notes and spend them in different combinations, e.g. split and join

--- a/tests/zsa.rs
+++ b/tests/zsa.rs
@@ -332,23 +332,28 @@ fn zsa_issue_and_transfer() {
     )
     .unwrap();
 
-    // 2. Split single ZSA note into 2 notes
-    let delta = 2; // arbitrary number for value manipulation
+    // 2. Split single ZSA note into 3 notes
+    let delta1 = 2; // arbitrary number for value manipulation
+    let delta2 = 5; // arbitrary number for value manipulation
     build_and_verify_bundle(
         vec![&zsa_spend_1],
         vec![
             TestOutputInfo {
-                value: NoteValue::from_raw(zsa_spend_1.note.value().inner() - delta),
+                value: NoteValue::from_raw(zsa_spend_1.note.value().inner() - delta1 - delta2),
                 asset: zsa_spend_1.note.asset(),
             },
             TestOutputInfo {
-                value: NoteValue::from_raw(delta),
+                value: NoteValue::from_raw(delta1),
+                asset: zsa_spend_1.note.asset(),
+            },
+            TestOutputInfo {
+                value: NoteValue::from_raw(delta2),
                 asset: zsa_spend_1.note.asset(),
             },
         ],
         vec![],
         anchor,
-        2,
+        3,
         &keys,
     )
     .unwrap();
@@ -374,11 +379,11 @@ fn zsa_issue_and_transfer() {
         vec![&zsa_spend_1, &zsa_spend_2],
         vec![
             TestOutputInfo {
-                value: NoteValue::from_raw(zsa_spend_1.note.value().inner() - delta),
+                value: NoteValue::from_raw(zsa_spend_1.note.value().inner() - delta1),
                 asset: zsa_spend_1.note.asset(),
             },
             TestOutputInfo {
-                value: NoteValue::from_raw(zsa_spend_2.note.value().inner() + delta),
+                value: NoteValue::from_raw(zsa_spend_2.note.value().inner() + delta1),
                 asset: zsa_spend_2.note.asset(),
             },
         ],
@@ -418,13 +423,21 @@ fn zsa_issue_and_transfer() {
                 asset: zsa_spend_1.note.asset(),
             },
             TestOutputInfo {
-                value: native_spend.note.value(),
+                value: NoteValue::from_raw(native_spend.note.value().inner() - delta1 - delta2),
+                asset: AssetBase::native(),
+            },
+            TestOutputInfo {
+                value: NoteValue::from_raw(delta1),
+                asset: AssetBase::native(),
+            },
+            TestOutputInfo {
+                value: NoteValue::from_raw(delta2),
                 asset: AssetBase::native(),
             },
         ],
         vec![],
         native_anchor,
-        4,
+        5,
         &keys,
     )
     .unwrap();
@@ -467,11 +480,11 @@ fn zsa_issue_and_transfer() {
             vec![&zsa_spend_t7_1, &zsa_spend_t7_2],
             vec![
                 TestOutputInfo {
-                    value: NoteValue::from_raw(zsa_spend_t7_1.note.value().inner() + delta),
+                    value: NoteValue::from_raw(zsa_spend_t7_1.note.value().inner() + delta1),
                     asset: zsa_spend_t7_1.note.asset(),
                 },
                 TestOutputInfo {
-                    value: NoteValue::from_raw(zsa_spend_t7_2.note.value().inner() - delta),
+                    value: NoteValue::from_raw(zsa_spend_t7_2.note.value().inner() - delta1),
                     asset: zsa_spend_t7_2.note.asset(),
                 },
             ],

--- a/tests/zsa.rs
+++ b/tests/zsa.rs
@@ -266,19 +266,18 @@ fn build_and_verify_bundle(
 }
 
 fn verify_unique_spent_nullifiers(bundle: &Bundle<Authorized, i64>) -> bool {
+    let mut unique_nulifiers = Vec::new();
     let spent_nullifiers = bundle
         .actions()
         .iter()
         .map(|action| *action.nullifier())
         .collect::<Vec<_>>();
-    for (i, nullifier) in spent_nullifiers.iter().enumerate() {
-        for other_nullifier in spent_nullifiers[i + 1..].iter() {
-            if *nullifier == *other_nullifier {
-                return false;
-            }
-        }
-    }
-    true
+    spent_nullifiers.iter().enumerate().all(|(i, item)| {
+        unique_nulifiers.push(*item);
+        // Check if the item is already in the unique_nullifiers vector by checking that the first
+        // position of the item is equal to the current index i.
+        unique_nulifiers.iter().position(|x| x == item) == Some(i)
+    })
 }
 
 /// Issue several ZSA and native notes and spend them in different combinations, e.g. split and join
@@ -333,21 +332,21 @@ fn zsa_issue_and_transfer() {
     .unwrap();
 
     // 2. Split single ZSA note into 3 notes
-    let delta1 = 2; // arbitrary number for value manipulation
-    let delta2 = 5; // arbitrary number for value manipulation
+    let delta_1 = 2; // arbitrary number for value manipulation
+    let delta_2 = 5; // arbitrary number for value manipulation
     build_and_verify_bundle(
         vec![&zsa_spend_1],
         vec![
             TestOutputInfo {
-                value: NoteValue::from_raw(zsa_spend_1.note.value().inner() - delta1 - delta2),
+                value: NoteValue::from_raw(zsa_spend_1.note.value().inner() - delta_1 - delta_2),
                 asset: zsa_spend_1.note.asset(),
             },
             TestOutputInfo {
-                value: NoteValue::from_raw(delta1),
+                value: NoteValue::from_raw(delta_1),
                 asset: zsa_spend_1.note.asset(),
             },
             TestOutputInfo {
-                value: NoteValue::from_raw(delta2),
+                value: NoteValue::from_raw(delta_2),
                 asset: zsa_spend_1.note.asset(),
             },
         ],
@@ -379,11 +378,11 @@ fn zsa_issue_and_transfer() {
         vec![&zsa_spend_1, &zsa_spend_2],
         vec![
             TestOutputInfo {
-                value: NoteValue::from_raw(zsa_spend_1.note.value().inner() - delta1),
+                value: NoteValue::from_raw(zsa_spend_1.note.value().inner() - delta_1),
                 asset: zsa_spend_1.note.asset(),
             },
             TestOutputInfo {
-                value: NoteValue::from_raw(zsa_spend_2.note.value().inner() + delta1),
+                value: NoteValue::from_raw(zsa_spend_2.note.value().inner() + delta_1),
                 asset: zsa_spend_2.note.asset(),
             },
         ],
@@ -423,15 +422,15 @@ fn zsa_issue_and_transfer() {
                 asset: zsa_spend_1.note.asset(),
             },
             TestOutputInfo {
-                value: NoteValue::from_raw(native_spend.note.value().inner() - delta1 - delta2),
+                value: NoteValue::from_raw(native_spend.note.value().inner() - delta_1 - delta_2),
                 asset: AssetBase::native(),
             },
             TestOutputInfo {
-                value: NoteValue::from_raw(delta1),
+                value: NoteValue::from_raw(delta_1),
                 asset: AssetBase::native(),
             },
             TestOutputInfo {
-                value: NoteValue::from_raw(delta2),
+                value: NoteValue::from_raw(delta_2),
                 asset: AssetBase::native(),
             },
         ],
@@ -480,11 +479,11 @@ fn zsa_issue_and_transfer() {
             vec![&zsa_spend_t7_1, &zsa_spend_t7_2],
             vec![
                 TestOutputInfo {
-                    value: NoteValue::from_raw(zsa_spend_t7_1.note.value().inner() + delta1),
+                    value: NoteValue::from_raw(zsa_spend_t7_1.note.value().inner() + delta_1),
                     asset: zsa_spend_t7_1.note.asset(),
                 },
                 TestOutputInfo {
-                    value: NoteValue::from_raw(zsa_spend_t7_2.note.value().inner() - delta1),
+                    value: NoteValue::from_raw(zsa_spend_t7_2.note.value().inner() - delta_1),
                     asset: zsa_spend_t7_2.note.asset(),
                 },
             ],


### PR DESCRIPTION
Due to privacy considerations, we might incorporate dummy or split notes while generating a bundle.
However, to maintain consistency with the previous version, we choose not to include split notes for native asset.

In addition, we use a new dummy/split notes for each extend in order to have different nullifiers.