### PR TITLE
better memory management

### DIFF
--- a/src/bundle/burn_validation.rs
+++ b/src/bundle/burn_validation.rs
@@ -80,7 +80,7 @@ mod tests {
     ///
     /// A tuple `(AssetBase, Amount)` representing the burn list item.
     ///
-    pub fn get_burn_tuple(asset_desc: &Vec<u8>, value: i64) -> (AssetBase, i64) {
+    pub fn get_burn_tuple(asset_desc: &[u8], value: i64) -> (AssetBase, i64) {
         use crate::keys::{IssuanceAuthorizingKey, IssuanceValidatingKey};
 
         let isk = IssuanceAuthorizingKey::from_bytes([1u8; 32]).unwrap();
@@ -94,9 +94,9 @@ mod tests {
     #[test]
     fn validate_bundle_burn_success() {
         let bundle_burn = vec![
-            get_burn_tuple(&b"Asset 1".to_vec(), 10),
-            get_burn_tuple(&b"Asset 2".to_vec(), 20),
-            get_burn_tuple(&b"Asset 3".to_vec(), 10),
+            get_burn_tuple(b"Asset 1", 10),
+            get_burn_tuple(b"Asset 2", 20),
+            get_burn_tuple(b"Asset 3", 10),
         ];
 
         let result = validate_bundle_burn(&bundle_burn);
@@ -107,9 +107,9 @@ mod tests {
     #[test]
     fn validate_bundle_burn_duplicate_asset() {
         let bundle_burn = vec![
-            get_burn_tuple(&b"Asset 1".to_vec(), 10),
-            get_burn_tuple(&b"Asset 1".to_vec(), 20),
-            get_burn_tuple(&b"Asset 3".to_vec(), 10),
+            get_burn_tuple(b"Asset 1", 10),
+            get_burn_tuple(b"Asset 1", 20),
+            get_burn_tuple(b"Asset 3", 10),
         ];
 
         let result = validate_bundle_burn(&bundle_burn);
@@ -120,9 +120,9 @@ mod tests {
     #[test]
     fn validate_bundle_burn_native_asset() {
         let bundle_burn = vec![
-            get_burn_tuple(&b"Asset 1".to_vec(), 10),
+            get_burn_tuple(b"Asset 1", 10),
             (AssetBase::native(), 20),
-            get_burn_tuple(&b"Asset 3".to_vec(), 10),
+            get_burn_tuple(b"Asset 3", 10),
         ];
 
         let result = validate_bundle_burn(&bundle_burn);
@@ -133,9 +133,9 @@ mod tests {
     #[test]
     fn validate_bundle_burn_zero_value() {
         let bundle_burn = vec![
-            get_burn_tuple(&b"Asset 1".to_vec(), 10),
-            get_burn_tuple(&b"Asset 2".to_vec(), 0),
-            get_burn_tuple(&b"Asset 3".to_vec(), 10),
+            get_burn_tuple(b"Asset 1", 10),
+            get_burn_tuple(b"Asset 2", 0),
+            get_burn_tuple(b"Asset 3", 10),
         ];
 
         let result = validate_bundle_burn(&bundle_burn);

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -224,7 +224,7 @@ impl<T: IssueAuth> IssueBundle<T> {
     pub fn get_actions_by_desc(&self, asset_desc: &[u8]) -> Vec<&IssueAction> {
         self.actions
             .iter()
-            .filter(|a| a.asset_desc == asset_desc)
+            .filter(|a| a.asset_desc.eq(asset_desc))
             .collect()
     }
 

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -647,7 +647,11 @@ mod tests {
         (rng, isk, ik, recipient, sighash)
     }
 
-    fn setup_verify_supply_test_params(
+    /// Sets up test parameters for supply tests.
+    ///
+    /// This function generates two notes with the specified values and asset descriptions,
+    /// and returns the issuance validating key, the asset base, and the issue action.
+    fn supply_test_params(
         note1_value: u64,
         note2_value: u64,
         note1_asset_desc: &[u8],
@@ -682,12 +686,17 @@ mod tests {
         )
     }
 
-    // This function computes the identity point on the Pallas curve and returns an Asset Base with that value.
+    /// This function computes the identity point on the Pallas curve and returns an Asset Base with that value.
     fn identity_point() -> AssetBase {
         let identity_point = (Point::generator() * -Scalar::one()) + Point::generator();
         AssetBase::from_bytes(&identity_point.to_bytes()).unwrap()
     }
 
+    /// Sets up test parameters for identity point tests.
+    ///
+    /// This function generates two notes with the identity point as their asset base,
+    /// and returns the issuance authorizing key, an unauthorized issue bundle containing
+    /// the notes, and a sighash
     fn identity_point_test_params(
         note1_value: u64,
         note2_value: u64,
@@ -720,8 +729,7 @@ mod tests {
 
     #[test]
     fn verify_supply_valid() {
-        let (ik, test_asset, action) =
-            setup_verify_supply_test_params(10, 20, b"Asset 1", None, false);
+        let (ik, test_asset, action) = supply_test_params(10, 20, b"Asset 1", None, false);
 
         let result = action.verify_supply(&ik);
 
@@ -746,8 +754,7 @@ mod tests {
 
     #[test]
     fn verify_supply_finalized() {
-        let (ik, test_asset, action) =
-            setup_verify_supply_test_params(10, 20, b"Asset 1", None, true);
+        let (ik, test_asset, action) = supply_test_params(10, 20, b"Asset 1", None, true);
 
         let result = action.verify_supply(&ik);
 
@@ -762,8 +769,7 @@ mod tests {
 
     #[test]
     fn verify_supply_incorrect_asset_base() {
-        let (ik, _, action) =
-            setup_verify_supply_test_params(10, 20, b"Asset 1", Some(b"Asset 2"), false);
+        let (ik, _, action) = supply_test_params(10, 20, b"Asset 1", Some(b"Asset 2"), false);
 
         assert_eq!(
             action.verify_supply(&ik),
@@ -773,7 +779,7 @@ mod tests {
 
     #[test]
     fn verify_supply_ik_mismatch_asset_base() {
-        let (_, _, action) = setup_verify_supply_test_params(10, 20, b"Asset 1", None, false);
+        let (_, _, action) = supply_test_params(10, 20, b"Asset 1", None, false);
         let (_, _, ik, _, _) = setup_params();
 
         assert_eq!(

--- a/src/supply_info.rs
+++ b/src/supply_info.rs
@@ -79,7 +79,7 @@ impl Default for SupplyInfo {
 mod tests {
     use super::*;
 
-    fn create_test_asset(asset_desc: &Vec<u8>) -> AssetBase {
+    fn create_test_asset(asset_desc: &[u8]) -> AssetBase {
         use crate::keys::{IssuanceAuthorizingKey, IssuanceValidatingKey};
 
         let isk = IssuanceAuthorizingKey::from_bytes([1u8; 32]).unwrap();
@@ -98,8 +98,8 @@ mod tests {
     fn test_add_supply_valid() {
         let mut supply_info = SupplyInfo::new();
 
-        let asset1 = create_test_asset(&b"Asset 1".to_vec());
-        let asset2 = create_test_asset(&b"Asset 2".to_vec());
+        let asset1 = create_test_asset(b"Asset 1");
+        let asset2 = create_test_asset(b"Asset 2");
 
         let supply1 = AssetSupply::new(ValueSum::from_raw(20), false);
         let supply2 = AssetSupply::new(ValueSum::from_raw(30), true);
@@ -167,9 +167,9 @@ mod tests {
     fn test_update_finalization_set() {
         let mut supply_info = SupplyInfo::new();
 
-        let asset1 = create_test_asset(&b"Asset 1".to_vec());
-        let asset2 = create_test_asset(&b"Asset 2".to_vec());
-        let asset3 = create_test_asset(&b"Asset 3".to_vec());
+        let asset1 = create_test_asset(b"Asset 1");
+        let asset2 = create_test_asset(b"Asset 2");
+        let asset3 = create_test_asset(b"Asset 3");
 
         let supply1 = AssetSupply::new(ValueSum::from_raw(10), false);
         let supply2 = AssetSupply::new(ValueSum::from_raw(20), true);

--- a/tests/zsa.rs
+++ b/tests/zsa.rs
@@ -136,12 +136,12 @@ pub fn build_merkle_path_with_two_leaves(
     (merkle_path1, merkle_path2, anchor)
 }
 
-fn issue_zsa_notes(asset_descr: &Vec<u8>, keys: &Keychain) -> (Note, Note) {
+fn issue_zsa_notes(asset_descr: &[u8], keys: &Keychain) -> (Note, Note) {
     let mut rng = OsRng;
     // Create a issuance bundle
     let unauthorized_asset = IssueBundle::new(
         keys.ik().clone(),
-        asset_descr.clone(),
+        asset_descr.to_owned(),
         Some(IssueInfo {
             recipient: keys.recipient,
             value: NoteValue::from_raw(40),
@@ -166,8 +166,8 @@ fn issue_zsa_notes(asset_descr: &Vec<u8>, keys: &Keychain) -> (Note, Note) {
 
     // Take notes from first action
     let notes = issue_bundle.get_all_notes();
-    let note1 = notes.get(0).unwrap();
-    let note2 = notes.get(1).unwrap();
+    let note1 = notes[0];
+    let note2 = notes[1];
 
     assert!(verify_issue_bundle(
         &issue_bundle,
@@ -446,7 +446,7 @@ fn zsa_issue_and_transfer() {
     .unwrap();
 
     // 7. Spend ZSA notes of different asset types
-    let (zsa_note_t7, _) = issue_zsa_notes(&b"zsa_asset2".to_vec(), &keys);
+    let (zsa_note_t7, _) = issue_zsa_notes(b"zsa_asset2", &keys);
     let (merkle_path_t7_1, merkle_path_t7_2, anchor_t7) =
         build_merkle_path_with_two_leaves(&zsa_note_t7, &zsa_note_2);
     let zsa_spend_t7_1: TestSpendInfo = TestSpendInfo {


### PR DESCRIPTION
Improved memory management and compatibility by replacing `&vec<u8>` to `&[u8]` in some places and some other minor changes. 