### PR TITLE
Upgrade orchard to v0.5 and integrate corresponding librustzcash upgrade

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,7 +42,7 @@ reddsa = "0.5"
 nonempty = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 subtle = "2.3"
-zcash_note_encryption = "0.2"
+zcash_note_encryption = "0.3"
 incrementalmerkletree = "0.3.1"
 
 # Logging
@@ -58,7 +58,7 @@ criterion = "0.3"
 halo2_gadgets = { git = "https://github.com/QED-it/halo2", branch = "zsa1", features = ["test-dependencies"] }
 hex = "0.4"
 proptest = "1.0.0"
-zcash_note_encryption = { version = "0.2", features = ["pre-zip-212"] }
+zcash_note_encryption = { version = "0.3", features = ["pre-zip-212"] }
 incrementalmerkletree = { version = "0.3", features = ["test-dependencies"] }
 
 [target.'cfg(unix)'.dev-dependencies]
@@ -93,6 +93,6 @@ debug = true
 debug = true
 
 [patch.crates-io]
-zcash_note_encryption = { git = "https://github.com/QED-it/librustzcash.git", rev = "07c377ddedf71ab7c7a266d284b054a2dafc2ed4" }
+zcash_note_encryption = { git="https://github.com/QED-it/librustzcash.git", rev="980736806fe5417e36cbbdf00cdcf51b755e3b28" }
 bridgetree = { git = "https://github.com/zcash/incrementalmerkletree.git", rev = "ea1686e8f8f6c1e41aa97251a7eb4fadfd33df47" }
 incrementalmerkletree = { git = "https://github.com/zcash/incrementalmerkletree.git", rev = "ea1686e8f8f6c1e41aa97251a7eb4fadfd33df47" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,5 +92,4 @@ debug = true
 debug = true
 
 [patch.crates-io]
-#zcash_note_encryption = { git = "https://github.com/QED-it/librustzcash.git", branch = "upgrade_for_orchard_v05" }
-zcash_note_encryption = { path = "../librustzcash/components/zcash_note_encryption" }
+zcash_note_encryption = { git = "https://github.com/QED-it/librustzcash.git", branch = "upgrade_for_orchard_v05" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -93,6 +93,6 @@ debug = true
 debug = true
 
 [patch.crates-io]
-zcash_note_encryption = { git="https://github.com/QED-it/librustzcash.git", rev="980736806fe5417e36cbbdf00cdcf51b755e3b28" }
+zcash_note_encryption = { git="https://github.com/QED-it/librustzcash.git", branch="merge_zcash_980736806" }
 bridgetree = { git = "https://github.com/zcash/incrementalmerkletree.git", rev = "ea1686e8f8f6c1e41aa97251a7eb4fadfd33df47" }
 incrementalmerkletree = { git = "https://github.com/zcash/incrementalmerkletree.git", rev = "ea1686e8f8f6c1e41aa97251a7eb4fadfd33df47" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ reddsa = "0.5"
 nonempty = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 subtle = "2.3"
-zcash_note_encryption = "0.3"
+zcash_note_encryption = "0.4"
 incrementalmerkletree = "0.4"
 
 # Logging
@@ -57,7 +57,7 @@ criterion = "0.3"
 halo2_gadgets = { git = "https://github.com/QED-it/halo2", branch = "zsa1", features = ["test-dependencies"] }
 hex = "0.4"
 proptest = "1.0.0"
-zcash_note_encryption = { version = "0.3", features = ["pre-zip-212"] }
+zcash_note_encryption = { version = "0.4", features = ["pre-zip-212"] }
 incrementalmerkletree = { version = "0.4", features = ["test-dependencies"] }
 
 [target.'cfg(unix)'.dev-dependencies]
@@ -92,4 +92,5 @@ debug = true
 debug = true
 
 [patch.crates-io]
-zcash_note_encryption = { git = "https://github.com/QED-it/librustzcash.git", branch = "upgrade_for_orchard_v05" }
+#zcash_note_encryption = { git = "https://github.com/QED-it/librustzcash.git", branch = "upgrade_for_orchard_v05" }
+zcash_note_encryption = { path = "../librustzcash/components/zcash_note_encryption" }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -268,7 +268,6 @@ impl ActionInfo {
         let encryptor = OrchardNoteEncryption::new(
             self.output.ovk,
             note,
-            self.output.recipient,
             self.output.memo.unwrap_or_else(|| {
                 let mut memo = [0; 512];
                 memo[0] = 0xf6;

--- a/src/note_encryption_v3.rs
+++ b/src/note_encryption_v3.rs
@@ -253,11 +253,7 @@ impl Domain for OrchardDomainV3 {
         secret.kdf_orchard(ephemeral_key)
     }
 
-    fn note_plaintext_bytes(
-        note: &Self::Note,
-        _: &Self::Recipient,
-        memo: &Self::Memo,
-    ) -> NotePlaintextBytes {
+    fn note_plaintext_bytes(note: &Self::Note, memo: &Self::Memo) -> NotePlaintextBytes {
         let mut np = [0u8; NOTE_PLAINTEXT_SIZE_V3];
         np[0] = 0x03;
         np[1..12].copy_from_slice(note.recipient().diversifier().as_array());
@@ -499,7 +495,7 @@ mod tests {
             let memo = &crate::test_vectors::note_encryption::test_vectors()[0].memo;
 
             // Encode.
-            let mut plaintext = OrchardDomainV3::note_plaintext_bytes(&note, &note.recipient(), memo);
+            let mut plaintext = OrchardDomainV3::note_plaintext_bytes(&note, memo);
 
             // Decode.
             let domain = OrchardDomainV3 { rho: note.rho() };
@@ -622,7 +618,7 @@ mod tests {
             // Test encryption
             //
 
-            let ne = OrchardNoteEncryption::new_with_esk(esk, Some(ovk), note, recipient, tv.memo);
+            let ne = OrchardNoteEncryption::new_with_esk(esk, Some(ovk), note, tv.memo);
 
             assert_eq!(ne.encrypt_note_plaintext().as_ref(), &tv.c_enc[..]);
             assert_eq!(

--- a/src/note_encryption_v3.rs
+++ b/src/note_encryption_v3.rs
@@ -310,21 +310,6 @@ impl Domain for OrchardDomainV3 {
         plaintext: &CompactNotePlaintextBytes,
     ) -> Option<(Self::Note, Self::Recipient)> {
         orchard_parse_note_plaintext_without_memo(self, plaintext, |_| Some(*pk_d))
-        // FIXME: Is that correct to replace this code with one-line code above?
-        /*
-        orchard_parse_note_plaintext_without_memo(self, plaintext, |diversifier| {
-            if esk
-                .derive_public(diversify_hash(diversifier.as_array()))
-                .to_bytes()
-                .0
-                == ephemeral_key.0
-            {
-                Some(*pk_d)
-            } else {
-                None
-            }
-        })
-        */
     }
 
     fn extract_memo(

--- a/src/note_encryption_v3.rs
+++ b/src/note_encryption_v3.rs
@@ -16,7 +16,6 @@ use crate::{
         OutgoingViewingKey, PreparedEphemeralPublicKey, PreparedIncomingViewingKey, SharedSecret,
     },
     note::{ExtractedNoteCommitment, Nullifier, RandomSeed},
-    spec::diversify_hash,
     value::{NoteValue, ValueCommitment},
     Address, Note,
 };
@@ -308,10 +307,11 @@ impl Domain for OrchardDomainV3 {
     fn parse_note_plaintext_without_memo_ovk(
         &self,
         pk_d: &Self::DiversifiedTransmissionKey,
-        esk: &Self::EphemeralSecretKey,
-        ephemeral_key: &EphemeralKeyBytes,
         plaintext: &CompactNotePlaintextBytes,
     ) -> Option<(Self::Note, Self::Recipient)> {
+        orchard_parse_note_plaintext_without_memo(self, plaintext, |_| Some(*pk_d))
+        // FIXME: Is that correct to replace this code with one-line code above?
+        /*
         orchard_parse_note_plaintext_without_memo(self, plaintext, |diversifier| {
             if esk
                 .derive_public(diversify_hash(diversifier.as_array()))
@@ -324,6 +324,7 @@ impl Domain for OrchardDomainV3 {
                 None
             }
         })
+        */
     }
 
     fn extract_memo(


### PR DESCRIPTION
This pull request focuses on upgrading the `orchard` repository to integrate it with a version of `librustzcash` repository compatible with `orchard` v0.5. 

The necessary changes have been made in the `upgrade_librustzcash_for_orchard_v05` branch, and merge conflicts have been resolved. `upgrade_librustzcash_for_orchard_v05` branch was created from `librustzcash_980736806` branch that contains previous attempt of upgading.