### PR TITLE
Preventing Asset Base from being the identity point on the Pallas curve

### DIFF
--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -527,6 +527,8 @@ pub enum Error {
     WrongAssetDescSize,
     /// The `IssueAction` is not finalized but contains no notes.
     IssueActionWithoutNoteNotFinalized,
+    /// The `AssetBase` is the Pallas identity point.
+    AssetBaseIdentityPoint,
 
     /// Verification errors:
     /// Invalid signature.
@@ -561,6 +563,13 @@ impl fmt::Display for Error {
                     "this `IssueAction` contains no notes but is not finalized"
                 )
             }
+            AssetBaseIdentityPoint => {
+                write!(
+                    f,
+                    "the AssetBase is the identity point of the Pallas curve, which is invalid."
+                )
+            }
+
             IssueBundleInvalidSignature(_) => {
                 write!(f, "invalid signature")
             }

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -605,7 +605,7 @@ mod tests {
     };
     use crate::note::{AssetBase, Nullifier};
     use crate::value::{NoteValue, ValueSum};
-    use crate::{Address, bundle, Note};
+    use crate::{bundle, Address, Note};
     use group::{Group, GroupEncoding};
     use nonempty::NonEmpty;
     use pasta_curves::pallas;
@@ -681,8 +681,14 @@ mod tests {
         note1_value: u64,
         note2_value: u64,
         finalize: bool,
-    ) -> (OsRng, IssuanceAuthorizingKey, IssuanceValidatingKey, IssueAction, IssueBundle<Unauthorized>, [u8; 32]) {
-
+    ) -> (
+        OsRng,
+        IssuanceAuthorizingKey,
+        IssuanceValidatingKey,
+        IssueAction,
+        IssueBundle<Unauthorized>,
+        [u8; 32],
+    ) {
         let (mut rng, isk, ik, recipient, sighash) = setup_params();
 
         let asset = generate_identity_point_asset_base();
@@ -703,7 +709,8 @@ mod tests {
             &mut rng,
         );
 
-        let action = IssueAction::from_parts("arbitrary asset_desc".into(), vec![note1, note2], finalize);
+        let action =
+            IssueAction::from_parts("arbitrary asset_desc".into(), vec![note1, note2], finalize);
 
         let ik2 = ik.clone();
         let action2 = action.clone();
@@ -1342,8 +1349,8 @@ mod tests {
 
     #[test]
     fn issue_bundle_cannot_be_signed_with_asset_base_identity_point() {
-
-        let (rng, isk, _, _, bundle, sighash) = identity_point_asset_base_test_params(10,20,false);
+        let (rng, isk, _, _, bundle, sighash) =
+            identity_point_asset_base_test_params(10, 20, false);
 
         assert_eq!(
             bundle.prepare(sighash).sign(rng, &isk).unwrap_err(),

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -1343,8 +1343,7 @@ mod tests {
 
     #[test]
     fn issue_bundle_cannot_be_signed_with_asset_base_identity_point() {
-        let (rng, isk, bundle, sighash) =
-            identity_point_test_params(10, 20);
+        let (rng, isk, bundle, sighash) = identity_point_test_params(10, 20);
 
         assert_eq!(
             bundle.prepare(sighash).sign(rng, &isk).unwrap_err(),
@@ -1354,8 +1353,7 @@ mod tests {
 
     #[test]
     fn issue_bundle_verify_fail_asset_base_identity_point() {
-        let (mut rng, isk, bundle, sighash) =
-            identity_point_test_params(10, 20);
+        let (mut rng, isk, bundle, sighash) = identity_point_test_params(10, 20);
 
         let signed = IssueBundle {
             ik: bundle.ik,

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -1359,6 +1359,27 @@ mod tests {
     }
 
     #[test]
+    fn issue_bundle_verify_fail_asset_base_identity_point() {
+        let (mut rng, isk, ik, _, bundle, sighash) =
+            identity_point_asset_base_test_params(10, 20, false);
+
+        let signed = IssueBundle {
+            ik,
+            actions: bundle.actions,
+            authorization: Signed {
+                signature: isk.sign(&mut rng, &sighash),
+            },
+        };
+
+        let prev_finalized = HashSet::new();
+
+        assert_eq!(
+            verify_issue_bundle(&signed, sighash, &prev_finalized).unwrap_err(),
+            AssetBaseCannotBeIdentityPoint
+        );
+    }
+
+    #[test]
     fn test_finalize_flag_serialization() {
         let mut rng = OsRng;
         let (_, _, note) = Note::dummy(&mut rng, None, AssetBase::native());

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -714,7 +714,7 @@ mod tests {
     }
 
     #[test]
-    fn test_verify_supply_valid() {
+    fn verify_supply_valid() {
         let (ik, test_asset, action) =
             setup_verify_supply_test_params(10, 20, "Asset 1", None, false);
 
@@ -730,7 +730,7 @@ mod tests {
     }
 
     #[test]
-    fn test_verify_supply_invalid_for_asset_base_as_identity() {
+    fn verify_supply_invalid_for_asset_base_as_identity() {
         let (_, _, bundle, _) = identity_point_test_params(10, 20);
 
         assert_eq!(
@@ -740,7 +740,7 @@ mod tests {
     }
 
     #[test]
-    fn test_verify_supply_finalized() {
+    fn verify_supply_finalized() {
         let (ik, test_asset, action) =
             setup_verify_supply_test_params(10, 20, "Asset 1", None, true);
 
@@ -756,7 +756,7 @@ mod tests {
     }
 
     #[test]
-    fn test_verify_supply_incorrect_asset_base() {
+    fn verify_supply_incorrect_asset_base() {
         let (ik, _, action) =
             setup_verify_supply_test_params(10, 20, "Asset 1", Some("Asset 2"), false);
 
@@ -767,7 +767,7 @@ mod tests {
     }
 
     #[test]
-    fn test_verify_supply_ik_mismatch_asset_base() {
+    fn verify_supply_ik_mismatch_asset_base() {
         let (_, _, action) = setup_verify_supply_test_params(10, 20, "Asset 1", None, false);
         let (_, _, ik, _, _) = setup_params();
 
@@ -1372,7 +1372,7 @@ mod tests {
     }
 
     #[test]
-    fn test_finalize_flag_serialization() {
+    fn finalize_flag_serialization() {
         let mut rng = OsRng;
         let (_, _, note) = Note::dummy(&mut rng, None, AssetBase::native());
 

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -608,7 +608,7 @@ mod tests {
     use crate::{Address, Note};
     use group::{Group, GroupEncoding};
     use nonempty::NonEmpty;
-    use pasta_curves::pallas;
+    use pasta_curves::pallas::{Point, Scalar};
     use rand::rngs::OsRng;
     use rand::RngCore;
     use reddsa::Error::InvalidSignature;
@@ -673,8 +673,7 @@ mod tests {
 
     // This function computes the identity point on the Pallas curve and returns an Asset Base with that value.
     fn identity_point() -> AssetBase {
-        let identity_point =
-            (pallas::Point::generator() * -pallas::Scalar::one()) + pallas::Point::generator();
+        let identity_point = (Point::generator() * -Scalar::one()) + Point::generator();
         AssetBase::from_bytes(&identity_point.to_bytes()).unwrap()
     }
 

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -599,13 +599,13 @@ mod tests {
         IssueActionPreviouslyFinalizedAssetBase, IssueBundleIkMismatchAssetBase,
         IssueBundleInvalidSignature, WrongAssetDescSize,
     };
-    use crate::issuance::{verify_issue_bundle, IssueAction, IssueAuth, Signed, Unauthorized};
+    use crate::issuance::{verify_issue_bundle, IssueAction, Signed, Unauthorized};
     use crate::keys::{
         FullViewingKey, IssuanceAuthorizingKey, IssuanceValidatingKey, Scope, SpendingKey,
     };
     use crate::note::{AssetBase, Nullifier};
     use crate::value::{NoteValue, ValueSum};
-    use crate::{bundle, Address, Note};
+    use crate::{Address, Note};
     use group::{Group, GroupEncoding};
     use nonempty::NonEmpty;
     use pasta_curves::pallas;

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -670,6 +670,12 @@ mod tests {
         )
     }
 
+    fn generate_identity_point_asset_base() -> AssetBase {
+        let identity_point =
+            (pallas::Point::generator() * -pallas::Scalar::one()) + pallas::Point::generator();
+        AssetBase::from_bytes(&identity_point.to_bytes()).unwrap()
+    }
+
     #[test]
     fn test_verify_supply_valid() {
         let (ik, test_asset, action) =
@@ -689,9 +695,8 @@ mod tests {
     #[test]
     fn test_verify_supply_invalid_for_asset_base_as_identity() {
         let (mut rng, _, ik, recipient, _) = setup_params();
-        let identity_point =
-            (pallas::Point::generator() * -pallas::Scalar::one()) + pallas::Point::generator();
-        let asset = AssetBase::from_bytes(&identity_point.to_bytes()).unwrap();
+
+        let asset = generate_identity_point_asset_base();
 
         let note1 = Note::new(
             recipient,
@@ -1317,6 +1322,18 @@ mod tests {
         assert_eq!(
             verify_issue_bundle(&signed, sighash, &prev_finalized).unwrap_err(),
             WrongAssetDescSize
+        );
+    }
+
+    #[test]
+    fn issue_bundle_verify_fail_asset_base_identity_point() {
+
+        let (rng, isk, ik, recipient, sighash) = setup_params();
+
+
+        assert_eq!(
+            verify_issue_bundle(&signed, sighash, prev_finalized).unwrap_err(),
+            AssetBaseCannotBeIdentityPoint
         );
     }
 

--- a/src/note/asset_base.rs
+++ b/src/note/asset_base.rs
@@ -1,5 +1,5 @@
 use blake2b_simd::{Hash as Blake2bHash, Params};
-use group::GroupEncoding;
+use group::{Group, GroupEncoding};
 use halo2_proofs::arithmetic::CurveExt;
 use pasta_curves::pallas;
 use rand::RngCore;
@@ -54,10 +54,13 @@ impl AssetBase {
     ///
     /// # Panics
     ///
-    /// Panics if `asset_desc` is empty or greater than `MAX_ASSET_DESCRIPTION_SIZE`.
+    /// Panics if `asset_desc` is empty or greater than `MAX_ASSET_DESCRIPTION_SIZE` or if the derived Asset Base is the identity point (this will happen with negligible probability).
     #[allow(non_snake_case)]
     pub fn derive(ik: &IssuanceValidatingKey, asset_desc: &str) -> Self {
-        assert!(is_asset_desc_of_valid_size(asset_desc), "The asset_desc string is not of valid size");
+        assert!(
+            is_asset_desc_of_valid_size(asset_desc),
+            "The asset_desc string is not of valid size"
+        );
 
         // EncodeAssetId(ik, asset_desc) = version_byte || ik || asset_desc
         let version_byte = [0x00];
@@ -65,11 +68,15 @@ impl AssetBase {
 
         let asset_digest = asset_digest(encode_asset_id);
 
-        let asset_base_point = pallas::Point::hash_to_curve(ZSA_ASSET_BASE_PERSONALIZATION)(asset_digest.as_bytes());
+        let asset_base_point: pallas::Point =
+            pallas::Point::hash_to_curve(ZSA_ASSET_BASE_PERSONALIZATION)(asset_digest.as_bytes());
+        assert!(
+            bool::from(!asset_base_point.is_identity()),
+            "The Asset Base is the identity point, which is invalid."
+        );
+
         // AssetBase = ZSAValueBase(AssetDigest)
-        AssetBase(
-            asset_base_point,
-        )
+        AssetBase(asset_base_point)
     }
 
     /// Note type for the "native" currency (zec), maintains backward compatibility with Orchard untyped notes.

--- a/src/note/asset_base.rs
+++ b/src/note/asset_base.rs
@@ -70,6 +70,7 @@ impl AssetBase {
 
         let asset_base_point: pallas::Point =
             pallas::Point::hash_to_curve(ZSA_ASSET_BASE_PERSONALIZATION)(asset_digest.as_bytes());
+
         assert!(
             bool::from(!asset_base_point.is_identity()),
             "The Asset Base is the identity point, which is invalid."

--- a/src/note/asset_base.rs
+++ b/src/note/asset_base.rs
@@ -54,7 +54,7 @@ impl AssetBase {
     ///
     /// # Panics
     ///
-    /// Panics if `asset_desc` is empty or greater than `MAX_ASSET_DESCRIPTION_SIZE` or if the derived Asset Base is the identity point (this will happen with negligible probability).
+    /// Panics if `asset_desc` is empty or greater than `MAX_ASSET_DESCRIPTION_SIZE` or if the derived Asset Base is the identity point.
     #[allow(non_snake_case)]
     pub fn derive(ik: &IssuanceValidatingKey, asset_desc: &str) -> Self {
         assert!(
@@ -68,16 +68,17 @@ impl AssetBase {
 
         let asset_digest = asset_digest(encode_asset_id);
 
-        let asset_base_point: pallas::Point =
+        let asset_base =
             pallas::Point::hash_to_curve(ZSA_ASSET_BASE_PERSONALIZATION)(asset_digest.as_bytes());
 
+        // this will happen with negligible probability.
         assert!(
-            bool::from(!asset_base_point.is_identity()),
+            bool::from(!asset_base.is_identity()),
             "The Asset Base is the identity point, which is invalid."
         );
 
         // AssetBase = ZSAValueBase(AssetDigest)
-        AssetBase(asset_base_point)
+        AssetBase(asset_base)
     }
 
     /// Note type for the "native" currency (zec), maintains backward compatibility with Orchard untyped notes.

--- a/src/note/asset_base.rs
+++ b/src/note/asset_base.rs
@@ -65,9 +65,10 @@ impl AssetBase {
 
         let asset_digest = asset_digest(encode_asset_id);
 
+        let asset_base_point = pallas::Point::hash_to_curve(ZSA_ASSET_BASE_PERSONALIZATION)(asset_digest.as_bytes());
         // AssetBase = ZSAValueBase(AssetDigest)
         AssetBase(
-            pallas::Point::hash_to_curve(ZSA_ASSET_BASE_PERSONALIZATION)(asset_digest.as_bytes()),
+            asset_base_point,
         )
     }
 

--- a/src/note/asset_base.rs
+++ b/src/note/asset_base.rs
@@ -57,7 +57,7 @@ impl AssetBase {
     /// Panics if `asset_desc` is empty or greater than `MAX_ASSET_DESCRIPTION_SIZE`.
     #[allow(non_snake_case)]
     pub fn derive(ik: &IssuanceValidatingKey, asset_desc: &str) -> Self {
-        assert!(is_asset_desc_of_valid_size(asset_desc));
+        assert!(is_asset_desc_of_valid_size(asset_desc), "The asset_desc string is not of valid size");
 
         // EncodeAssetId(ik, asset_desc) = version_byte || ik || asset_desc
         let version_byte = [0x00];


### PR DESCRIPTION
As in the title, this is done in two portions:
- A protection is added to `AssetBase::derive()`, which panics if the output is going to be the identity point. This panic will occur with negligible probability due to the properties of the hash.
- The `verify_supply()` function now returns an error if the Asset Base of the notes involved is the identity point. 