### PR TITLE
Fix issuance key derivation

### DIFF
--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -606,8 +606,8 @@ mod tests {
     ) {
         let mut rng = OsRng;
 
-        let sk = IssuanceKey::random(&mut rng);
-        let isk: IssuanceAuthorizingKey = (&sk).into();
+        let sk_iss = IssuanceKey::random(&mut rng);
+        let isk: IssuanceAuthorizingKey = (&sk_iss).into();
         let ik: IssuanceValidatingKey = (&isk).into();
 
         let fvk = FullViewingKey::from(&SpendingKey::random(&mut rng));
@@ -1204,8 +1204,8 @@ mod tests {
 
         let mut signed = bundle.prepare(sighash).sign(rng, &isk).unwrap();
 
-        let incorrect_sk = IssuanceKey::random(&mut rng);
-        let incorrect_isk: IssuanceAuthorizingKey = (&incorrect_sk).into();
+        let incorrect_sk_iss = IssuanceKey::random(&mut rng);
+        let incorrect_isk: IssuanceAuthorizingKey = (&incorrect_sk_iss).into();
         let incorrect_ik: IssuanceValidatingKey = (&incorrect_isk).into();
 
         // Add "bad" note

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -586,7 +586,8 @@ mod tests {
     };
     use crate::issuance::{verify_issue_bundle, IssueAction, Signed};
     use crate::keys::{
-        FullViewingKey, IssuanceAuthorizingKey, IssuanceValidatingKey, Scope, SpendingKey,
+        FullViewingKey, IssuanceAuthorizingKey, IssuanceKey, IssuanceValidatingKey, Scope,
+        SpendingKey,
     };
     use crate::note::{AssetBase, Nullifier};
     use crate::value::{NoteValue, ValueSum};
@@ -605,7 +606,7 @@ mod tests {
     ) {
         let mut rng = OsRng;
 
-        let sk = SpendingKey::random(&mut rng);
+        let sk = IssuanceKey::random(&mut rng);
         let isk: IssuanceAuthorizingKey = (&sk).into();
         let ik: IssuanceValidatingKey = (&isk).into();
 
@@ -876,7 +877,7 @@ mod tests {
         )
         .unwrap();
 
-        let wrong_isk: IssuanceAuthorizingKey = (&SpendingKey::random(&mut OsRng)).into();
+        let wrong_isk: IssuanceAuthorizingKey = (&IssuanceKey::random(&mut OsRng)).into();
 
         let err = bundle
             .prepare([0; 32])
@@ -1108,7 +1109,7 @@ mod tests {
         )
         .unwrap();
 
-        let wrong_isk: IssuanceAuthorizingKey = (&SpendingKey::random(&mut rng)).into();
+        let wrong_isk: IssuanceAuthorizingKey = (&IssuanceKey::random(&mut rng)).into();
 
         let mut signed = bundle.prepare(sighash).sign(rng, &isk).unwrap();
 
@@ -1203,7 +1204,7 @@ mod tests {
 
         let mut signed = bundle.prepare(sighash).sign(rng, &isk).unwrap();
 
-        let incorrect_sk = SpendingKey::random(&mut rng);
+        let incorrect_sk = IssuanceKey::random(&mut rng);
         let incorrect_isk: IssuanceAuthorizingKey = (&incorrect_sk).into();
         let incorrect_ik: IssuanceValidatingKey = (&incorrect_isk).into();
 

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -24,7 +24,10 @@ use crate::{
         to_scalar, NonIdentityPallasPoint, NonZeroPallasBase, NonZeroPallasScalar,
         PreparedNonIdentityBase, PreparedNonZeroScalar, PrfExpand,
     },
-    zip32::{self, ChildIndex, ExtendedSpendingKey},
+    zip32::{
+        self, ChildIndex, ExtendedSpendingKey, ZIP32_ORCHARD_PERSONALIZATION,
+        ZIP32_ORCHARD_PERSONALIZATION_FOR_ISSUANCE,
+    },
 };
 
 const KDF_ORCHARD_PERSONALIZATION: &[u8; 16] = b"Zcash_OrchardKDF";
@@ -100,7 +103,8 @@ impl SpendingKey {
             ChildIndex::try_from(coin_type)?,
             ChildIndex::try_from(account)?,
         ];
-        ExtendedSpendingKey::from_path(seed, path).map(|esk| esk.sk())
+        ExtendedSpendingKey::from_path(seed, path, ZIP32_ORCHARD_PERSONALIZATION)
+            .map(|esk| esk.sk())
     }
 }
 
@@ -256,7 +260,8 @@ impl IssuanceKey {
             ChildIndex::try_from(coin_type)?,
             ChildIndex::try_from(account)?,
         ];
-        ExtendedSpendingKey::from_path(seed, path).map(|esk| esk.sk().into())
+        ExtendedSpendingKey::from_path(seed, path, ZIP32_ORCHARD_PERSONALIZATION_FOR_ISSUANCE)
+            .map(|esk| esk.sk().into())
     }
 }
 

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -261,7 +261,7 @@ impl IssuanceKey {
         // `IssuanceAuthorizingKey::from` here because we only need to know
         // whether isk = 0; the adjustment to potentially negate isk is not
         // needed. Also, `from` would panic on isk = 0.
-        let isk = to_scalar(PrfExpand::ZsaIsk.expand(&sk_iss.0));
+        let isk = IssuanceAuthorizingKey::derive_inner(&sk_iss);
         CtOption::new(sk_iss, !isk.is_zero())
     }
 

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -257,10 +257,7 @@ impl IssuanceKey {
     /// Returns `None` if the bytes do not correspond to a valid Orchard issuance key.
     pub fn from_bytes(sk_iss: [u8; 32]) -> CtOption<Self> {
         let sk_iss = IssuanceKey(sk_iss);
-        // If isk = 0, discard this key. We call `derive_inner` rather than
-        // `IssuanceAuthorizingKey::from` here because we only need to know
-        // whether isk = 0; the adjustment to potentially negate isk is not
-        // needed. Also, `from` would panic on isk = 0.
+        // If isk = 0 (A scalar value), discard this key.
         let isk = IssuanceAuthorizingKey::derive_inner(&sk_iss);
         CtOption::new(sk_iss, !isk.is_zero())
     }

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -11,7 +11,7 @@ use group::{
     prime::PrimeCurveAffine,
     Curve, GroupEncoding,
 };
-use pasta_curves::pallas;
+use pasta_curves::{pallas, pallas::Scalar};
 use rand::{CryptoRng, RngCore};
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 use zcash_note_encryption::EphemeralKeyBytes;
@@ -137,13 +137,17 @@ impl From<&SpendingKey> for SpendAuthorizingKey {
         // SpendingKey cannot be constructed such that this assertion would fail.
         assert!(!bool::from(ask.is_zero()));
         // TODO: Add TryFrom<S::Scalar> for SpendAuthorizingKey.
-        let ret = SpendAuthorizingKey(ask.to_repr().try_into().unwrap());
-        // If the last bit of repr_P(ak) is 1, negate ask.
-        if (<[u8; 32]>::from(SpendValidatingKey::from(&ret).0)[31] >> 7) == 1 {
-            SpendAuthorizingKey((-ask).to_repr().try_into().unwrap())
-        } else {
-            ret
-        }
+        SpendAuthorizingKey(conditionally_negate(ask))
+    }
+}
+
+// If the last bit of repr_P(ak) is 1, negate ask.
+fn conditionally_negate<T: redpallas::SigType>(scalar: Scalar) -> redpallas::SigningKey<T> {
+    let ret = redpallas::SigningKey::<T>(scalar.to_repr().try_into().unwrap());
+    if (<[u8; 32]>::from(redpallas::VerificationKey::<T>::from(&ret).0)[31] >> 7) == 1 {
+        redpallas::SigningKey::<T>((-scalar).to_repr().try_into().unwrap())
+    } else {
+        ret
     }
 }
 
