### PR TITLE
Update ShieldedOutput implementation to return reference from enc_ciphertext

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2552,7 +2552,7 @@ dependencies = [
 [[package]]
 name = "zcash_note_encryption"
 version = "0.4.0"
-source = "git+https://github.com/QED-it/zcash_note_encryption?branch=return-ref-from-enc-ciphertext#3a54c7281bacf59fe8dcffc6d9b82db60ae465f6"
+source = "git+https://github.com/QED-it/zcash_note_encryption?branch=zsa1#76745f00551d4442dee11ad64a8400b75132d18f"
 dependencies = [
  "chacha20",
  "chacha20poly1305",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2552,7 +2552,7 @@ dependencies = [
 [[package]]
 name = "zcash_note_encryption"
 version = "0.4.0"
-source = "git+https://github.com/QED-it/zcash_note_encryption?branch=zsa1#58384553aab76b2ee6d6eb328cf2187fa824ec9a"
+source = "git+https://github.com/QED-it/zcash_note_encryption?branch=return-ref-from-enc-ciphertext#3a54c7281bacf59fe8dcffc6d9b82db60ae465f6"
 dependencies = [
  "chacha20",
  "chacha20poly1305",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ reddsa = "0.5"
 nonempty = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 subtle = "2.3"
-zcash_note_encryption_zsa = { package = "zcash_note_encryption", version = "0.4", git = "https://github.com/QED-it/zcash_note_encryption", branch = "return-ref-from-enc-ciphertext" }
+zcash_note_encryption_zsa = { package = "zcash_note_encryption", version = "0.4", git = "https://github.com/QED-it/zcash_note_encryption", branch = "zsa1" }
 incrementalmerkletree = "0.5"
 zcash_spec = "0.1"
 zip32 = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,7 +60,7 @@ bridgetree = "0.4"
 criterion = "0.4" # 0.5 depends on clap 4 which has MSRV 1.70
 halo2_gadgets = { git = "https://github.com/QED-it/halo2", rev = "7f5c0babd61f8ca46c9165a1adfac298d3fd3a11", features = ["test-dependencies"] }
 proptest = "1.0.0"
-zcash_note_encryption_zsa = { package = "zcash_note_encryption", version = "0.4", git = "https://github.com/QED-it/zcash_note_encryption", branch = "return-ref-from-enc-ciphertext", features = ["pre-zip-212"] }
+zcash_note_encryption_zsa = { package = "zcash_note_encryption", version = "0.4", git = "https://github.com/QED-it/zcash_note_encryption", branch = "zsa1", features = ["pre-zip-212"] }
 incrementalmerkletree = { version = "0.5", features = ["test-dependencies"] }
 ahash = "=0.8.6" #Pinned: 0.8.7 depends on Rust 1.72
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ reddsa = "0.5"
 nonempty = "0.7"
 serde = { version = "1.0", features = ["derive"] }
 subtle = "2.3"
-zcash_note_encryption_zsa = { package = "zcash_note_encryption", version = "0.4", git = "https://github.com/QED-it/zcash_note_encryption", branch = "zsa1" }
+zcash_note_encryption_zsa = { package = "zcash_note_encryption", version = "0.4", git = "https://github.com/QED-it/zcash_note_encryption", branch = "return-ref-from-enc-ciphertext" }
 incrementalmerkletree = "0.5"
 zcash_spec = "0.1"
 zip32 = "0.1"
@@ -60,7 +60,7 @@ bridgetree = "0.4"
 criterion = "0.4" # 0.5 depends on clap 4 which has MSRV 1.70
 halo2_gadgets = { git = "https://github.com/QED-it/halo2", rev = "7f5c0babd61f8ca46c9165a1adfac298d3fd3a11", features = ["test-dependencies"] }
 proptest = "1.0.0"
-zcash_note_encryption_zsa = { package = "zcash_note_encryption", version = "0.4", git = "https://github.com/QED-it/zcash_note_encryption", branch = "zsa1", features = ["pre-zip-212"] }
+zcash_note_encryption_zsa = { package = "zcash_note_encryption", version = "0.4", git = "https://github.com/QED-it/zcash_note_encryption", branch = "return-ref-from-enc-ciphertext", features = ["pre-zip-212"] }
 incrementalmerkletree = { version = "0.5", features = ["test-dependencies"] }
 ahash = "=0.8.6" #Pinned: 0.8.7 depends on Rust 1.72
 

--- a/src/bundle/commitments.rs
+++ b/src/bundle/commitments.rs
@@ -2,13 +2,11 @@
 
 use blake2b_simd::{Hash as Blake2bHash, Params, State};
 
-use zcash_note_encryption_zsa::MEMO_SIZE;
-
 use crate::{
     bundle::{Authorization, Authorized, Bundle},
     issuance::{IssueAuth, IssueBundle, Signed},
     note::AssetBase,
-    note_encryption::OrchardDomainCommon,
+    note_encryption::{OrchardDomainCommon, MEMO_SIZE},
     orchard_flavor::{OrchardVanilla, OrchardZSA},
     value::NoteValue,
 };

--- a/src/note_encryption.rs
+++ b/src/note_encryption.rs
@@ -11,6 +11,8 @@ mod orchard_domain;
 mod orchard_domain_vanilla;
 mod orchard_domain_zsa;
 
+pub(crate) use domain::MEMO_SIZE;
+
 pub use {
     compact_action::CompactAction,
     orchard_domain::{OrchardDomain, OrchardDomainCommon},

--- a/src/note_encryption/compact_action.rs
+++ b/src/note_encryption/compact_action.rs
@@ -121,10 +121,11 @@ pub mod testing {
         address::Address,
         keys::OutgoingViewingKey,
         note::{AssetBase, ExtractedNoteCommitment, Note, Nullifier, RandomSeed, Rho},
+        note_encryption::MEMO_SIZE,
         value::NoteValue,
     };
 
-    use super::{CompactAction, OrchardDomain, OrchardDomainCommon, MEMO_SIZE};
+    use super::{CompactAction, OrchardDomain, OrchardDomainCommon};
 
     /// Creates a fake `CompactAction` paying the given recipient the specified value.
     ///

--- a/src/note_encryption/compact_action.rs
+++ b/src/note_encryption/compact_action.rs
@@ -115,7 +115,7 @@ impl<D: OrchardDomainCommon> CompactAction<D> {
 pub mod testing {
     use rand::RngCore;
 
-    use zcash_note_encryption_zsa::{note_bytes::NoteBytes, Domain, NoteEncryption, MEMO_SIZE};
+    use zcash_note_encryption_zsa::{note_bytes::NoteBytes, Domain, NoteEncryption};
 
     use crate::{
         address::Address,
@@ -124,7 +124,7 @@ pub mod testing {
         value::NoteValue,
     };
 
-    use super::{CompactAction, OrchardDomain, OrchardDomainCommon};
+    use super::{CompactAction, OrchardDomain, OrchardDomainCommon, MEMO_SIZE};
 
     /// Creates a fake `CompactAction` paying the given recipient the specified value.
     ///

--- a/src/note_encryption/compact_action.rs
+++ b/src/note_encryption/compact_action.rs
@@ -20,8 +20,8 @@ impl<A, D: OrchardDomainCommon> ShieldedOutput<OrchardDomain<D>> for Action<A, D
         self.cmx().to_bytes()
     }
 
-    fn enc_ciphertext(&self) -> Option<D::NoteCiphertextBytes> {
-        Some(self.encrypted_note().enc_ciphertext)
+    fn enc_ciphertext(&self) -> Option<&D::NoteCiphertextBytes> {
+        Some(&self.encrypted_note().enc_ciphertext)
     }
 
     fn enc_ciphertext_compact(&self) -> D::CompactNoteCiphertextBytes {
@@ -69,7 +69,7 @@ impl<D: OrchardDomainCommon> ShieldedOutput<OrchardDomain<D>> for CompactAction<
         self.cmx.to_bytes()
     }
 
-    fn enc_ciphertext(&self) -> Option<D::NoteCiphertextBytes> {
+    fn enc_ciphertext(&self) -> Option<&D::NoteCiphertextBytes> {
         None
     }
 

--- a/src/note_encryption/domain.rs
+++ b/src/note_encryption/domain.rs
@@ -8,7 +8,7 @@ use blake2b_simd::Params;
 
 use zcash_note_encryption_zsa::{
     note_bytes::NoteBytes, BatchDomain, Domain, EphemeralKeyBytes, OutPlaintextBytes,
-    OutgoingCipherKey, MEMO_SIZE, OUT_PLAINTEXT_SIZE,
+    OutgoingCipherKey, OUT_PLAINTEXT_SIZE,
 };
 
 use crate::{
@@ -50,6 +50,9 @@ pub(super) const NOTE_VERSION_BYTE_V2: u8 = 0x02;
 
 /// The version byte for ZSA.
 pub(super) const NOTE_VERSION_BYTE_V3: u8 = 0x03;
+
+/// The size of the memo.
+pub(crate) const MEMO_SIZE: usize = 512;
 
 pub(super) type Memo = [u8; MEMO_SIZE];
 

--- a/src/note_encryption/orchard_domain.rs
+++ b/src/note_encryption/orchard_domain.rs
@@ -3,7 +3,7 @@
 
 use core::fmt;
 
-use zcash_note_encryption_zsa::{note_bytes::NoteBytes, AEAD_TAG_SIZE, MEMO_SIZE};
+use zcash_note_encryption_zsa::{note_bytes::NoteBytes, AEAD_TAG_SIZE};
 
 use crate::{
     action::Action,
@@ -11,7 +11,10 @@ use crate::{
     Note,
 };
 
-use super::{compact_action::CompactAction, domain::Memo};
+use super::{
+    compact_action::CompactAction,
+    domain::{Memo, MEMO_SIZE},
+};
 
 /// Represents the Orchard protocol domain specifics required for note encryption and decryption.
 pub trait OrchardDomainCommon: fmt::Debug + Clone {


### PR DESCRIPTION
This PR updates the `ShieldedOutput` implementation for the `Action`/`CompactAction` struct to align with the recent changes in the `zcash_note_encryption` crate. Specifically, the `enc_ciphertext` method now returns a reference instead of a copy.

This change was discussed and suggested in PR zcash/zcash_note_encryption#2 review.

