### PR TITLE
Upgrade zcash_note_encryption dependency and align with `merge_zcash_980736806->zsa1` PR in librustzcash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ reddsa = "0.5"
 nonempty = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 subtle = "2.3"
-zcash_note_encryption = "0.2"
+zcash_note_encryption = "0.3"
 incrementalmerkletree = "0.3.1"
 
 # Logging
@@ -58,7 +58,7 @@ criterion = "0.3"
 halo2_gadgets = { git = "https://github.com/QED-it/halo2", branch = "zsa1", features = ["test-dependencies"] }
 hex = "0.4"
 proptest = "1.0.0"
-zcash_note_encryption = { version = "0.2", features = ["pre-zip-212"] }
+zcash_note_encryption = { version = "0.3", features = ["pre-zip-212"] }
 incrementalmerkletree = { version = "0.3", features = ["test-dependencies"] }
 
 [target.'cfg(unix)'.dev-dependencies]
@@ -93,6 +93,6 @@ debug = true
 debug = true
 
 [patch.crates-io]
-zcash_note_encryption = { git = "https://github.com/QED-it/librustzcash.git", rev = "07c377ddedf71ab7c7a266d284b054a2dafc2ed4" }
+zcash_note_encryption = { git="https://github.com/QED-it/librustzcash.git", rev="980736806fe5417e36cbbdf00cdcf51b755e3b28" }
 bridgetree = { git = "https://github.com/zcash/incrementalmerkletree.git", rev = "ea1686e8f8f6c1e41aa97251a7eb4fadfd33df47" }
 incrementalmerkletree = { git = "https://github.com/zcash/incrementalmerkletree.git", rev = "ea1686e8f8f6c1e41aa97251a7eb4fadfd33df47" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,6 @@ debug = true
 debug = true
 
 [patch.crates-io]
-zcash_note_encryption = { git="https://github.com/QED-it/librustzcash.git", rev="980736806fe5417e36cbbdf00cdcf51b755e3b28" }
+zcash_note_encryption = { git="https://github.com/QED-it/librustzcash.git", branch="merge_zcash_980736806" }
 bridgetree = { git = "https://github.com/zcash/incrementalmerkletree.git", rev = "ea1686e8f8f6c1e41aa97251a7eb4fadfd33df47" }
 incrementalmerkletree = { git = "https://github.com/zcash/incrementalmerkletree.git", rev = "ea1686e8f8f6c1e41aa97251a7eb4fadfd33df47" }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -268,7 +268,6 @@ impl ActionInfo {
         let encryptor = OrchardNoteEncryption::new(
             self.output.ovk,
             note,
-            self.output.recipient,
             self.output.memo.unwrap_or_else(|| {
                 let mut memo = [0; 512];
                 memo[0] = 0xf6;

--- a/src/note_encryption_v3.rs
+++ b/src/note_encryption_v3.rs
@@ -253,11 +253,7 @@ impl Domain for OrchardDomainV3 {
         secret.kdf_orchard(ephemeral_key)
     }
 
-    fn note_plaintext_bytes(
-        note: &Self::Note,
-        _: &Self::Recipient,
-        memo: &Self::Memo,
-    ) -> NotePlaintextBytes {
+    fn note_plaintext_bytes(note: &Self::Note, memo: &Self::Memo) -> NotePlaintextBytes {
         let mut np = [0u8; NOTE_PLAINTEXT_SIZE_V3];
         np[0] = 0x03;
         np[1..12].copy_from_slice(note.recipient().diversifier().as_array());
@@ -499,7 +495,7 @@ mod tests {
             let memo = &crate::test_vectors::note_encryption::test_vectors()[0].memo;
 
             // Encode.
-            let mut plaintext = OrchardDomainV3::note_plaintext_bytes(&note, &note.recipient(), memo);
+            let mut plaintext = OrchardDomainV3::note_plaintext_bytes(&note, memo);
 
             // Decode.
             let domain = OrchardDomainV3 { rho: note.rho() };
@@ -622,7 +618,7 @@ mod tests {
             // Test encryption
             //
 
-            let ne = OrchardNoteEncryption::new_with_esk(esk, Some(ovk), note, recipient, tv.memo);
+            let ne = OrchardNoteEncryption::new_with_esk(esk, Some(ovk), note, tv.memo);
 
             assert_eq!(ne.encrypt_note_plaintext().as_ref(), &tv.c_enc[..]);
             assert_eq!(


### PR DESCRIPTION
This pull request aims to upgrade the `zcash_note_encryption` dependency (from `librustzcash` repo) to version 0.3, aligning it with the changes introduced in the `merge_zcash_980736806->zsa1` pull request in the `QED-it/librustzcash` repository. 

Here's an overview of the changes included in this upgrade:

1. Updated the `Cargo.toml` files to refer to the `zcash_note_encryption` crate v0.3 from the new version of `librustzcash`.
2. Made code modifications to bring the `orchard` repository in compliance with the slightly changed usage and interface of the `zcash_note_encryption` crate.
