### PR TITLE
Fix IssueBundle and IssueAction structures

### DIFF
--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -7,10 +7,9 @@ use std::fmt;
 
 use crate::bundle::commitments::{hash_issue_bundle_auth_data, hash_issue_bundle_txid_data};
 use crate::issuance::Error::{
-    IssueActionAlreadyFinalized, IssueActionIncorrectAssetBase, IssueActionNotFound,
-    IssueActionPreviouslyFinalizedAssetBase, IssueActionWithoutNoteNotFinalized,
-    IssueBundleIkMismatchAssetBase, IssueBundleInvalidSignature, ValueSumOverflow,
-    WrongAssetDescSize,
+    IssueActionIncorrectAssetBase, IssueActionNotFound, IssueActionPreviouslyFinalizedAssetBase,
+    IssueActionWithoutNoteNotFinalized, IssueBundleIkMismatchAssetBase,
+    IssueBundleInvalidSignature, ValueSumOverflow, WrongAssetDescSize,
 };
 use crate::keys::{IssuanceAuthorizingKey, IssuanceValidatingKey};
 use crate::note::asset_base::is_asset_desc_of_valid_size;
@@ -267,9 +266,11 @@ impl IssueBundle<Unauthorized> {
     /// note_params values and with `finalize` set to false. In this created note, rho will be
     /// randomly sampled, similar to dummy note generation.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if `asset_desc` is empty or longer than 512 bytes.
+    /// This function may return an error in any of the following cases:
+    ///
+    /// * `WrongAssetDescSize`: If `asset_desc` is empty or longer than 512 bytes.
     pub fn new(
         ik: IssuanceValidatingKey,
         asset_desc: String,
@@ -319,9 +320,11 @@ impl IssueBundle<Unauthorized> {
     ///
     /// Rho will be randomly sampled, similar to dummy note generation.
     ///
-    /// # Panics
+    /// # Errors
     ///
-    /// Panics if `asset_desc` is empty or longer than 512 bytes.
+    /// This function may return an error in any of the following cases:
+    ///
+    /// * `WrongAssetDescSize`: If `asset_desc` is empty or longer than 512 bytes.
     pub fn add_recipient(
         &mut self,
         asset_desc: String,
@@ -530,8 +533,6 @@ pub fn verify_issue_bundle(
 /// Errors produced during the issuance process
 #[derive(Debug, PartialEq, Eq)]
 pub enum Error {
-    /// Unable to add note to the IssueAction since it has already been finalized.
-    IssueActionAlreadyFinalized,
     /// The requested IssueAction not exists in the bundle.
     IssueActionNotFound,
     /// Not all `AssetBase`s are the same inside the action.
@@ -558,12 +559,6 @@ impl std::error::Error for Error {}
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            IssueActionAlreadyFinalized => {
-                write!(
-                    f,
-                    "unable to add note to the IssueAction since it has already been finalized"
-                )
-            }
             IssueActionNotFound => {
                 write!(f, "the requested IssueAction not exists in the bundle.")
             }

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -336,28 +336,25 @@ impl IssueBundle<Unauthorized> {
             &mut rng,
         );
 
-        let found = match self
+        let action = self
             .actions
             .iter_mut()
-            .find(|issue_action| issue_action.asset_desc.eq(&asset_desc))
-        {
-            // Append to an existing IssueAction.
-            Some(action) => {
-                action.notes.push(note);
-                true
-            }
-            None => false,
-        };
+            .find(|issue_action| issue_action.asset_desc.eq(&asset_desc));
 
-        // Insert a new IssueAction.
-        if !found {
-            let action = IssueAction {
-                asset_desc,
-                notes: vec![note],
-                finalize: false,
-            };
-            self.actions.push(action);
-        }
+        match action {
+            Some(action) => {
+                // Append to an existing IssueAction.
+                action.notes.push(note);
+            }
+            None => {
+                // Insert a new IssueAction.
+                self.actions.push(IssueAction {
+                    asset_desc,
+                    notes: vec![note],
+                    finalize: false,
+                });
+            }
+        };
 
         Ok(asset)
     }

--- a/tests/zsa.rs
+++ b/tests/zsa.rs
@@ -138,17 +138,19 @@ pub fn build_merkle_path_with_two_leaves(
 fn issue_zsa_notes(asset_descr: &str, keys: &Keychain) -> (Note, Note) {
     let mut rng = OsRng;
     // Create a issuance bundle
-    let mut unauthorized = IssueBundle::new(keys.ik().clone());
+    let unauthorized_asset = IssueBundle::new(
+        keys.ik().clone(),
+        asset_descr.to_string(),
+        keys.recipient,
+        NoteValue::from_raw(40),
+        false,
+        &mut rng,
+    );
 
-    assert!(unauthorized
-        .add_recipient(
-            asset_descr.to_string(),
-            keys.recipient,
-            NoteValue::from_raw(40),
-            false,
-            &mut rng,
-        )
-        .is_ok());
+    assert!(unauthorized_asset.is_ok());
+
+    let (mut unauthorized, _) = unauthorized_asset.unwrap();
+
     assert!(unauthorized
         .add_recipient(
             asset_descr.to_string(),

--- a/tests/zsa.rs
+++ b/tests/zsa.rs
@@ -4,7 +4,7 @@ use crate::builder::verify_bundle;
 use bridgetree::BridgeTree;
 use incrementalmerkletree::Hashable;
 use orchard::bundle::Authorized;
-use orchard::issuance::{verify_issue_bundle, IssueBundle, Signed, Unauthorized};
+use orchard::issuance::{verify_issue_bundle, IssueBundle, NoteParams, Signed, Unauthorized};
 use orchard::keys::{IssuanceAuthorizingKey, IssuanceValidatingKey};
 use orchard::note::{AssetBase, ExtractedNoteCommitment};
 use orchard::note_encryption_v3::OrchardDomainV3;
@@ -141,9 +141,10 @@ fn issue_zsa_notes(asset_descr: &str, keys: &Keychain) -> (Note, Note) {
     let unauthorized_asset = IssueBundle::new(
         keys.ik().clone(),
         asset_descr.to_string(),
-        keys.recipient,
-        NoteValue::from_raw(40),
-        false,
+        Some(NoteParams {
+            recipient: keys.recipient,
+            value: NoteValue::from_raw(40),
+        }),
         &mut rng,
     );
 
@@ -156,7 +157,6 @@ fn issue_zsa_notes(asset_descr: &str, keys: &Keychain) -> (Note, Note) {
             asset_descr.to_string(),
             keys.recipient,
             NoteValue::from_raw(2),
-            false,
             &mut rng,
         )
         .is_ok());

--- a/tests/zsa.rs
+++ b/tests/zsa.rs
@@ -4,7 +4,7 @@ use crate::builder::verify_bundle;
 use bridgetree::BridgeTree;
 use incrementalmerkletree::Hashable;
 use orchard::bundle::Authorized;
-use orchard::issuance::{verify_issue_bundle, IssueBundle, NoteParams, Signed, Unauthorized};
+use orchard::issuance::{verify_issue_bundle, IssueBundle, IssueInfo, Signed, Unauthorized};
 use orchard::keys::{IssuanceAuthorizingKey, IssuanceValidatingKey};
 use orchard::note::{AssetBase, ExtractedNoteCommitment};
 use orchard::note_encryption_v3::OrchardDomainV3;
@@ -141,7 +141,7 @@ fn issue_zsa_notes(asset_descr: &str, keys: &Keychain) -> (Note, Note) {
     let unauthorized_asset = IssueBundle::new(
         keys.ik().clone(),
         asset_descr.to_string(),
-        Some(NoteParams {
+        Some(IssueInfo {
             recipient: keys.recipient,
             value: NoteValue::from_raw(40),
         }),


### PR DESCRIPTION
The vector of issue actions in an IssueBundle must not be empty.
The vector of notes in an IssueAction could be empty when `finalize` is set to true.

We could add some actions in an `IssueAction` even if `finalize` is set to true.
Only the next block is affected by the `finalize` flag, not the current block.