@@ -196,6 +200,21 @@ impl SpendValidatingKey {
             .ok()
             .and_then(check_structural_validity)
             .map(SpendValidatingKey)
+    }
+}
+
+/// A function to check structural validity of the validating keys for authorizing transfers and
+/// issuing assets
+/// Structural validity checks for ak_P or ik_P:
+///  - The point must not be the identity (which for Pallas is canonically encoded as all-zeroes).
+///  - The compressed y-coordinate bit must be 0.
+fn check_structural_validity(
+    verification_key_bytes: [u8; 32],
+) -> Option<VerificationKey<SpendAuth>> {
+    if verification_key_bytes != [0; 32] && verification_key_bytes[31] & 0x80 == 0 {
+        <redpallas::VerificationKey<SpendAuth>>::try_from(verification_key_bytes).ok()
+    } else {
+        None
     }
 }
 
@@ -276,11 +295,6 @@ impl IssuanceKey {
 pub struct IssuanceAuthorizingKey(redpallas::SigningKey<IssuanceAuth>);
 
 impl IssuanceAuthorizingKey {
-    /// Derives isk from incorrect_sk_iss. Internal use only, does not enforce all constraints.
-    fn derive_inner(sk_iss: &IssuanceKey) -> pallas::Scalar {
-        to_scalar(PrfExpand::ZsaIsk.expand(&sk_iss.0))
-    }
-
     /// Sign the provided message using the `IssuanceAuthorizingKey`.
     pub fn sign(
         &self,
@@ -293,16 +307,10 @@ impl IssuanceAuthorizingKey {
 
 impl From<&IssuanceKey> for IssuanceAuthorizingKey {
     fn from(sk_iss: &IssuanceKey) -> Self {
-        let isk = Self::derive_inner(sk_iss);
+        let isk = to_scalar(PrfExpand::ZsaIsk.expand(&sk_iss.0));
         // IssuanceAuthorizingKey cannot be constructed such that this assertion would fail.
         assert!(!bool::from(isk.is_zero()));
-        let ret = IssuanceAuthorizingKey(isk.to_repr().try_into().unwrap());
-        // If the last bit of repr_P(ik) is 1, negate isk.
-        if (<[u8; 32]>::from(IssuanceValidatingKey::from(&ret).0)[31] >> 7) == 1 {
-            IssuanceAuthorizingKey((-isk).to_repr().try_into().unwrap())
-        } else {
-            ret
-        }
+        IssuanceAuthorizingKey(conditionally_negate(isk))
     }
 }
 
@@ -362,21 +370,6 @@ impl IssuanceValidatingKey {
         signature: &redpallas::Signature<IssuanceAuth>,
     ) -> Result<(), reddsa::Error> {
         self.0.verify(msg, signature)
-    }
-}
-
-/// A function to check structural validity of the validating keys for authorizing transfers and
-/// issuing assets
-/// Structural validity checks for ak_P or ik_P:
-///  - The point must not be the identity (which for Pallas is canonically encoded as all-zeroes).
-///  - The compressed y-coordinate bit must be 0.
-fn check_structural_validity(
-    verification_key_bytes: [u8; 32],
-) -> Option<VerificationKey<SpendAuth>> {
-    if verification_key_bytes != [0; 32] && verification_key_bytes[31] & 0x80 == 0 {
-        <redpallas::VerificationKey<SpendAuth>>::try_from(verification_key_bytes).ok()
-    } else {
-        None
     }
 }
 

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -298,6 +298,11 @@ impl IssuanceKey {
 pub struct IssuanceAuthorizingKey(redpallas::SigningKey<IssuanceAuth>);
 
 impl IssuanceAuthorizingKey {
+    /// Derives isk from sk_iss. Internal use only, does not enforce all constraints.
+    fn derive_inner(sk_iss: &IssuanceKey) -> pallas::Scalar {
+        to_scalar(PrfExpand::ZsaIsk.expand(&sk_iss.0))
+    }
+
     /// Sign the provided message using the `IssuanceAuthorizingKey`.
     pub fn sign(
         &self,
@@ -310,7 +315,7 @@ impl IssuanceAuthorizingKey {
 
 impl From<&IssuanceKey> for IssuanceAuthorizingKey {
     fn from(sk_iss: &IssuanceKey) -> Self {
-        let isk = to_scalar(PrfExpand::ZsaIsk.expand(&sk_iss.0));
+        let isk = IssuanceAuthorizingKey::derive_inner(sk_iss);
         // IssuanceAuthorizingKey cannot be constructed such that this assertion would fail.
         assert!(!bool::from(isk.is_zero()));
         IssuanceAuthorizingKey(conditionally_negate(isk))

--- a/src/note/asset_base.rs
+++ b/src/note/asset_base.rs
@@ -92,8 +92,8 @@ impl AssetBase {
     ///
     /// This is only used in tests.
     pub(crate) fn random(rng: &mut impl RngCore) -> Self {
-        let sk = IssuanceKey::random(rng);
-        let isk = IssuanceAuthorizingKey::from(&sk);
+        let sk_iss = IssuanceKey::random(rng);
+        let isk = IssuanceAuthorizingKey::from(&sk_iss);
         let ik = IssuanceValidatingKey::from(&isk);
         let asset_descr = "zsa_asset";
         AssetBase::derive(&ik, asset_descr)
@@ -155,10 +155,10 @@ pub mod testing {
     prop_compose! {
         /// Generate an asset ID
         pub fn arb_zsa_asset_id()(
-            sk in arb_issuance_key(),
+            sk_iss in arb_issuance_key(),
             str in "[A-Za-z]{255}"
         ) -> AssetBase {
-            let isk = IssuanceAuthorizingKey::from(&sk);
+            let isk = IssuanceAuthorizingKey::from(&sk_iss);
             AssetBase::derive(&IssuanceValidatingKey::from(&isk), &str)
         }
     }
@@ -166,10 +166,10 @@ pub mod testing {
     prop_compose! {
         /// Generate an asset ID using a specific description
         pub fn zsa_asset_id(asset_desc: String)(
-            sk in arb_issuance_key(),
+            sk_iss in arb_issuance_key(),
         ) -> AssetBase {
             assert!(super::is_asset_desc_of_valid_size(&asset_desc));
-            let isk = IssuanceAuthorizingKey::from(&sk);
+            let isk = IssuanceAuthorizingKey::from(&sk_iss);
             AssetBase::derive(&IssuanceValidatingKey::from(&isk), &asset_desc)
         }
     }

--- a/src/note/asset_base.rs
+++ b/src/note/asset_base.rs
@@ -10,7 +10,7 @@ use subtle::{Choice, ConstantTimeEq, CtOption};
 use crate::constants::fixed_bases::{
     NATIVE_ASSET_BASE_V_BYTES, VALUE_COMMITMENT_PERSONALIZATION, ZSA_ASSET_BASE_PERSONALIZATION,
 };
-use crate::keys::{IssuanceAuthorizingKey, IssuanceValidatingKey, SpendingKey};
+use crate::keys::{IssuanceAuthorizingKey, IssuanceKey, IssuanceValidatingKey};
 
 /// Note type identifier.
 #[derive(Clone, Copy, Debug, Eq)]
@@ -92,7 +92,7 @@ impl AssetBase {
     ///
     /// This is only used in tests.
     pub(crate) fn random(rng: &mut impl RngCore) -> Self {
-        let sk = SpendingKey::random(rng);
+        let sk = IssuanceKey::random(rng);
         let isk = IssuanceAuthorizingKey::from(&sk);
         let ik = IssuanceValidatingKey::from(&isk);
         let asset_descr = "zsa_asset";
@@ -126,13 +126,13 @@ pub mod testing {
 
     use proptest::prelude::*;
 
-    use crate::keys::{testing::arb_spending_key, IssuanceAuthorizingKey, IssuanceValidatingKey};
+    use crate::keys::{testing::arb_issuance_key, IssuanceAuthorizingKey, IssuanceValidatingKey};
 
     prop_compose! {
         /// Generate a uniformly distributed note type
         pub fn arb_asset_id()(
             is_native in prop::bool::ANY,
-            sk in arb_spending_key(),
+            sk in arb_issuance_key(),
             str in "[A-Za-z]{255}",
         ) -> AssetBase {
             if is_native {
@@ -155,7 +155,7 @@ pub mod testing {
     prop_compose! {
         /// Generate an asset ID
         pub fn arb_zsa_asset_id()(
-            sk in arb_spending_key(),
+            sk in arb_issuance_key(),
             str in "[A-Za-z]{255}"
         ) -> AssetBase {
             let isk = IssuanceAuthorizingKey::from(&sk);
@@ -166,7 +166,7 @@ pub mod testing {
     prop_compose! {
         /// Generate an asset ID using a specific description
         pub fn zsa_asset_id(asset_desc: String)(
-            sk in arb_spending_key(),
+            sk in arb_issuance_key(),
         ) -> AssetBase {
             assert!(super::is_asset_desc_of_valid_size(&asset_desc));
             let isk = IssuanceAuthorizingKey::from(&sk);

--- a/src/primitives/redpallas.rs
+++ b/src/primitives/redpallas.rs
@@ -23,7 +23,7 @@ impl SigType for Binding {}
 
 /// A RedPallas signing key.
 #[derive(Clone, Copy, Debug)]
-pub struct SigningKey<T: SigType>(reddsa::SigningKey<T>);
+pub struct SigningKey<T: SigType>(pub(crate) reddsa::SigningKey<T>);
 
 impl<T: SigType> From<SigningKey<T>> for [u8; 32] {
     fn from(sk: SigningKey<T>) -> [u8; 32] {
@@ -63,7 +63,7 @@ impl<T: SigType> SigningKey<T> {
 
 /// A RedPallas verification key.
 #[derive(Clone, Debug)]
-pub struct VerificationKey<T: SigType>(reddsa::VerificationKey<T>);
+pub struct VerificationKey<T: SigType>(pub(crate) reddsa::VerificationKey<T>);
 
 impl<T: SigType> From<VerificationKey<T>> for [u8; 32] {
     fn from(vk: VerificationKey<T>) -> [u8; 32] {

--- a/src/supply_info.rs
+++ b/src/supply_info.rs
@@ -80,9 +80,9 @@ mod tests {
     use super::*;
 
     fn create_test_asset(asset_desc: &str) -> AssetBase {
-        use crate::keys::{IssuanceAuthorizingKey, IssuanceValidatingKey, SpendingKey};
+        use crate::keys::{IssuanceAuthorizingKey, IssuanceKey, IssuanceValidatingKey};
 
-        let sk = SpendingKey::from_bytes([0u8; 32]).unwrap();
+        let sk = IssuanceKey::from_bytes([0u8; 32]).unwrap();
         let isk: IssuanceAuthorizingKey = (&sk).into();
 
         AssetBase::derive(&IssuanceValidatingKey::from(&isk), asset_desc)

--- a/src/supply_info.rs
+++ b/src/supply_info.rs
@@ -82,8 +82,8 @@ mod tests {
     fn create_test_asset(asset_desc: &str) -> AssetBase {
         use crate::keys::{IssuanceAuthorizingKey, IssuanceKey, IssuanceValidatingKey};
 
-        let sk = IssuanceKey::from_bytes([0u8; 32]).unwrap();
-        let isk: IssuanceAuthorizingKey = (&sk).into();
+        let sk_iss = IssuanceKey::from_bytes([0u8; 32]).unwrap();
+        let isk: IssuanceAuthorizingKey = (&sk_iss).into();
 
         AssetBase::derive(&IssuanceValidatingKey::from(&isk), asset_desc)
     }

--- a/src/zip32.rs
+++ b/src/zip32.rs
@@ -10,8 +10,11 @@ use crate::{
     spec::PrfExpand,
 };
 
-const ZIP32_ORCHARD_PERSONALIZATION: &[u8; 16] = b"ZcashIP32Orchard";
 const ZIP32_ORCHARD_FVFP_PERSONALIZATION: &[u8; 16] = b"ZcashOrchardFVFP";
+/// Personalization for the master extended spending key
+pub const ZIP32_ORCHARD_PERSONALIZATION: &[u8; 16] = b"ZcashIP32Orchard";
+/// Personalization for the master extended issuance key
+pub const ZIP32_ORCHARD_PERSONALIZATION_FOR_ISSUANCE: &[u8; 16] = b"ZIP32ZSAIssue_V1";
 
 /// Errors produced in derivation of extended spending keys
 #[derive(Debug, PartialEq, Eq)]
@@ -117,8 +120,12 @@ impl ExtendedSpendingKey {
     /// # Panics
     ///
     /// Panics if seed results in invalid spending key.
-    pub fn from_path(seed: &[u8], path: &[ChildIndex]) -> Result<Self, Error> {
-        let mut xsk = Self::master(seed)?;
+    pub fn from_path(
+        seed: &[u8],
+        path: &[ChildIndex],
+        personalization: &[u8; 16],
+    ) -> Result<Self, Error> {
+        let mut xsk = Self::master(seed, personalization)?;
         for i in path {
             xsk = xsk.derive_child(*i)?;
         }
@@ -134,13 +141,13 @@ impl ExtendedSpendingKey {
     /// # Panics
     ///
     /// Panics if the seed is shorter than 32 bytes or longer than 252 bytes.
-    fn master(seed: &[u8]) -> Result<Self, Error> {
+    fn master(seed: &[u8], personalization: &[u8; 16]) -> Result<Self, Error> {
         assert!(seed.len() >= 32 && seed.len() <= 252);
         // I := BLAKE2b-512("ZcashIP32Orchard", seed)
         let I: [u8; 64] = {
             let mut I = Blake2bParams::new()
                 .hash_length(64)
-                .personal(ZIP32_ORCHARD_PERSONALIZATION)
+                .personal(personalization)
                 .to_state();
             I.update(seed);
             I.finalize().as_bytes().try_into().unwrap()
@@ -213,7 +220,7 @@ mod tests {
     #[test]
     fn derive_child() {
         let seed = [0; 32];
-        let xsk_m = ExtendedSpendingKey::master(&seed).unwrap();
+        let xsk_m = ExtendedSpendingKey::master(&seed, ZIP32_ORCHARD_PERSONALIZATION).unwrap();
 
         let i_5 = 5;
         let xsk_5 = xsk_m.derive_child(i_5.try_into().unwrap());
@@ -224,20 +231,28 @@ mod tests {
     #[test]
     fn path() {
         let seed = [0; 32];
-        let xsk_m = ExtendedSpendingKey::master(&seed).unwrap();
+        let xsk_m = ExtendedSpendingKey::master(&seed, ZIP32_ORCHARD_PERSONALIZATION).unwrap();
 
         let xsk_5h = xsk_m.derive_child(5.try_into().unwrap()).unwrap();
         assert!(bool::from(
-            ExtendedSpendingKey::from_path(&seed, &[5.try_into().unwrap()])
-                .unwrap()
-                .ct_eq(&xsk_5h)
+            ExtendedSpendingKey::from_path(
+                &seed,
+                &[5.try_into().unwrap()],
+                ZIP32_ORCHARD_PERSONALIZATION
+            )
+            .unwrap()
+            .ct_eq(&xsk_5h)
         ));
 
         let xsk_5h_7 = xsk_5h.derive_child(7.try_into().unwrap()).unwrap();
         assert!(bool::from(
-            ExtendedSpendingKey::from_path(&seed, &[5.try_into().unwrap(), 7.try_into().unwrap()])
-                .unwrap()
-                .ct_eq(&xsk_5h_7)
+            ExtendedSpendingKey::from_path(
+                &seed,
+                &[5.try_into().unwrap(), 7.try_into().unwrap()],
+                ZIP32_ORCHARD_PERSONALIZATION
+            )
+            .unwrap()
+            .ct_eq(&xsk_5h_7)
         ));
     }
 }

--- a/tests/zsa.rs
+++ b/tests/zsa.rs
@@ -13,7 +13,10 @@ use orchard::{
     builder::Builder,
     bundle::Flags,
     circuit::{ProvingKey, VerifyingKey},
-    keys::{FullViewingKey, PreparedIncomingViewingKey, Scope, SpendAuthorizingKey, SpendingKey},
+    keys::{
+        FullViewingKey, IssuanceKey, PreparedIncomingViewingKey, Scope, SpendAuthorizingKey,
+        SpendingKey,
+    },
     value::NoteValue,
     Address, Anchor, Bundle, Note,
 };
@@ -58,15 +61,16 @@ fn prepare_keys() -> Keychain {
     let fvk = FullViewingKey::from(&sk);
     let recipient = fvk.address_at(0u32, Scope::External);
 
-    let isk = IssuanceAuthorizingKey::from(&sk);
-    let ik = IssuanceValidatingKey::from(&isk);
+    let ik = IssuanceKey::from_bytes([0; 32]).unwrap();
+    let isk = IssuanceAuthorizingKey::from(&ik);
+    let ivk = IssuanceValidatingKey::from(&isk);
     Keychain {
         pk,
         vk,
         sk,
         fvk,
         isk,
-        ik,
+        ik: ivk,
         recipient,
     }
 }

--- a/tests/zsa.rs
+++ b/tests/zsa.rs
@@ -61,16 +61,16 @@ fn prepare_keys() -> Keychain {
     let fvk = FullViewingKey::from(&sk);
     let recipient = fvk.address_at(0u32, Scope::External);
 
-    let ik = IssuanceKey::from_bytes([0; 32]).unwrap();
-    let isk = IssuanceAuthorizingKey::from(&ik);
-    let ivk = IssuanceValidatingKey::from(&isk);
+    let sk_iss = IssuanceKey::from_bytes([0; 32]).unwrap();
+    let isk = IssuanceAuthorizingKey::from(&sk_iss);
+    let ik = IssuanceValidatingKey::from(&isk);
     Keychain {
         pk,
         vk,
         sk,
         fvk,
         isk,
-        ik: ivk,
+        ik,
         recipient,
     }
 }


### PR DESCRIPTION
Updated constants for master (extended) issuance key according to ZIP 227. Previously, we used the same personalization for the master extended spending key and the master extended issuance key, as well as the same purpose constant for the spending master key and the issuance master key.

Now, the following updates have been made:
- Personalization for the master extended issuance key: ZIP32ZSAIssue_V1
- Purpose constant for the issuance master key: 227"
