### PR TITLE
Draft: porting Batch Validator changes on top of the latest zsa1 branch (after PR #81 merge)

### DIFF
--- a/src/bundle/batch.rs
+++ b/src/bundle/batch.rs
@@ -3,9 +3,10 @@ use pasta_curves::vesta;
 use rand::{CryptoRng, RngCore};
 use tracing::debug;
 
-use super::{Authorized, Bundle};
+use super::{burn_validation::validate_bundle_burn, Authorized, Bundle};
 use crate::{
     circuit::VerifyingKey,
+    note::AssetBase,
     primitives::redpallas::{self, Binding, SpendAuth},
 };
 
@@ -23,6 +24,7 @@ struct BundleSignature {
 pub struct BatchValidator {
     proofs: plonk::BatchVerifier<vesta::Affine>,
     signatures: Vec<BundleSignature>,
+    burns: Vec<(AssetBase, i64)>,
 }
 
 impl BatchValidator {
@@ -31,10 +33,11 @@ impl BatchValidator {
         BatchValidator {
             proofs: plonk::BatchVerifier::new(),
             signatures: vec![],
+            burns: vec![],
         }
     }
 
-    /// Adds the proof and RedPallas signatures from the given bundle to the validator.
+    /// Adds the proof, RedPallas signatures and burn mechanism values from the given bundle to the validator.
     pub fn add_bundle<V: Copy + Into<i64>>(
         &mut self,
         bundle: &Bundle<Authorized, V>,
@@ -58,6 +61,13 @@ impl BatchValidator {
             .authorization()
             .proof()
             .add_to_batch(&mut self.proofs, bundle.to_instances());
+
+        self.burns.extend(
+            bundle
+                .burn
+                .iter()
+                .map(|(asset, amount)| (*asset, (*amount).into())),
+        );
     }
 
     /// Batch-validates the accumulated bundles.
@@ -67,6 +77,10 @@ impl BatchValidator {
     /// figure out which of the accumulated bundles might be invalid; if that information
     /// is desired, construct separate [`BatchValidator`]s for sub-batches of the bundles.
     pub fn validate<R: RngCore + CryptoRng>(self, vk: &VerifyingKey, rng: R) -> bool {
+        if validate_bundle_burn(&self.burns).is_err() {
+            return false;
+        }
+
         if self.signatures.is_empty() {
             // An empty batch is always valid, but is not free to run; skip it.
             // Note that a transaction has at least a binding signature, so if

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -1,6 +1,7 @@
 //! Structs related to issuance bundles and the associated logic.
 use blake2b_simd::Hash as Blake2bHash;
 use group::Group;
+use memuse::DynamicUsage;
 use nonempty::NonEmpty;
 use rand::{CryptoRng, RngCore};
 use std::collections::HashSet;
@@ -25,6 +26,10 @@ use crate::{
 
 use crate::supply_info::{AssetSupply, SupplyInfo};
 
+mod batch;
+
+pub use batch::BatchValidator;
+
 /// A bundle of actions to be applied to the ledger.
 #[derive(Debug, Clone)]
 pub struct IssueBundle<T: IssueAuth> {
@@ -47,6 +52,24 @@ pub struct IssueAction {
     notes: Vec<Note>,
     /// `finalize` will prevent further issuance of the same asset type.
     finalize: bool,
+}
+
+impl DynamicUsage for IssueAction {
+    #[inline(always)]
+    fn dynamic_usage(&self) -> usize {
+        self.asset_desc.dynamic_usage() + self.notes.dynamic_usage()
+    }
+
+    #[inline(always)]
+    fn dynamic_usage_bounds(&self) -> (usize, Option<usize>) {
+        let asset_desc_bounds = self.asset_desc.dynamic_usage_bounds();
+        let note_bounds = self.notes.dynamic_usage_bounds();
+
+        (
+            asset_desc_bounds.0 + note_bounds.0,
+            asset_desc_bounds.1.zip(note_bounds.1).map(|(a, b)| a + b),
+        )
+    }
 }
 
 /// The parameters required to add a Note into an IssueAction.
@@ -201,6 +224,15 @@ impl Signed {
 impl IssueAuth for Unauthorized {}
 impl IssueAuth for Prepared {}
 impl IssueAuth for Signed {}
+
+impl DynamicUsage for Signed {
+    fn dynamic_usage(&self) -> usize {
+        0
+    }
+    fn dynamic_usage_bounds(&self) -> (usize, Option<usize>) {
+        (0, Some(0))
+    }
+}
 
 impl<T: IssueAuth> IssueBundle<T> {
     /// Returns the issuer verification key for the bundle.
@@ -457,6 +489,27 @@ impl IssueBundle<Signed> {
     /// This together with `IssueBundle::commitment` bind the entire bundle.
     pub fn authorizing_commitment(&self) -> IssueBundleAuthorizingCommitment {
         IssueBundleAuthorizingCommitment(hash_issue_bundle_auth_data(self))
+    }
+}
+
+impl DynamicUsage for IssueBundle<Signed> {
+    fn dynamic_usage(&self) -> usize {
+        self.actions.dynamic_usage() + self.ik.dynamic_usage() + self.authorization.dynamic_usage()
+    }
+
+    fn dynamic_usage_bounds(&self) -> (usize, Option<usize>) {
+        let action_bounds = self.actions.dynamic_usage_bounds();
+        let ik_bounds = self.ik.dynamic_usage_bounds();
+        let authorization_bounds = self.authorization.dynamic_usage_bounds();
+
+        (
+            action_bounds.0 + ik_bounds.0 + authorization_bounds.0,
+            action_bounds
+                .1
+                .zip(ik_bounds.1)
+                .zip(authorization_bounds.1)
+                .map(|((a, b), c)| a + b + c),
+        )
     }
 }
 

--- a/src/issuance/batch.rs
+++ b/src/issuance/batch.rs
@@ -1,0 +1,36 @@
+use std::collections::HashSet;
+
+use super::{verify_issue_bundle, AssetBase, IssueBundle, Signed};
+
+/// Batch validation context for Issuance.
+///
+#[derive(Debug, Default)]
+pub struct BatchValidator {
+    bundles: Vec<(IssueBundle<Signed>, [u8; 32])>,
+}
+
+impl BatchValidator {
+    /// Constructs a new batch validation context.
+    pub fn new() -> Self {
+        BatchValidator { bundles: vec![] }
+    }
+
+    /// Adds bundle to the validator.
+    pub fn add_bundle(&mut self, bundle: &IssueBundle<Signed>, sighash: [u8; 32]) {
+        self.bundles.push((bundle.clone(), sighash))
+    }
+
+    /// Batch-validates the accumulated bundles.
+    ///
+    /// Returns `true` if every bundle added to the batch validator is valid, or `false`
+    /// if one or more are invalid.
+    pub fn validate(self) -> bool {
+        // FIXME: take/save finalization set from/to the global state
+        let finalized = HashSet::<AssetBase>::new();
+
+        // FIXME: process resulting supply_info
+        self.bundles
+            .into_iter()
+            .all(|(bundle, sighash)| verify_issue_bundle(&bundle, sighash, &finalized).is_ok())
+    }
+}

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -11,6 +11,7 @@ use group::{
     prime::PrimeCurveAffine,
     Curve, GroupEncoding,
 };
+use memuse::DynamicUsage;
 use pasta_curves::{pallas, pallas::Scalar};
 use rand::{CryptoRng, RngCore};
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
@@ -348,6 +349,18 @@ impl PartialEq for IssuanceValidatingKey {
 }
 
 impl Eq for IssuanceValidatingKey {}
+
+impl DynamicUsage for IssuanceValidatingKey {
+    #[inline(always)]
+    fn dynamic_usage(&self) -> usize {
+        0
+    }
+
+    #[inline(always)]
+    fn dynamic_usage_bounds(&self) -> (usize, Option<usize>) {
+        (0, Some(0))
+    }
+}
 
 impl IssuanceValidatingKey {
     /// Converts this spend validating key to its serialized form,

--- a/src/note.rs
+++ b/src/note.rs
@@ -2,6 +2,7 @@
 use core::fmt;
 
 use group::GroupEncoding;
+use memuse::DynamicUsage;
 use pasta_curves::pallas;
 use rand::RngCore;
 use subtle::{Choice, ConditionallySelectable, CtOption};
@@ -303,6 +304,18 @@ impl Note {
             rseed_split_note: CtOption::new(RandomSeed::random(rng, &self.rho), 1u8.into()),
             ..self
         }
+    }
+}
+
+impl DynamicUsage for Note {
+    #[inline(always)]
+    fn dynamic_usage(&self) -> usize {
+        0
+    }
+
+    #[inline(always)]
+    fn dynamic_usage_bounds(&self) -> (usize, Option<usize>) {
+        (0, Some(0))
     }
 }
 


### PR DESCRIPTION
This pull request represents draft work related to Batch Validators for the `zsa1` branch. Initially, these changes were developed in the i`vk-to-bytes-visibility-downgrade-with-burn-valid` branch with the intention of integration into the updated Zcash repository. However, we later decided to shift our focus to the Zebra project instead of Zcashd. As Batch Validators are not used in Zebra, we made the decision to revert the related changes from the `ivk-to-bytes-visibility-downgrade-with-burn-valid` branch and merged it into `zsa1` without those changes (see PR #81).

To ensure that the Batch Validator changes are preserved for potential future use, we created the `draft-batch-validators-changes` branch from the latest version of `zsa1` after the merge of #81. We then copied the Batch Validators work into this branch and created this draft PR to update the `zsa1` branch.

Please note that this PR is a draft and not intended for immediate merging. It serves as a work in progress and a reference point for the changes made.