### PR TITLE
Rename `sk_iss` to `imk`, the `IssuanceKey` struct to `IssuanceMasterKey`, and move to a two key structure

### DIFF
--- a/src/bundle/burn_validation.rs
+++ b/src/bundle/burn_validation.rs
@@ -69,7 +69,7 @@ mod tests {
     /// Creates an item of bundle burn list for a given asset description and value.
     ///
     /// This function is deterministic and guarantees that each call with the same parameters
-    /// will return the same result. It achieves determinism by using a static `IssuanceMasterKey`.
+    /// will return the same result. It achieves determinism by using a static `IssuanceAuthorizingKey`.
     ///
     /// # Arguments
     ///
@@ -81,12 +81,12 @@ mod tests {
     /// A tuple `(AssetBase, Amount)` representing the burn list item.
     ///
     pub fn get_burn_tuple(asset_desc: &str, value: i64) -> (AssetBase, i64) {
-        use crate::keys::{IssuanceMasterKey, IssuanceValidatingKey};
+        use crate::keys::{IssuanceAuthorizingKey, IssuanceValidatingKey};
 
-        let imk = IssuanceMasterKey::from_bytes([0u8; 32]).unwrap();
+        let isk = IssuanceAuthorizingKey::from_bytes([0u8; 32]).unwrap();
 
         (
-            AssetBase::derive(&IssuanceValidatingKey::from(&imk), asset_desc),
+            AssetBase::derive(&IssuanceValidatingKey::from(&isk), asset_desc),
             value,
         )
     }

--- a/src/bundle/burn_validation.rs
+++ b/src/bundle/burn_validation.rs
@@ -83,8 +83,8 @@ mod tests {
     pub fn get_burn_tuple(asset_desc: &str, value: i64) -> (AssetBase, i64) {
         use crate::keys::{IssuanceAuthorizingKey, IssuanceKey, IssuanceValidatingKey};
 
-        let sk_iss = IssuanceKey::from_bytes([0u8; 32]).unwrap();
-        let isk: IssuanceAuthorizingKey = (&sk_iss).into();
+        let imk = IssuanceKey::from_bytes([0u8; 32]).unwrap();
+        let isk: IssuanceAuthorizingKey = (&imk).into();
 
         (
             AssetBase::derive(&IssuanceValidatingKey::from(&isk), asset_desc),

--- a/src/bundle/burn_validation.rs
+++ b/src/bundle/burn_validation.rs
@@ -69,7 +69,7 @@ mod tests {
     /// Creates an item of bundle burn list for a given asset description and value.
     ///
     /// This function is deterministic and guarantees that each call with the same parameters
-    /// will return the same result. It achieves determinism by using a static `IssuanceKey`.
+    /// will return the same result. It achieves determinism by using a static `IssuanceMasterKey`.
     ///
     /// # Arguments
     ///
@@ -81,9 +81,9 @@ mod tests {
     /// A tuple `(AssetBase, Amount)` representing the burn list item.
     ///
     pub fn get_burn_tuple(asset_desc: &str, value: i64) -> (AssetBase, i64) {
-        use crate::keys::{IssuanceAuthorizingKey, IssuanceKey, IssuanceValidatingKey};
+        use crate::keys::{IssuanceAuthorizingKey, IssuanceMasterKey, IssuanceValidatingKey};
 
-        let imk = IssuanceKey::from_bytes([0u8; 32]).unwrap();
+        let imk = IssuanceMasterKey::from_bytes([0u8; 32]).unwrap();
         let isk: IssuanceAuthorizingKey = (&imk).into();
 
         (

--- a/src/bundle/burn_validation.rs
+++ b/src/bundle/burn_validation.rs
@@ -81,13 +81,12 @@ mod tests {
     /// A tuple `(AssetBase, Amount)` representing the burn list item.
     ///
     pub fn get_burn_tuple(asset_desc: &str, value: i64) -> (AssetBase, i64) {
-        use crate::keys::{IssuanceAuthorizingKey, IssuanceMasterKey, IssuanceValidatingKey};
+        use crate::keys::{IssuanceMasterKey, IssuanceValidatingKey};
 
         let imk = IssuanceMasterKey::from_bytes([0u8; 32]).unwrap();
-        let isk: IssuanceAuthorizingKey = (&imk).into();
 
         (
-            AssetBase::derive(&IssuanceValidatingKey::from(&isk), asset_desc),
+            AssetBase::derive(&IssuanceValidatingKey::from(&imk), asset_desc),
             value,
         )
     }

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -606,7 +606,7 @@ mod tests {
     };
     use crate::issuance::{verify_issue_bundle, IssueAction, Signed, Unauthorized};
     use crate::keys::{
-        FullViewingKey, IssuanceAuthorizingKey, IssuanceKey, IssuanceValidatingKey, Scope,
+        FullViewingKey, IssuanceAuthorizingKey, IssuanceMasterKey, IssuanceValidatingKey, Scope,
         SpendingKey,
     };
     use crate::note::{AssetBase, Nullifier};
@@ -629,7 +629,7 @@ mod tests {
     ) {
         let mut rng = OsRng;
 
-        let imk = IssuanceKey::random(&mut rng);
+        let imk = IssuanceMasterKey::random(&mut rng);
         let isk: IssuanceAuthorizingKey = (&imk).into();
         let ik: IssuanceValidatingKey = (&isk).into();
 
@@ -951,7 +951,7 @@ mod tests {
         )
         .unwrap();
 
-        let wrong_isk: IssuanceAuthorizingKey = (&IssuanceKey::random(&mut OsRng)).into();
+        let wrong_isk: IssuanceAuthorizingKey = (&IssuanceMasterKey::random(&mut OsRng)).into();
 
         let err = bundle
             .prepare([0; 32])
@@ -1183,7 +1183,7 @@ mod tests {
         )
         .unwrap();
 
-        let wrong_isk: IssuanceAuthorizingKey = (&IssuanceKey::random(&mut rng)).into();
+        let wrong_isk: IssuanceAuthorizingKey = (&IssuanceMasterKey::random(&mut rng)).into();
 
         let mut signed = bundle.prepare(sighash).sign(rng, &isk).unwrap();
 
@@ -1278,7 +1278,7 @@ mod tests {
 
         let mut signed = bundle.prepare(sighash).sign(rng, &isk).unwrap();
 
-        let incorrect_imk = IssuanceKey::random(&mut rng);
+        let incorrect_imk = IssuanceMasterKey::random(&mut rng);
         let incorrect_isk: IssuanceAuthorizingKey = (&incorrect_imk).into();
         let incorrect_ik: IssuanceValidatingKey = (&incorrect_isk).into();
 

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -606,8 +606,7 @@ mod tests {
     };
     use crate::issuance::{verify_issue_bundle, IssueAction, Signed, Unauthorized};
     use crate::keys::{
-        FullViewingKey, IssuanceMasterKey, IssuanceValidatingKey, Scope,
-        SpendingKey,
+        FullViewingKey, IssuanceMasterKey, IssuanceValidatingKey, Scope, SpendingKey,
     };
     use crate::note::{AssetBase, Nullifier};
     use crate::value::{NoteValue, ValueSum};

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -629,8 +629,8 @@ mod tests {
     ) {
         let mut rng = OsRng;
 
-        let sk_iss = IssuanceKey::random(&mut rng);
-        let isk: IssuanceAuthorizingKey = (&sk_iss).into();
+        let imk = IssuanceKey::random(&mut rng);
+        let isk: IssuanceAuthorizingKey = (&imk).into();
         let ik: IssuanceValidatingKey = (&isk).into();
 
         let fvk = FullViewingKey::from(&SpendingKey::random(&mut rng));
@@ -1278,8 +1278,8 @@ mod tests {
 
         let mut signed = bundle.prepare(sighash).sign(rng, &isk).unwrap();
 
-        let incorrect_sk_iss = IssuanceKey::random(&mut rng);
-        let incorrect_isk: IssuanceAuthorizingKey = (&incorrect_sk_iss).into();
+        let incorrect_imk = IssuanceKey::random(&mut rng);
+        let incorrect_isk: IssuanceAuthorizingKey = (&incorrect_imk).into();
         let incorrect_ik: IssuanceValidatingKey = (&incorrect_isk).into();
 
         // Add "bad" note

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -12,7 +12,7 @@ use crate::issuance::Error::{
     IssueActionWithoutNoteNotFinalized, IssueBundleIkMismatchAssetBase,
     IssueBundleInvalidSignature, ValueSumOverflow, WrongAssetDescSize,
 };
-use crate::keys::{IssuanceMasterKey, IssuanceValidatingKey};
+use crate::keys::{IssuanceAuthorizingKey, IssuanceValidatingKey};
 use crate::note::asset_base::is_asset_desc_of_valid_size;
 use crate::note::{AssetBase, Nullifier};
 use crate::primitives::redpallas::Signature;
@@ -408,13 +408,13 @@ impl IssueBundle<Unauthorized> {
 
 impl IssueBundle<Prepared> {
     /// Sign the `IssueBundle`.
-    /// The call makes sure that the provided `imk` matches the `ik` and the driven `asset` for each note in the bundle.
+    /// The call makes sure that the provided `isk` matches the `ik` and the driven `asset` for each note in the bundle.
     pub fn sign<R: RngCore + CryptoRng>(
         self,
         mut rng: R,
-        imk: &IssuanceMasterKey,
+        isk: &IssuanceAuthorizingKey,
     ) -> Result<IssueBundle<Signed>, Error> {
-        let expected_ik: IssuanceValidatingKey = (imk).into();
+        let expected_ik: IssuanceValidatingKey = (isk).into();
 
         // Make sure the `expected_ik` matches the `asset` for all notes.
         self.actions.iter().try_for_each(|action| {
@@ -426,7 +426,7 @@ impl IssueBundle<Prepared> {
             ik: self.ik,
             actions: self.actions,
             authorization: Signed {
-                signature: imk.sign(&mut rng, &self.authorization.sighash),
+                signature: isk.sign(&mut rng, &self.authorization.sighash),
             },
         })
     }
@@ -532,7 +532,7 @@ pub fn verify_issue_bundle(
 pub enum Error {
     /// The requested IssueAction not exists in the bundle.
     IssueActionNotFound,
-    /// The provided `imk` and the driven `ik` does not match at least one note type.
+    /// The provided `isk` and the derived `ik` does not match at least one note type.
     IssueBundleIkMismatchAssetBase,
     /// `asset_desc` should be between 1 and 512 bytes.
     WrongAssetDescSize,
@@ -562,7 +562,7 @@ impl fmt::Display for Error {
             IssueBundleIkMismatchAssetBase => {
                 write!(
                     f,
-                    "the provided `imk` and the derived `ik` do not match at least one note type"
+                    "the provided `isk` and the derived `ik` do not match at least one note type"
                 )
             }
             WrongAssetDescSize => {
@@ -606,7 +606,7 @@ mod tests {
     };
     use crate::issuance::{verify_issue_bundle, IssueAction, Signed, Unauthorized};
     use crate::keys::{
-        FullViewingKey, IssuanceMasterKey, IssuanceValidatingKey, Scope, SpendingKey,
+        FullViewingKey, IssuanceAuthorizingKey, IssuanceValidatingKey, Scope, SpendingKey,
     };
     use crate::note::{AssetBase, Nullifier};
     use crate::value::{NoteValue, ValueSum};
@@ -621,15 +621,15 @@ mod tests {
 
     fn setup_params() -> (
         OsRng,
-        IssuanceMasterKey,
+        IssuanceAuthorizingKey,
         IssuanceValidatingKey,
         Address,
         [u8; 32],
     ) {
         let mut rng = OsRng;
 
-        let imk = IssuanceMasterKey::random(&mut rng);
-        let ik: IssuanceValidatingKey = (&imk).into();
+        let isk = IssuanceAuthorizingKey::random(&mut rng);
+        let ik: IssuanceValidatingKey = (&isk).into();
 
         let fvk = FullViewingKey::from(&SpendingKey::random(&mut rng));
         let recipient = fvk.address_at(0u32, Scope::External);
@@ -637,7 +637,7 @@ mod tests {
         let mut sighash = [0u8; 32];
         rng.fill_bytes(&mut sighash);
 
-        (rng, imk, ik, recipient, sighash)
+        (rng, isk, ik, recipient, sighash)
     }
 
     fn setup_verify_supply_test_params(
@@ -686,11 +686,11 @@ mod tests {
         note2_value: u64,
     ) -> (
         OsRng,
-        IssuanceMasterKey,
+        IssuanceAuthorizingKey,
         IssueBundle<Unauthorized>,
         [u8; 32],
     ) {
-        let (mut rng, imk, ik, recipient, sighash) = setup_params();
+        let (mut rng, isk, ik, recipient, sighash) = setup_params();
 
         let note1 = Note::new(
             recipient,
@@ -713,7 +713,7 @@ mod tests {
 
         let bundle = IssueBundle::from_parts(ik, NonEmpty::new(action), Unauthorized);
 
-        (rng, imk, bundle, sighash)
+        (rng, isk, bundle, sighash)
     }
 
     #[test]
@@ -915,7 +915,7 @@ mod tests {
 
     #[test]
     fn issue_bundle_sign() {
-        let (rng, imk, ik, recipient, sighash) = setup_params();
+        let (rng, isk, ik, recipient, sighash) = setup_params();
 
         let (bundle, _) = IssueBundle::new(
             ik.clone(),
@@ -928,14 +928,14 @@ mod tests {
         )
         .unwrap();
 
-        let signed = bundle.prepare(sighash).sign(rng, &imk).unwrap();
+        let signed = bundle.prepare(sighash).sign(rng, &isk).unwrap();
 
         ik.verify(&sighash, &signed.authorization.signature)
             .expect("signature should be valid");
     }
 
     #[test]
-    fn issue_bundle_invalid_imk_for_signature() {
+    fn issue_bundle_invalid_isk_for_signature() {
         let (rng, _, ik, recipient, _) = setup_params();
 
         let (bundle, _) = IssueBundle::new(
@@ -949,11 +949,11 @@ mod tests {
         )
         .unwrap();
 
-        let wrong_imk: IssuanceMasterKey = IssuanceMasterKey::random(&mut OsRng);
+        let wrong_isk: IssuanceAuthorizingKey = IssuanceAuthorizingKey::random(&mut OsRng);
 
         let err = bundle
             .prepare([0; 32])
-            .sign(rng, &wrong_imk)
+            .sign(rng, &wrong_isk)
             .expect_err("should not be able to sign");
 
         assert_eq!(err, IssueBundleIkMismatchAssetBase);
@@ -961,7 +961,7 @@ mod tests {
 
     #[test]
     fn issue_bundle_incorrect_asset_for_signature() {
-        let (mut rng, imk, ik, recipient, _) = setup_params();
+        let (mut rng, isk, ik, recipient, _) = setup_params();
 
         // Create a bundle with "normal" note
         let (mut bundle, _) = IssueBundle::new(
@@ -987,7 +987,7 @@ mod tests {
 
         let err = bundle
             .prepare([0; 32])
-            .sign(rng, &imk)
+            .sign(rng, &isk)
             .expect_err("should not be able to sign");
 
         assert_eq!(err, IssueBundleIkMismatchAssetBase);
@@ -995,7 +995,7 @@ mod tests {
 
     #[test]
     fn issue_bundle_verify() {
-        let (rng, imk, ik, recipient, sighash) = setup_params();
+        let (rng, isk, ik, recipient, sighash) = setup_params();
 
         let (bundle, _) = IssueBundle::new(
             ik,
@@ -1008,7 +1008,7 @@ mod tests {
         )
         .unwrap();
 
-        let signed = bundle.prepare(sighash).sign(rng, &imk).unwrap();
+        let signed = bundle.prepare(sighash).sign(rng, &isk).unwrap();
         let prev_finalized = &mut HashSet::new();
 
         let supply_info = verify_issue_bundle(&signed, sighash, prev_finalized).unwrap();
@@ -1020,7 +1020,7 @@ mod tests {
 
     #[test]
     fn issue_bundle_verify_with_finalize() {
-        let (rng, imk, ik, recipient, sighash) = setup_params();
+        let (rng, isk, ik, recipient, sighash) = setup_params();
 
         let (mut bundle, _) = IssueBundle::new(
             ik.clone(),
@@ -1037,7 +1037,7 @@ mod tests {
             .finalize_action(String::from("Verify with finalize"))
             .unwrap();
 
-        let signed = bundle.prepare(sighash).sign(rng, &imk).unwrap();
+        let signed = bundle.prepare(sighash).sign(rng, &isk).unwrap();
         let prev_finalized = &mut HashSet::new();
 
         let supply_info = verify_issue_bundle(&signed, sighash, prev_finalized).unwrap();
@@ -1050,7 +1050,7 @@ mod tests {
 
     #[test]
     fn issue_bundle_verify_with_supply_info() {
-        let (rng, imk, ik, recipient, sighash) = setup_params();
+        let (rng, isk, ik, recipient, sighash) = setup_params();
 
         let asset1_desc = "Verify with supply info 1";
         let asset2_desc = "Verify with supply info 2";
@@ -1102,7 +1102,7 @@ mod tests {
             )
             .unwrap();
 
-        let signed = bundle.prepare(sighash).sign(rng, &imk).unwrap();
+        let signed = bundle.prepare(sighash).sign(rng, &isk).unwrap();
         let prev_finalized = &mut HashSet::new();
 
         let supply_info = verify_issue_bundle(&signed, sighash, prev_finalized).unwrap();
@@ -1133,7 +1133,7 @@ mod tests {
 
     #[test]
     fn issue_bundle_verify_fail_previously_finalized() {
-        let (rng, imk, ik, recipient, sighash) = setup_params();
+        let (rng, isk, ik, recipient, sighash) = setup_params();
 
         let (bundle, _) = IssueBundle::new(
             ik.clone(),
@@ -1146,7 +1146,7 @@ mod tests {
         )
         .unwrap();
 
-        let signed = bundle.prepare(sighash).sign(rng, &imk).unwrap();
+        let signed = bundle.prepare(sighash).sign(rng, &isk).unwrap();
         let prev_finalized = &mut HashSet::new();
 
         let final_type = AssetBase::derive(&ik, &String::from("already final"));
@@ -1168,7 +1168,7 @@ mod tests {
             }
         }
 
-        let (mut rng, imk, ik, recipient, sighash) = setup_params();
+        let (mut rng, isk, ik, recipient, sighash) = setup_params();
 
         let (bundle, _) = IssueBundle::new(
             ik,
@@ -1181,12 +1181,12 @@ mod tests {
         )
         .unwrap();
 
-        let wrong_imk: IssuanceMasterKey = IssuanceMasterKey::random(&mut rng);
+        let wrong_isk: IssuanceAuthorizingKey = IssuanceAuthorizingKey::random(&mut rng);
 
-        let mut signed = bundle.prepare(sighash).sign(rng, &imk).unwrap();
+        let mut signed = bundle.prepare(sighash).sign(rng, &isk).unwrap();
 
         signed.set_authorization(Signed {
-            signature: wrong_imk.sign(&mut rng, &sighash),
+            signature: wrong_isk.sign(&mut rng, &sighash),
         });
 
         let prev_finalized = &HashSet::new();
@@ -1199,7 +1199,7 @@ mod tests {
 
     #[test]
     fn issue_bundle_verify_fail_wrong_sighash() {
-        let (rng, imk, ik, recipient, random_sighash) = setup_params();
+        let (rng, isk, ik, recipient, random_sighash) = setup_params();
         let (bundle, _) = IssueBundle::new(
             ik,
             String::from("Asset description"),
@@ -1212,7 +1212,7 @@ mod tests {
         .unwrap();
 
         let sighash: [u8; 32] = bundle.commitment().into();
-        let signed = bundle.prepare(sighash).sign(rng, &imk).unwrap();
+        let signed = bundle.prepare(sighash).sign(rng, &isk).unwrap();
         let prev_finalized = &HashSet::new();
 
         assert_eq!(
@@ -1223,7 +1223,7 @@ mod tests {
 
     #[test]
     fn issue_bundle_verify_fail_incorrect_asset_description() {
-        let (mut rng, imk, ik, recipient, sighash) = setup_params();
+        let (mut rng, isk, ik, recipient, sighash) = setup_params();
 
         let (bundle, _) = IssueBundle::new(
             ik,
@@ -1236,7 +1236,7 @@ mod tests {
         )
         .unwrap();
 
-        let mut signed = bundle.prepare(sighash).sign(rng, &imk).unwrap();
+        let mut signed = bundle.prepare(sighash).sign(rng, &isk).unwrap();
 
         // Add "bad" note
         let note = Note::new(
@@ -1261,7 +1261,7 @@ mod tests {
     fn issue_bundle_verify_fail_incorrect_ik() {
         let asset_description = "Asset";
 
-        let (mut rng, imk, ik, recipient, sighash) = setup_params();
+        let (mut rng, isk, ik, recipient, sighash) = setup_params();
 
         let (bundle, _) = IssueBundle::new(
             ik,
@@ -1274,10 +1274,10 @@ mod tests {
         )
         .unwrap();
 
-        let mut signed = bundle.prepare(sighash).sign(rng, &imk).unwrap();
+        let mut signed = bundle.prepare(sighash).sign(rng, &isk).unwrap();
 
-        let incorrect_imk = IssuanceMasterKey::random(&mut rng);
-        let incorrect_ik: IssuanceValidatingKey = (&incorrect_imk).into();
+        let incorrect_isk = IssuanceAuthorizingKey::random(&mut rng);
+        let incorrect_ik: IssuanceValidatingKey = (&incorrect_isk).into();
 
         // Add "bad" note
         let note = Note::new(
@@ -1307,7 +1307,7 @@ mod tests {
             }
         }
 
-        let (rng, imk, ik, recipient, sighash) = setup_params();
+        let (rng, isk, ik, recipient, sighash) = setup_params();
 
         let (bundle, _) = IssueBundle::new(
             ik,
@@ -1320,7 +1320,7 @@ mod tests {
         )
         .unwrap();
 
-        let mut signed = bundle.prepare(sighash).sign(rng, &imk).unwrap();
+        let mut signed = bundle.prepare(sighash).sign(rng, &isk).unwrap();
         let prev_finalized = HashSet::new();
 
         // 1. Try too long description
@@ -1345,23 +1345,23 @@ mod tests {
 
     #[test]
     fn issue_bundle_cannot_be_signed_with_asset_base_identity_point() {
-        let (rng, imk, bundle, sighash) = identity_point_test_params(10, 20);
+        let (rng, isk, bundle, sighash) = identity_point_test_params(10, 20);
 
         assert_eq!(
-            bundle.prepare(sighash).sign(rng, &imk).unwrap_err(),
+            bundle.prepare(sighash).sign(rng, &isk).unwrap_err(),
             AssetBaseCannotBeIdentityPoint
         );
     }
 
     #[test]
     fn issue_bundle_verify_fail_asset_base_identity_point() {
-        let (mut rng, imk, bundle, sighash) = identity_point_test_params(10, 20);
+        let (mut rng, isk, bundle, sighash) = identity_point_test_params(10, 20);
 
         let signed = IssueBundle {
             ik: bundle.ik,
             actions: bundle.actions,
             authorization: Signed {
-                signature: imk.sign(&mut rng, &sighash),
+                signature: isk.sign(&mut rng, &sighash),
             },
         };
 

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -257,12 +257,7 @@ impl IssuanceAuthorizingKey {
     /// Returns `None` if the bytes do not correspond to a valid Orchard issuance key.
     pub fn from_bytes(isk_bytes: [u8; 32]) -> CtOption<Self> {
         let isk = IssuanceAuthorizingKey(isk_bytes);
-        CtOption::new(isk, isk.is_valid())
-    }
-
-    /// Checks whether the Orchard-ZSA issuance key is valid //TODO: What are the criteria?
-    pub fn is_valid(self) -> Choice {
-        1u8.into()
+        CtOption::new(isk, 1u8.into())
     }
 
     /// Returns the raw bytes of the issuance key.

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -223,9 +223,9 @@ type IssuanceAuth = SpendAuth;
 
 /// An issuance key, from which all key material is derived.
 ///
-/// $\mathsf{sk}$ as defined in [Zcash Protocol Spec § 4.2.3: Orchard Key Components][orchardkeycomponents].
+/// $\mathsf{imk}$ as defined in [ZIP 227][issuancekeycomponents].
 ///
-/// [orchardkeycomponents]: https://zips.z.cash/protocol/nu5.pdf#orchardkeycomponents
+/// [issuancekeycomponents]: https://qed-it.github.io/zips/zip-0227#issuance-key-derivation
 #[derive(Debug, Copy, Clone)]
 pub struct IssuanceMasterKey([u8; 32]);
 

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -16,7 +16,6 @@ use rand::{CryptoRng, RngCore};
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 use zcash_note_encryption::EphemeralKeyBytes;
 
-use crate::primitives::redpallas::SigningKey;
 use crate::{
     address::Address,
     primitives::redpallas::{self, SpendAuth, VerificationKey},
@@ -1243,9 +1242,6 @@ mod tests {
             assert_eq!(<[u8; 32]>::from(&ask.0), tv.ask);
 
             let imk = IssuanceMasterKey::from_bytes(tv.sk).unwrap();
-
-            let isk: IssuanceAuthorizingKey = (&imk).into(); // TOREMOVE
-            assert_eq!(<[u8; 32]>::from(&isk.0), tv.isk); // TOREMOVE
 
             let ak: SpendValidatingKey = (&ask).into();
             assert_eq!(<[u8; 32]>::from(ak.0), tv.ak);

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -1116,8 +1116,8 @@ impl SharedSecret {
 #[cfg_attr(docsrs, doc(cfg(feature = "test-dependencies")))]
 pub mod testing {
     use super::{
-        DiversifierIndex, DiversifierKey, EphemeralSecretKey, IssuanceAuthorizingKey, IssuanceMasterKey,
-        IssuanceValidatingKey, SpendingKey,
+        DiversifierIndex, DiversifierKey, EphemeralSecretKey, IssuanceAuthorizingKey,
+        IssuanceMasterKey, IssuanceValidatingKey, SpendingKey,
     };
     use proptest::prelude::*;
     use rand::{rngs::StdRng, SeedableRng};

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -270,7 +270,7 @@ impl IssuanceMasterKey {
         &self.0
     }
 
-    /// Derives the Orchard issuance key for the given seed, coin type, and account.
+    /// Derives the Orchard-ZSA issuance key for the given seed, coin type, and account.
     pub fn from_zip32_seed(
         seed: &[u8],
         coin_type: u32,
@@ -1102,7 +1102,6 @@ pub mod testing {
         IssuanceValidatingKey, SpendingKey,
     };
     use proptest::prelude::*;
-    use rand::{rngs::StdRng, SeedableRng};
 
     prop_compose! {
         /// Generate a uniformly distributed Orchard spending key.

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -16,6 +16,7 @@ use rand::{CryptoRng, RngCore};
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 use zcash_note_encryption::EphemeralKeyBytes;
 
+use crate::primitives::redpallas::SigningKey;
 use crate::{
     address::Address,
     primitives::redpallas::{self, SpendAuth, VerificationKey},
@@ -29,7 +30,6 @@ use crate::{
         ZIP32_ORCHARD_PERSONALIZATION_FOR_ISSUANCE,
     },
 };
-use crate::primitives::redpallas::SigningKey;
 
 const KDF_ORCHARD_PERSONALIZATION: &[u8; 16] = b"Zcash_OrchardKDF";
 const ZIP32_PURPOSE: u32 = 32;
@@ -301,7 +301,6 @@ impl IssuanceMasterKey {
         conditionally_negate(self.derive_inner()).sign(rng, msg)
     }
 }
-
 
 /// A key used to validate issuance authorization signatures.
 ///
@@ -1100,8 +1099,8 @@ impl SharedSecret {
 #[cfg_attr(docsrs, doc(cfg(feature = "test-dependencies")))]
 pub mod testing {
     use super::{
-        DiversifierIndex, DiversifierKey, EphemeralSecretKey,
-        IssuanceMasterKey, IssuanceValidatingKey, SpendingKey,
+        DiversifierIndex, DiversifierKey, EphemeralSecretKey, IssuanceMasterKey,
+        IssuanceValidatingKey, SpendingKey,
     };
     use proptest::prelude::*;
     use rand::{rngs::StdRng, SeedableRng};

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -255,11 +255,11 @@ impl IssuanceKey {
     /// Constructs an Orchard issuance key from uniformly-random bytes.
     ///
     /// Returns `None` if the bytes do not correspond to a valid Orchard issuance key.
-    pub fn from_bytes(sk_iss: [u8; 32]) -> CtOption<Self> {
-        let sk_iss = IssuanceKey(sk_iss);
+    pub fn from_bytes(imk: [u8; 32]) -> CtOption<Self> {
+        let imk = IssuanceKey(imk);
         // If isk = 0 (A scalar value), discard this key.
-        let isk = IssuanceAuthorizingKey::derive_inner(&sk_iss);
-        CtOption::new(sk_iss, !isk.is_zero())
+        let isk = IssuanceAuthorizingKey::derive_inner(&imk);
+        CtOption::new(imk, !isk.is_zero())
     }
 
     /// Returns the raw bytes of the issuance key.
@@ -295,9 +295,9 @@ impl IssuanceKey {
 pub struct IssuanceAuthorizingKey(redpallas::SigningKey<IssuanceAuth>);
 
 impl IssuanceAuthorizingKey {
-    /// Derives isk from sk_iss. Internal use only, does not enforce all constraints.
-    fn derive_inner(sk_iss: &IssuanceKey) -> pallas::Scalar {
-        to_scalar(PrfExpand::ZsaIsk.expand(&sk_iss.0))
+    /// Derives isk from imk. Internal use only, does not enforce all constraints.
+    fn derive_inner(imk: &IssuanceKey) -> pallas::Scalar {
+        to_scalar(PrfExpand::ZsaIsk.expand(&imk.0))
     }
 
     /// Sign the provided message using the `IssuanceAuthorizingKey`.
@@ -311,8 +311,8 @@ impl IssuanceAuthorizingKey {
 }
 
 impl From<&IssuanceKey> for IssuanceAuthorizingKey {
-    fn from(sk_iss: &IssuanceKey) -> Self {
-        let isk = IssuanceAuthorizingKey::derive_inner(sk_iss);
+    fn from(imk: &IssuanceKey) -> Self {
+        let isk = IssuanceAuthorizingKey::derive_inner(imk);
         // IssuanceAuthorizingKey cannot be constructed such that this assertion would fail.
         assert!(!bool::from(isk.is_zero()));
         IssuanceAuthorizingKey(conditionally_negate(isk))
@@ -1267,9 +1267,9 @@ mod tests {
             let ask: SpendAuthorizingKey = (&sk).into();
             assert_eq!(<[u8; 32]>::from(&ask.0), tv.ask);
 
-            let sk_iss = IssuanceKey::from_bytes(tv.sk).unwrap();
+            let imk = IssuanceKey::from_bytes(tv.sk).unwrap();
 
-            let isk: IssuanceAuthorizingKey = (&sk_iss).into();
+            let isk: IssuanceAuthorizingKey = (&imk).into();
             assert_eq!(<[u8; 32]>::from(&isk.0), tv.isk);
 
             let ak: SpendValidatingKey = (&ask).into();

--- a/src/note/asset_base.rs
+++ b/src/note/asset_base.rs
@@ -10,7 +10,7 @@ use subtle::{Choice, ConstantTimeEq, CtOption};
 use crate::constants::fixed_bases::{
     NATIVE_ASSET_BASE_V_BYTES, VALUE_COMMITMENT_PERSONALIZATION, ZSA_ASSET_BASE_PERSONALIZATION,
 };
-use crate::keys::{IssuanceAuthorizingKey, IssuanceKey, IssuanceValidatingKey};
+use crate::keys::{IssuanceAuthorizingKey, IssuanceMasterKey, IssuanceValidatingKey};
 
 /// Note type identifier.
 #[derive(Clone, Copy, Debug, Eq)]
@@ -102,7 +102,7 @@ impl AssetBase {
     ///
     /// This is only used in tests.
     pub(crate) fn random(rng: &mut impl RngCore) -> Self {
-        let imk = IssuanceKey::random(rng);
+        let imk = IssuanceMasterKey::random(rng);
         let isk = IssuanceAuthorizingKey::from(&imk);
         let ik = IssuanceValidatingKey::from(&isk);
         let asset_descr = "zsa_asset";

--- a/src/note/asset_base.rs
+++ b/src/note/asset_base.rs
@@ -135,7 +135,7 @@ pub mod testing {
 
     use proptest::prelude::*;
 
-    use crate::keys::{testing::arb_issuance_master_key, IssuanceMasterKey, IssuanceValidatingKey};
+    use crate::keys::{testing::arb_issuance_master_key, IssuanceValidatingKey};
 
     prop_compose! {
         /// Generate a uniformly distributed note type

--- a/src/note/asset_base.rs
+++ b/src/note/asset_base.rs
@@ -10,7 +10,7 @@ use subtle::{Choice, ConstantTimeEq, CtOption};
 use crate::constants::fixed_bases::{
     NATIVE_ASSET_BASE_V_BYTES, VALUE_COMMITMENT_PERSONALIZATION, ZSA_ASSET_BASE_PERSONALIZATION,
 };
-use crate::keys::{IssuanceMasterKey, IssuanceValidatingKey};
+use crate::keys::{IssuanceAuthorizingKey, IssuanceValidatingKey};
 
 /// Note type identifier.
 #[derive(Clone, Copy, Debug, Eq)]
@@ -102,8 +102,8 @@ impl AssetBase {
     ///
     /// This is only used in tests.
     pub(crate) fn random(rng: &mut impl RngCore) -> Self {
-        let imk = IssuanceMasterKey::random(rng);
-        let ik = IssuanceValidatingKey::from(&imk);
+        let isk = IssuanceAuthorizingKey::random(rng);
+        let ik = IssuanceValidatingKey::from(&isk);
         let asset_descr = "zsa_asset";
         AssetBase::derive(&ik, asset_descr)
     }
@@ -135,19 +135,19 @@ pub mod testing {
 
     use proptest::prelude::*;
 
-    use crate::keys::{testing::arb_issuance_master_key, IssuanceValidatingKey};
+    use crate::keys::{testing::arb_issuance_authorizing_key, IssuanceValidatingKey};
 
     prop_compose! {
         /// Generate a uniformly distributed note type
         pub fn arb_asset_id()(
             is_native in prop::bool::ANY,
-            imk in arb_issuance_master_key(),
+            isk in arb_issuance_authorizing_key(),
             str in "[A-Za-z]{255}",
         ) -> AssetBase {
             if is_native {
                 AssetBase::native()
             } else {
-                AssetBase::derive(&IssuanceValidatingKey::from(&imk), &str)
+                AssetBase::derive(&IssuanceValidatingKey::from(&isk), &str)
             }
         }
     }
@@ -163,20 +163,20 @@ pub mod testing {
     prop_compose! {
         /// Generate an asset ID
         pub fn arb_zsa_asset_id()(
-            imk in arb_issuance_master_key(),
+            isk in arb_issuance_authorizing_key(),
             str in "[A-Za-z]{255}"
         ) -> AssetBase {
-            AssetBase::derive(&IssuanceValidatingKey::from(&imk), &str)
+            AssetBase::derive(&IssuanceValidatingKey::from(&isk), &str)
         }
     }
 
     prop_compose! {
         /// Generate an asset ID using a specific description
         pub fn zsa_asset_id(asset_desc: String)(
-            imk in arb_issuance_master_key(),
+            isk in arb_issuance_authorizing_key(),
         ) -> AssetBase {
             assert!(super::is_asset_desc_of_valid_size(&asset_desc));
-            AssetBase::derive(&IssuanceValidatingKey::from(&imk), &asset_desc)
+            AssetBase::derive(&IssuanceValidatingKey::from(&isk), &asset_desc)
         }
     }
 

--- a/src/note/asset_base.rs
+++ b/src/note/asset_base.rs
@@ -102,8 +102,8 @@ impl AssetBase {
     ///
     /// This is only used in tests.
     pub(crate) fn random(rng: &mut impl RngCore) -> Self {
-        let sk_iss = IssuanceKey::random(rng);
-        let isk = IssuanceAuthorizingKey::from(&sk_iss);
+        let imk = IssuanceKey::random(rng);
+        let isk = IssuanceAuthorizingKey::from(&imk);
         let ik = IssuanceValidatingKey::from(&isk);
         let asset_descr = "zsa_asset";
         AssetBase::derive(&ik, asset_descr)
@@ -165,10 +165,10 @@ pub mod testing {
     prop_compose! {
         /// Generate an asset ID
         pub fn arb_zsa_asset_id()(
-            sk_iss in arb_issuance_key(),
+            imk in arb_issuance_key(),
             str in "[A-Za-z]{255}"
         ) -> AssetBase {
-            let isk = IssuanceAuthorizingKey::from(&sk_iss);
+            let isk = IssuanceAuthorizingKey::from(&imk);
             AssetBase::derive(&IssuanceValidatingKey::from(&isk), &str)
         }
     }
@@ -176,10 +176,10 @@ pub mod testing {
     prop_compose! {
         /// Generate an asset ID using a specific description
         pub fn zsa_asset_id(asset_desc: String)(
-            sk_iss in arb_issuance_key(),
+            imk in arb_issuance_key(),
         ) -> AssetBase {
             assert!(super::is_asset_desc_of_valid_size(&asset_desc));
-            let isk = IssuanceAuthorizingKey::from(&sk_iss);
+            let isk = IssuanceAuthorizingKey::from(&imk);
             AssetBase::derive(&IssuanceValidatingKey::from(&isk), &asset_desc)
         }
     }

--- a/src/note/asset_base.rs
+++ b/src/note/asset_base.rs
@@ -10,7 +10,7 @@ use subtle::{Choice, ConstantTimeEq, CtOption};
 use crate::constants::fixed_bases::{
     NATIVE_ASSET_BASE_V_BYTES, VALUE_COMMITMENT_PERSONALIZATION, ZSA_ASSET_BASE_PERSONALIZATION,
 };
-use crate::keys::{IssuanceAuthorizingKey, IssuanceMasterKey, IssuanceValidatingKey};
+use crate::keys::{IssuanceMasterKey, IssuanceValidatingKey};
 
 /// Note type identifier.
 #[derive(Clone, Copy, Debug, Eq)]
@@ -103,8 +103,7 @@ impl AssetBase {
     /// This is only used in tests.
     pub(crate) fn random(rng: &mut impl RngCore) -> Self {
         let imk = IssuanceMasterKey::random(rng);
-        let isk = IssuanceAuthorizingKey::from(&imk);
-        let ik = IssuanceValidatingKey::from(&isk);
+        let ik = IssuanceValidatingKey::from(&imk);
         let asset_descr = "zsa_asset";
         AssetBase::derive(&ik, asset_descr)
     }
@@ -136,20 +135,19 @@ pub mod testing {
 
     use proptest::prelude::*;
 
-    use crate::keys::{testing::arb_issuance_master_key, IssuanceAuthorizingKey, IssuanceValidatingKey};
+    use crate::keys::{testing::arb_issuance_master_key, IssuanceMasterKey, IssuanceValidatingKey};
 
     prop_compose! {
         /// Generate a uniformly distributed note type
         pub fn arb_asset_id()(
             is_native in prop::bool::ANY,
-            sk in arb_issuance_master_key(),
+            imk in arb_issuance_master_key(),
             str in "[A-Za-z]{255}",
         ) -> AssetBase {
             if is_native {
                 AssetBase::native()
             } else {
-                let isk = IssuanceAuthorizingKey::from(&sk);
-                AssetBase::derive(&IssuanceValidatingKey::from(&isk), &str)
+                AssetBase::derive(&IssuanceValidatingKey::from(&imk), &str)
             }
         }
     }
@@ -168,8 +166,7 @@ pub mod testing {
             imk in arb_issuance_master_key(),
             str in "[A-Za-z]{255}"
         ) -> AssetBase {
-            let isk = IssuanceAuthorizingKey::from(&imk);
-            AssetBase::derive(&IssuanceValidatingKey::from(&isk), &str)
+            AssetBase::derive(&IssuanceValidatingKey::from(&imk), &str)
         }
     }
 
@@ -179,8 +176,7 @@ pub mod testing {
             imk in arb_issuance_master_key(),
         ) -> AssetBase {
             assert!(super::is_asset_desc_of_valid_size(&asset_desc));
-            let isk = IssuanceAuthorizingKey::from(&imk);
-            AssetBase::derive(&IssuanceValidatingKey::from(&isk), &asset_desc)
+            AssetBase::derive(&IssuanceValidatingKey::from(&imk), &asset_desc)
         }
     }
 

--- a/src/note/asset_base.rs
+++ b/src/note/asset_base.rs
@@ -136,13 +136,13 @@ pub mod testing {
 
     use proptest::prelude::*;
 
-    use crate::keys::{testing::arb_issuance_key, IssuanceAuthorizingKey, IssuanceValidatingKey};
+    use crate::keys::{testing::arb_issuance_master_key, IssuanceAuthorizingKey, IssuanceValidatingKey};
 
     prop_compose! {
         /// Generate a uniformly distributed note type
         pub fn arb_asset_id()(
             is_native in prop::bool::ANY,
-            sk in arb_issuance_key(),
+            sk in arb_issuance_master_key(),
             str in "[A-Za-z]{255}",
         ) -> AssetBase {
             if is_native {
@@ -165,7 +165,7 @@ pub mod testing {
     prop_compose! {
         /// Generate an asset ID
         pub fn arb_zsa_asset_id()(
-            imk in arb_issuance_key(),
+            imk in arb_issuance_master_key(),
             str in "[A-Za-z]{255}"
         ) -> AssetBase {
             let isk = IssuanceAuthorizingKey::from(&imk);
@@ -176,7 +176,7 @@ pub mod testing {
     prop_compose! {
         /// Generate an asset ID using a specific description
         pub fn zsa_asset_id(asset_desc: String)(
-            imk in arb_issuance_key(),
+            imk in arb_issuance_master_key(),
         ) -> AssetBase {
             assert!(super::is_asset_desc_of_valid_size(&asset_desc));
             let isk = IssuanceAuthorizingKey::from(&imk);

--- a/src/supply_info.rs
+++ b/src/supply_info.rs
@@ -80,11 +80,11 @@ mod tests {
     use super::*;
 
     fn create_test_asset(asset_desc: &str) -> AssetBase {
-        use crate::keys::{IssuanceMasterKey, IssuanceValidatingKey};
+        use crate::keys::{IssuanceAuthorizingKey, IssuanceValidatingKey};
 
-        let imk = IssuanceMasterKey::from_bytes([0u8; 32]).unwrap();
+        let isk = IssuanceAuthorizingKey::from_bytes([0u8; 32]).unwrap();
 
-        AssetBase::derive(&IssuanceValidatingKey::from(&imk), asset_desc)
+        AssetBase::derive(&IssuanceValidatingKey::from(&isk), asset_desc)
     }
 
     fn sum<'a, T: IntoIterator<Item = &'a AssetSupply>>(supplies: T) -> Option<ValueSum> {

--- a/src/supply_info.rs
+++ b/src/supply_info.rs
@@ -82,8 +82,8 @@ mod tests {
     fn create_test_asset(asset_desc: &str) -> AssetBase {
         use crate::keys::{IssuanceAuthorizingKey, IssuanceKey, IssuanceValidatingKey};
 
-        let sk_iss = IssuanceKey::from_bytes([0u8; 32]).unwrap();
-        let isk: IssuanceAuthorizingKey = (&sk_iss).into();
+        let imk = IssuanceKey::from_bytes([0u8; 32]).unwrap();
+        let isk: IssuanceAuthorizingKey = (&imk).into();
 
         AssetBase::derive(&IssuanceValidatingKey::from(&isk), asset_desc)
     }

--- a/src/supply_info.rs
+++ b/src/supply_info.rs
@@ -80,12 +80,11 @@ mod tests {
     use super::*;
 
     fn create_test_asset(asset_desc: &str) -> AssetBase {
-        use crate::keys::{IssuanceAuthorizingKey, IssuanceMasterKey, IssuanceValidatingKey};
+        use crate::keys::{IssuanceMasterKey, IssuanceValidatingKey};
 
         let imk = IssuanceMasterKey::from_bytes([0u8; 32]).unwrap();
-        let isk: IssuanceAuthorizingKey = (&imk).into();
 
-        AssetBase::derive(&IssuanceValidatingKey::from(&isk), asset_desc)
+        AssetBase::derive(&IssuanceValidatingKey::from(&imk), asset_desc)
     }
 
     fn sum<'a, T: IntoIterator<Item = &'a AssetSupply>>(supplies: T) -> Option<ValueSum> {

--- a/src/supply_info.rs
+++ b/src/supply_info.rs
@@ -80,9 +80,9 @@ mod tests {
     use super::*;
 
     fn create_test_asset(asset_desc: &str) -> AssetBase {
-        use crate::keys::{IssuanceAuthorizingKey, IssuanceKey, IssuanceValidatingKey};
+        use crate::keys::{IssuanceAuthorizingKey, IssuanceMasterKey, IssuanceValidatingKey};
 
-        let imk = IssuanceKey::from_bytes([0u8; 32]).unwrap();
+        let imk = IssuanceMasterKey::from_bytes([0u8; 32]).unwrap();
         let isk: IssuanceAuthorizingKey = (&imk).into();
 
         AssetBase::derive(&IssuanceValidatingKey::from(&isk), asset_desc)

--- a/tests/zsa.rs
+++ b/tests/zsa.rs
@@ -61,8 +61,8 @@ fn prepare_keys() -> Keychain {
     let fvk = FullViewingKey::from(&sk);
     let recipient = fvk.address_at(0u32, Scope::External);
 
-    let sk_iss = IssuanceKey::from_bytes([0; 32]).unwrap();
-    let isk = IssuanceAuthorizingKey::from(&sk_iss);
+    let imk = IssuanceKey::from_bytes([0; 32]).unwrap();
+    let isk = IssuanceAuthorizingKey::from(&imk);
     let ik = IssuanceValidatingKey::from(&isk);
     Keychain {
         pk,

--- a/tests/zsa.rs
+++ b/tests/zsa.rs
@@ -13,10 +13,7 @@ use orchard::{
     builder::Builder,
     bundle::Flags,
     circuit::{ProvingKey, VerifyingKey},
-    keys::{
-        FullViewingKey, PreparedIncomingViewingKey, Scope, SpendAuthorizingKey,
-        SpendingKey,
-    },
+    keys::{FullViewingKey, PreparedIncomingViewingKey, Scope, SpendAuthorizingKey, SpendingKey},
     value::NoteValue,
     Address, Anchor, Bundle, Note,
 };

--- a/tests/zsa.rs
+++ b/tests/zsa.rs
@@ -14,7 +14,7 @@ use orchard::{
     bundle::Flags,
     circuit::{ProvingKey, VerifyingKey},
     keys::{
-        FullViewingKey, IssuanceKey, PreparedIncomingViewingKey, Scope, SpendAuthorizingKey,
+        FullViewingKey, IssuanceMasterKey, PreparedIncomingViewingKey, Scope, SpendAuthorizingKey,
         SpendingKey,
     },
     value::NoteValue,
@@ -61,7 +61,7 @@ fn prepare_keys() -> Keychain {
     let fvk = FullViewingKey::from(&sk);
     let recipient = fvk.address_at(0u32, Scope::External);
 
-    let imk = IssuanceKey::from_bytes([0; 32]).unwrap();
+    let imk = IssuanceMasterKey::from_bytes([0; 32]).unwrap();
     let isk = IssuanceAuthorizingKey::from(&imk);
     let ik = IssuanceValidatingKey::from(&isk);
     Keychain {


### PR DESCRIPTION
This PR performs a consistent renaming of the issuance master key to make it consistent with the ZIP. 
It also removes the `IssuanceAuthorizingKey` struct as part of using a two key structure for issuance, as specified in ZIP 227.