### PR TITLE
Rename `IssuanceKey` struct to `IssuanceMasterKey`

### DIFF
--- a/src/bundle/burn_validation.rs
+++ b/src/bundle/burn_validation.rs
@@ -69,7 +69,7 @@ mod tests {
     /// Creates an item of bundle burn list for a given asset description and value.
     ///
     /// This function is deterministic and guarantees that each call with the same parameters
-    /// will return the same result. It achieves determinism by using a static `IssuanceKey`.
+    /// will return the same result. It achieves determinism by using a static `IssuanceMasterKey`.
     ///
     /// # Arguments
     ///
@@ -81,9 +81,9 @@ mod tests {
     /// A tuple `(AssetBase, Amount)` representing the burn list item.
     ///
     pub fn get_burn_tuple(asset_desc: &str, value: i64) -> (AssetBase, i64) {
-        use crate::keys::{IssuanceAuthorizingKey, IssuanceKey, IssuanceValidatingKey};
+        use crate::keys::{IssuanceAuthorizingKey, IssuanceMasterKey, IssuanceValidatingKey};
 
-        let imk = IssuanceKey::from_bytes([0u8; 32]).unwrap();
+        let imk = IssuanceMasterKey::from_bytes([0u8; 32]).unwrap();
         let isk: IssuanceAuthorizingKey = (&imk).into();
 
         (

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -606,7 +606,7 @@ mod tests {
     };
     use crate::issuance::{verify_issue_bundle, IssueAction, Signed, Unauthorized};
     use crate::keys::{
-        FullViewingKey, IssuanceAuthorizingKey, IssuanceKey, IssuanceValidatingKey, Scope,
+        FullViewingKey, IssuanceAuthorizingKey, IssuanceMasterKey, IssuanceValidatingKey, Scope,
         SpendingKey,
     };
     use crate::note::{AssetBase, Nullifier};
@@ -629,7 +629,7 @@ mod tests {
     ) {
         let mut rng = OsRng;
 
-        let imk = IssuanceKey::random(&mut rng);
+        let imk = IssuanceMasterKey::random(&mut rng);
         let isk: IssuanceAuthorizingKey = (&imk).into();
         let ik: IssuanceValidatingKey = (&isk).into();
 
@@ -951,7 +951,7 @@ mod tests {
         )
         .unwrap();
 
-        let wrong_isk: IssuanceAuthorizingKey = (&IssuanceKey::random(&mut OsRng)).into();
+        let wrong_isk: IssuanceAuthorizingKey = (&IssuanceMasterKey::random(&mut OsRng)).into();
 
         let err = bundle
             .prepare([0; 32])
@@ -1183,7 +1183,7 @@ mod tests {
         )
         .unwrap();
 
-        let wrong_isk: IssuanceAuthorizingKey = (&IssuanceKey::random(&mut rng)).into();
+        let wrong_isk: IssuanceAuthorizingKey = (&IssuanceMasterKey::random(&mut rng)).into();
 
         let mut signed = bundle.prepare(sighash).sign(rng, &isk).unwrap();
 
@@ -1278,7 +1278,7 @@ mod tests {
 
         let mut signed = bundle.prepare(sighash).sign(rng, &isk).unwrap();
 
-        let incorrect_imk = IssuanceKey::random(&mut rng);
+        let incorrect_imk = IssuanceMasterKey::random(&mut rng);
         let incorrect_isk: IssuanceAuthorizingKey = (&incorrect_imk).into();
         let incorrect_ik: IssuanceValidatingKey = (&incorrect_isk).into();
 

--- a/src/note/asset_base.rs
+++ b/src/note/asset_base.rs
@@ -10,7 +10,7 @@ use subtle::{Choice, ConstantTimeEq, CtOption};
 use crate::constants::fixed_bases::{
     NATIVE_ASSET_BASE_V_BYTES, VALUE_COMMITMENT_PERSONALIZATION, ZSA_ASSET_BASE_PERSONALIZATION,
 };
-use crate::keys::{IssuanceAuthorizingKey, IssuanceKey, IssuanceValidatingKey};
+use crate::keys::{IssuanceAuthorizingKey, IssuanceMasterKey, IssuanceValidatingKey};
 
 /// Note type identifier.
 #[derive(Clone, Copy, Debug, Eq)]
@@ -102,7 +102,7 @@ impl AssetBase {
     ///
     /// This is only used in tests.
     pub(crate) fn random(rng: &mut impl RngCore) -> Self {
-        let imk = IssuanceKey::random(rng);
+        let imk = IssuanceMasterKey::random(rng);
         let isk = IssuanceAuthorizingKey::from(&imk);
         let ik = IssuanceValidatingKey::from(&isk);
         let asset_descr = "zsa_asset";

--- a/src/supply_info.rs
+++ b/src/supply_info.rs
@@ -80,9 +80,9 @@ mod tests {
     use super::*;
 
     fn create_test_asset(asset_desc: &str) -> AssetBase {
-        use crate::keys::{IssuanceAuthorizingKey, IssuanceKey, IssuanceValidatingKey};
+        use crate::keys::{IssuanceAuthorizingKey, IssuanceMasterKey, IssuanceValidatingKey};
 
-        let imk = IssuanceKey::from_bytes([0u8; 32]).unwrap();
+        let imk = IssuanceMasterKey::from_bytes([0u8; 32]).unwrap();
         let isk: IssuanceAuthorizingKey = (&imk).into();
 
         AssetBase::derive(&IssuanceValidatingKey::from(&isk), asset_desc)

--- a/tests/zsa.rs
+++ b/tests/zsa.rs
@@ -14,7 +14,7 @@ use orchard::{
     bundle::Flags,
     circuit::{ProvingKey, VerifyingKey},
     keys::{
-        FullViewingKey, IssuanceKey, PreparedIncomingViewingKey, Scope, SpendAuthorizingKey,
+        FullViewingKey, IssuanceMasterKey, PreparedIncomingViewingKey, Scope, SpendAuthorizingKey,
         SpendingKey,
     },
     value::NoteValue,
@@ -61,7 +61,7 @@ fn prepare_keys() -> Keychain {
     let fvk = FullViewingKey::from(&sk);
     let recipient = fvk.address_at(0u32, Scope::External);
 
-    let imk = IssuanceKey::from_bytes([0; 32]).unwrap();
+    let imk = IssuanceMasterKey::from_bytes([0; 32]).unwrap();
     let isk = IssuanceAuthorizingKey::from(&imk);
     let ik = IssuanceValidatingKey::from(&isk);
     Keychain {


### PR DESCRIPTION
This PR makes a consistent rename of the struct in order to improve consistency with ZIP 227.