### PR TITLE
Map authorization  for IssueAuth

### DIFF
--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -257,7 +257,7 @@ impl<T: IssueAuth> IssueBundle<T> {
     }
 
     /// Transitions this bundle from one authorization state to another.
-    pub fn map_authorization<R, T2: IssueAuth>(
+    pub fn map_authorization<T2: IssueAuth>(
         self,
         map_auth: impl FnOnce(T) -> T2,
     ) -> IssueBundle<T2> {

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -259,14 +259,13 @@ impl<T: IssueAuth> IssueBundle<T> {
     /// Transitions this bundle from one authorization state to another.
     pub fn map_authorization<R, T2: IssueAuth>(
         self,
-        context: &mut R,
-        map_auth: impl FnOnce(&mut R, T) -> T2,
+        map_auth: impl FnOnce(T) -> T2,
     ) -> IssueBundle<T2> {
         let authorization = self.authorization;
         IssueBundle {
             ik: self.ik,
             actions: self.actions,
-            authorization: map_auth(context, authorization),
+            authorization: map_auth(authorization),
         }
     }
 }

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -255,6 +255,20 @@ impl<T: IssueAuth> IssueBundle<T> {
             authorization,
         }
     }
+
+    /// Transitions this bundle from one authorization state to another.
+    pub fn map_authorization<R, T2: IssueAuth>(
+        self,
+        context: &mut R,
+        map_auth: impl FnOnce(&mut R, T) -> T2,
+    ) -> IssueBundle<T2> {
+        let authorization = self.authorization;
+        IssueBundle {
+            ik: self.ik,
+            actions: self.actions,
+            authorization: map_auth(context, authorization),
+        }
+    }
 }
 
 impl IssueBundle<Unauthorized> {


### PR DESCRIPTION
Added a new mehod map_authorization for IssueBundle to support workflow in Librustzcash where we trasform a Transaction from one authorization state (e,g, Unauthorized) to another (e.g. Aurhotized/Signed) by transfroming all underlying bundles