### PR TITLE
Add serialization of finalize flag

### DIFF
--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -137,11 +137,7 @@ impl IssueAction {
 
     /// Serialize `finalize` flag to a byte
     pub fn flags(&self) -> u8 {
-        if self.finalize {
-            0b0000_0001
-        } else {
-            0u8
-        }
+        self.finalize.then(|| 0b0000_0001).unwrap_or(0b0000_0000)
     }
 }
 
@@ -1287,7 +1283,7 @@ mod tests {
         let mut rng = OsRng;
         let (_, _, note) = Note::dummy(&mut rng, None, AssetBase::native());
         let mut action = IssueAction::new(String::from("Asset description"), &note);
-        assert_eq!(action.flags(), 0u8);
+        assert_eq!(action.flags(), 0b0000_0000);
         action.finalize = true;
         assert_eq!(action.flags(), 0b0000_0001);
     }

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -134,6 +134,15 @@ impl IssueAction {
             .then(|| Ok((asset, AssetSupply::new(value_sum, self.is_finalized()))))
             .ok_or(IssueBundleIkMismatchAssetBase)?
     }
+
+    /// Serialize finalize flag to a byte
+    pub fn flags(&self) -> u8 {
+        if self.finalize {
+            0b0000_0001
+        } else {
+            0u8
+        }
+    }
 }
 
 /// Defines the authorization type of an Issue bundle.

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -135,7 +135,7 @@ impl IssueAction {
             .ok_or(IssueBundleIkMismatchAssetBase)?
     }
 
-    /// Serialize finalize flag to a byte
+    /// Serialize `finalize` flag to a byte
     pub fn flags(&self) -> u8 {
         if self.finalize {
             0b0000_0001
@@ -1280,6 +1280,16 @@ mod tests {
             verify_issue_bundle(&signed, sighash, &prev_finalized).unwrap_err(),
             WrongAssetDescSize
         );
+    }
+
+    #[test]
+    fn test_finalize_flag_serialization() {
+        let mut rng = OsRng;
+        let (_, _, note) = Note::dummy(&mut rng, None, AssetBase::native());
+        let mut action = IssueAction::new(String::from("Asset description"), &note);
+        assert_eq!(action.flags(), 0u8);
+        action.finalize = true;
+        assert_eq!(action.flags(), 0b0000_0001);
     }
 }
 

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -61,6 +61,23 @@ impl IssueAction {
         }
     }
 
+    /// Constructs a new `IssueAction`.
+    pub fn new_with_finalize(asset_desc: String, note: &Note, flags: u8) -> Option<Self> {
+        let finalize = match flags {
+            0b0000_0000 => false,
+            0b0000_0001 => true,
+            _ => return None,
+        };
+        Some(IssueAction {
+            asset_desc,
+            notes: NonEmpty {
+                head: *note,
+                tail: vec![],
+            },
+            finalize,
+        })
+    }
+
     /// Constructs an `IssueAction` from its constituent parts.
     pub fn from_parts(asset_desc: String, notes: NonEmpty<Note>, finalize: bool) -> Self {
         IssueAction {
@@ -1282,10 +1299,17 @@ mod tests {
     fn test_finalize_flag_serialization() {
         let mut rng = OsRng;
         let (_, _, note) = Note::dummy(&mut rng, None, AssetBase::native());
-        let mut action = IssueAction::new(String::from("Asset description"), &note);
+
+        let action =
+            IssueAction::new_with_finalize(String::from("Asset description"), &note, 0u8).unwrap();
         assert_eq!(action.flags(), 0b0000_0000);
-        action.finalize = true;
+
+        let action =
+            IssueAction::new_with_finalize(String::from("Asset description"), &note, 1u8).unwrap();
         assert_eq!(action.flags(), 0b0000_0001);
+
+        let action = IssueAction::new_with_finalize(String::from("Asset description"), &note, 2u8);
+        assert!(action.is_none());
     }
 }
 


### PR DESCRIPTION
Add a function `flags` to serialize the `finalize` flag of an IssueAction to a byte.
This function will be used by the client.