### PR TITLE
Global padding for bundle

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -464,7 +464,7 @@ impl Builder {
         i64::try_from(value_balance).and_then(|i| V::try_from(i).map_err(|_| value::OverflowError))
     }
 
-    /// Returns the additional number of actions needed to this bundle in order to obtain at least MIN_ACTION actions.
+    /// Returns the number of actions to add to this bundle in order to contain at least MIN_ACTION actions.
     fn num_missing_actions(&self) -> usize {
         let num_actions = [self.spends.len(), self.recipients.len()]
             .iter()

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -471,11 +471,9 @@ impl Builder {
             .max()
             .cloned()
             .unwrap();
-        if num_actions < MIN_ACTIONS {
-            MIN_ACTIONS - num_actions
-        } else {
-            0
-        }
+        (num_actions < MIN_ACTIONS)
+            .then(|| MIN_ACTIONS - num_actions)
+            .unwrap_or(0)
     }
 
     /// Builds a bundle containing the given spent notes and recipients.
@@ -495,10 +493,10 @@ impl Builder {
             let num_spends = spends.len();
             let num_recipients = recipients.len();
             let mut num_actions = [num_spends, num_recipients].iter().max().cloned().unwrap();
-            // For the first asset, we might have to add dummy/split actions to reach the minimum number of actions.
-            if pre_actions.is_empty() {
-                num_actions += self.num_missing_actions();
-            }
+            // We might have to add dummy/split actions only for the first asset to reach MIN_ACTIONS.
+            pre_actions
+                .is_empty()
+                .then(|| num_actions += self.num_missing_actions());
 
             let first_spend = spends.first().cloned();
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -464,7 +464,7 @@ impl Builder {
         i64::try_from(value_balance).and_then(|i| V::try_from(i).map_err(|_| value::OverflowError))
     }
 
-    /// Returns the number of actions to add to this bundle in order to contain at least MIN_ACTION actions.
+    /// Returns the additional number of actions needed to this bundle in order to obtain at least MIN_ACTION actions.
     fn num_missing_actions(&self) -> usize {
         let num_actions = [self.spends.len(), self.recipients.len()]
             .iter()

--- a/tests/zsa.rs
+++ b/tests/zsa.rs
@@ -408,7 +408,7 @@ fn zsa_issue_and_transfer() {
         ],
         vec![],
         anchor,
-        4,
+        2,
         &keys,
     )
     .unwrap();
@@ -436,7 +436,7 @@ fn zsa_issue_and_transfer() {
         ],
         vec![],
         native_anchor,
-        5,
+        4,
         &keys,
     )
     .unwrap();
@@ -468,7 +468,7 @@ fn zsa_issue_and_transfer() {
         ],
         vec![],
         anchor_t7,
-        4,
+        2,
         &keys,
     )
     .unwrap();
@@ -489,7 +489,7 @@ fn zsa_issue_and_transfer() {
             ],
             vec![],
             anchor_t7,
-            4,
+            2,
             &keys,
         )
         .unwrap();


### PR DESCRIPTION
Each bundle must contain at least two actions for privacy concerns.
Previously, we pad bundle to have at least two actions per asset.
Now, we pad bundle globally, and add dummy/split actions to have at least two actions per bundle.