### PR TITLE
Updating variable name from `sk_iss` and `idk` to `imk`

### DIFF
--- a/src/bundle/burn_validation.rs
+++ b/src/bundle/burn_validation.rs
@@ -83,8 +83,8 @@ mod tests {
     pub fn get_burn_tuple(asset_desc: &str, value: i64) -> (AssetBase, i64) {
         use crate::keys::{IssuanceAuthorizingKey, IssuanceKey, IssuanceValidatingKey};
 
-        let sk_iss = IssuanceKey::from_bytes([0u8; 32]).unwrap();
-        let isk: IssuanceAuthorizingKey = (&sk_iss).into();
+        let imk = IssuanceKey::from_bytes([0u8; 32]).unwrap();
+        let isk: IssuanceAuthorizingKey = (&imk).into();
 
         (
             AssetBase::derive(&IssuanceValidatingKey::from(&isk), asset_desc),

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -629,8 +629,8 @@ mod tests {
     ) {
         let mut rng = OsRng;
 
-        let sk_iss = IssuanceKey::random(&mut rng);
-        let isk: IssuanceAuthorizingKey = (&sk_iss).into();
+        let imk = IssuanceKey::random(&mut rng);
+        let isk: IssuanceAuthorizingKey = (&imk).into();
         let ik: IssuanceValidatingKey = (&isk).into();
 
         let fvk = FullViewingKey::from(&SpendingKey::random(&mut rng));
@@ -1278,8 +1278,8 @@ mod tests {
 
         let mut signed = bundle.prepare(sighash).sign(rng, &isk).unwrap();
 
-        let incorrect_sk_iss = IssuanceKey::random(&mut rng);
-        let incorrect_isk: IssuanceAuthorizingKey = (&incorrect_sk_iss).into();
+        let incorrect_imk = IssuanceKey::random(&mut rng);
+        let incorrect_isk: IssuanceAuthorizingKey = (&incorrect_imk).into();
         let incorrect_ik: IssuanceValidatingKey = (&incorrect_isk).into();
 
         // Add "bad" note

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -255,11 +255,11 @@ impl IssuanceKey {
     /// Constructs an Orchard issuance key from uniformly-random bytes.
     ///
     /// Returns `None` if the bytes do not correspond to a valid Orchard issuance key.
-    pub fn from_bytes(sk_iss: [u8; 32]) -> CtOption<Self> {
-        let sk_iss = IssuanceKey(sk_iss);
+    pub fn from_bytes(imk: [u8; 32]) -> CtOption<Self> {
+        let imk = IssuanceKey(imk);
         // If isk = 0 (A scalar value), discard this key.
-        let isk = IssuanceAuthorizingKey::derive_inner(&sk_iss);
-        CtOption::new(sk_iss, !isk.is_zero())
+        let isk = IssuanceAuthorizingKey::derive_inner(&imk);
+        CtOption::new(imk, !isk.is_zero())
     }
 
     /// Returns the raw bytes of the issuance key.
@@ -295,9 +295,9 @@ impl IssuanceKey {
 pub struct IssuanceAuthorizingKey(redpallas::SigningKey<IssuanceAuth>);
 
 impl IssuanceAuthorizingKey {
-    /// Derives isk from sk_iss. Internal use only, does not enforce all constraints.
-    fn derive_inner(sk_iss: &IssuanceKey) -> pallas::Scalar {
-        to_scalar(PrfExpand::ZsaIsk.expand(&sk_iss.0))
+    /// Derives isk from imk. Internal use only, does not enforce all constraints.
+    fn derive_inner(imk: &IssuanceKey) -> pallas::Scalar {
+        to_scalar(PrfExpand::ZsaIsk.expand(&imk.0))
     }
 
     /// Sign the provided message using the `IssuanceAuthorizingKey`.
@@ -311,8 +311,8 @@ impl IssuanceAuthorizingKey {
 }
 
 impl From<&IssuanceKey> for IssuanceAuthorizingKey {
-    fn from(sk_iss: &IssuanceKey) -> Self {
-        let isk = IssuanceAuthorizingKey::derive_inner(sk_iss);
+    fn from(imk: &IssuanceKey) -> Self {
+        let isk = IssuanceAuthorizingKey::derive_inner(imk);
         // IssuanceAuthorizingKey cannot be constructed such that this assertion would fail.
         assert!(!bool::from(isk.is_zero()));
         IssuanceAuthorizingKey(conditionally_negate(isk))
@@ -1267,9 +1267,9 @@ mod tests {
             let ask: SpendAuthorizingKey = (&sk).into();
             assert_eq!(<[u8; 32]>::from(&ask.0), tv.ask);
 
-            let sk_iss = IssuanceKey::from_bytes(tv.sk).unwrap();
+            let imk = IssuanceKey::from_bytes(tv.sk).unwrap();
 
-            let isk: IssuanceAuthorizingKey = (&sk_iss).into();
+            let isk: IssuanceAuthorizingKey = (&imk).into();
             assert_eq!(<[u8; 32]>::from(&isk.0), tv.isk);
 
             let ak: SpendValidatingKey = (&ask).into();

--- a/src/note/asset_base.rs
+++ b/src/note/asset_base.rs
@@ -102,8 +102,8 @@ impl AssetBase {
     ///
     /// This is only used in tests.
     pub(crate) fn random(rng: &mut impl RngCore) -> Self {
-        let sk_iss = IssuanceKey::random(rng);
-        let isk = IssuanceAuthorizingKey::from(&sk_iss);
+        let imk = IssuanceKey::random(rng);
+        let isk = IssuanceAuthorizingKey::from(&imk);
         let ik = IssuanceValidatingKey::from(&isk);
         let asset_descr = "zsa_asset";
         AssetBase::derive(&ik, asset_descr)
@@ -165,10 +165,10 @@ pub mod testing {
     prop_compose! {
         /// Generate an asset ID
         pub fn arb_zsa_asset_id()(
-            sk_iss in arb_issuance_key(),
+            imk in arb_issuance_key(),
             str in "[A-Za-z]{255}"
         ) -> AssetBase {
-            let isk = IssuanceAuthorizingKey::from(&sk_iss);
+            let isk = IssuanceAuthorizingKey::from(&imk);
             AssetBase::derive(&IssuanceValidatingKey::from(&isk), &str)
         }
     }
@@ -176,10 +176,10 @@ pub mod testing {
     prop_compose! {
         /// Generate an asset ID using a specific description
         pub fn zsa_asset_id(asset_desc: String)(
-            sk_iss in arb_issuance_key(),
+            imk in arb_issuance_key(),
         ) -> AssetBase {
             assert!(super::is_asset_desc_of_valid_size(&asset_desc));
-            let isk = IssuanceAuthorizingKey::from(&sk_iss);
+            let isk = IssuanceAuthorizingKey::from(&imk);
             AssetBase::derive(&IssuanceValidatingKey::from(&isk), &asset_desc)
         }
     }

--- a/src/supply_info.rs
+++ b/src/supply_info.rs
@@ -82,8 +82,8 @@ mod tests {
     fn create_test_asset(asset_desc: &str) -> AssetBase {
         use crate::keys::{IssuanceAuthorizingKey, IssuanceKey, IssuanceValidatingKey};
 
-        let sk_iss = IssuanceKey::from_bytes([0u8; 32]).unwrap();
-        let isk: IssuanceAuthorizingKey = (&sk_iss).into();
+        let imk = IssuanceKey::from_bytes([0u8; 32]).unwrap();
+        let isk: IssuanceAuthorizingKey = (&imk).into();
 
         AssetBase::derive(&IssuanceValidatingKey::from(&isk), asset_desc)
     }

--- a/tests/zsa.rs
+++ b/tests/zsa.rs
@@ -61,8 +61,8 @@ fn prepare_keys() -> Keychain {
     let fvk = FullViewingKey::from(&sk);
     let recipient = fvk.address_at(0u32, Scope::External);
 
-    let sk_iss = IssuanceKey::from_bytes([0; 32]).unwrap();
-    let isk = IssuanceAuthorizingKey::from(&sk_iss);
+    let imk = IssuanceKey::from_bytes([0; 32]).unwrap();
+    let isk = IssuanceAuthorizingKey::from(&imk);
     let ik = IssuanceValidatingKey::from(&isk);
     Keychain {
         pk,


### PR DESCRIPTION
This PR updates the notation for the issuance keys in order to make it consistent with the spec.