### PR TITLE
Merge branch main into zsa1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to Rust's notion of
 
 ## [Unreleased]
 
+## [0.5.0] - 2023-06-06
+### Changed
+- Migrated to `zcash_note_encryption 0.4`, `incrementalmerkletree 0.4`, `bridgetree 0.3`.
+  `bridgetree` is now exclusively a test dependency.
+
 ## [0.4.0] - 2023-04-11
 ### Added
 - `orchard::builder`:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "orchard"
-version = "0.4.0"
+version = "0.5.0"
 authors = [
     "Sean Bowe <sean@electriccoin.co>",
     "Jack Grigg <jack@electriccoin.co>",
@@ -26,7 +26,6 @@ rustdoc-args = ["--cfg", "docsrs", "--html-in-header", "katex-header.html"]
 aes = "0.8"
 bitvec = "1"
 blake2b_simd = "1"
-bridgetree = { version = "0.2", optional = true }
 ff = "0.13"
 fpe = "0.6"
 group = { version = "0.13", features = ["wnaf-memuse"] }
@@ -43,7 +42,7 @@ nonempty = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 subtle = "2.3"
 zcash_note_encryption = "0.2"
-incrementalmerkletree = "0.3.1"
+incrementalmerkletree = "0.4"
 
 # Logging
 tracing = "0.1"
@@ -53,13 +52,13 @@ image = { version = ">= 0.24, < 0.24.5", optional = true } # 0.24.5 has MSRV 1.6
 plotters = { version = "0.3.0", optional = true }
 
 [dev-dependencies]
-bridgetree = "0.2"
+bridgetree = "0.3"
 criterion = "0.3"
 halo2_gadgets = { git = "https://github.com/QED-it/halo2", branch = "zsa1", features = ["test-dependencies"] }
 hex = "0.4"
 proptest = "1.0.0"
 zcash_note_encryption = { version = "0.2", features = ["pre-zip-212"] }
-incrementalmerkletree = { version = "0.3", features = ["test-dependencies"] }
+incrementalmerkletree = { version = "0.4", features = ["test-dependencies"] }
 
 [target.'cfg(unix)'.dev-dependencies]
 inferno = ">= 0.11, < 0.11.15"
@@ -72,7 +71,7 @@ bench = false
 default = ["multicore"]
 multicore = ["halo2_proofs/multicore"]
 dev-graph = ["halo2_proofs/dev-graph", "image", "plotters"]
-test-dependencies = ["bridgetree", "proptest"]
+test-dependencies = ["proptest"]
 
 [[bench]]
 name = "note_decryption"
@@ -94,5 +93,3 @@ debug = true
 
 [patch.crates-io]
 zcash_note_encryption = { git = "https://github.com/QED-it/librustzcash.git", rev = "07c377ddedf71ab7c7a266d284b054a2dafc2ed4" }
-bridgetree = { git = "https://github.com/zcash/incrementalmerkletree.git", rev = "ea1686e8f8f6c1e41aa97251a7eb4fadfd33df47" }
-incrementalmerkletree = { git = "https://github.com/zcash/incrementalmerkletree.git", rev = "ea1686e8f8f6c1e41aa97251a7eb4fadfd33df47" }

--- a/book/src/design/circuit/note-commit.md
+++ b/book/src/design/circuit/note-commit.md
@@ -361,7 +361,7 @@ $$
 \begin{array}{|c|l|}
 \hline
 \text{Degree} & \text{Constraint} \\\hline
-2 & q_{\NoteCommit,x(\mathsf{pk_d})} \cdot (b_3 + c \cdot 2^4 + d_0 \cdot 2^{254} - x(\mathsf{pk_d}) = 0 \\\hline
+2 & q_{\NoteCommit,x(\mathsf{pk_d})} \cdot \left(b_3 + c \cdot 2^4 + d_0 \cdot 2^{254} - x(\mathsf{pk_d}) \right) = 0 \\\hline
 3 & q_{\NoteCommit,x(\mathsf{pk_d})} \cdot d_0 \cdot z_{c,13} = 0 \\\hline
 2 & q_{\NoteCommit,x(\mathsf{pk_d})} \cdot (b_3 + c \cdot 2^4 + 2^{140} - t_\mathbb{P} - {b_3}c') = 0 \\\hline
 3 & q_{\NoteCommit,x(\mathsf{pk_d})} \cdot d_0 \cdot z_{{b_3}c',14} = 0 \\\hline

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -912,8 +912,8 @@ impl OutputView for RecipientInfo {
 #[cfg(any(test, feature = "test-dependencies"))]
 #[cfg_attr(docsrs, doc(cfg(feature = "test-dependencies")))]
 pub mod testing {
-    use bridgetree::BridgeTree;
     use core::fmt::Debug;
+    use incrementalmerkletree::{frontier::Frontier, Hashable};
     use rand::{rngs::StdRng, CryptoRng, SeedableRng};
 
     use proptest::collection::vec;
@@ -1008,23 +1008,26 @@ pub mod testing {
             ),
             rng_seed in prop::array::uniform32(prop::num::u8::ANY)
         ) -> ArbitraryBundleInputs<StdRng> {
-            const MERKLE_DEPTH_ORCHARD: u8 = crate::constants::MERKLE_DEPTH_ORCHARD as u8;
-            let mut tree = BridgeTree::<MerkleHashOrchard, u32, MERKLE_DEPTH_ORCHARD>::new(100, 0);
+            use crate::constants::MERKLE_DEPTH_ORCHARD;
+            let mut frontier = Frontier::<MerkleHashOrchard, { MERKLE_DEPTH_ORCHARD as u8 }>::empty();
             let mut notes_and_auth_paths: Vec<(Note, MerklePath)> = Vec::new();
 
             for note in notes.iter() {
                 let leaf = MerkleHashOrchard::from_cmx(&note.commitment().into());
-                tree.append(leaf);
-                let position = tree.mark().expect("tree is not empty");
+                frontier.append(leaf);
 
-                let path = MerklePath::from((position, tree.witness(position, 0).expect("we just witnessed the path")));
-                notes_and_auth_paths.push((*note, path));
+                let path = frontier
+                    .witness(|addr| Some(<MerkleHashOrchard as Hashable>::empty_root(addr.level())))
+                    .ok()
+                    .flatten()
+                    .expect("we can always construct a correct Merkle path");
+                notes_and_auth_paths.push((*note, path.into()));
             }
 
             ArbitraryBundleInputs {
                 rng: StdRng::from_seed(rng_seed),
                 sk,
-                anchor: tree.root(0).unwrap().into(),
+                anchor: frontier.root().into(),
                 notes: notes_and_auth_paths,
                 recipient_amounts
             }

--- a/tests/builder.rs
+++ b/tests/builder.rs
@@ -33,7 +33,7 @@ pub fn build_merkle_path(note: &Note) -> (MerklePath, Anchor) {
     // Use the tree with a single leaf.
     let cmx: ExtractedNoteCommitment = note.commitment().into();
     let leaf = MerkleHashOrchard::from_cmx(&cmx);
-    let mut tree = BridgeTree::<MerkleHashOrchard, u32, 32>::new(100, 0);
+    let mut tree = BridgeTree::<MerkleHashOrchard, u32, 32>::new(100);
     tree.append(leaf);
     let position = tree.mark().unwrap();
     let root = tree.root(0).unwrap();

--- a/tests/zsa.rs
+++ b/tests/zsa.rs
@@ -99,7 +99,7 @@ pub fn build_merkle_path_with_two_leaves(
     note1: &Note,
     note2: &Note,
 ) -> (MerklePath, MerklePath, Anchor) {
-    let mut tree = BridgeTree::<MerkleHashOrchard, u32, 32>::new(100, 0);
+    let mut tree = BridgeTree::<MerkleHashOrchard, u32, 32>::new(100);
 
     // Add first leaf
     let cmx1: ExtractedNoteCommitment = note1.commitment().into();


### PR DESCRIPTION
For zcash_note_encryption, we have to use version 0.2 with QEDIT patch.