### PR TITLE
Provide compatibility with librustzcash/zcash_client_backend: derive Clone for CompactAction

### DIFF
--- a/src/note_encryption/compact_action.rs
+++ b/src/note_encryption/compact_action.rs
@@ -33,6 +33,7 @@ impl<A, D: OrchardDomainCommon> ShieldedOutput<OrchardDomain<D>> for Action<A, D
 }
 
 /// A compact Action for light clients.
+#[derive(Clone)]
 pub struct CompactAction<D: OrchardDomainCommon> {
     nullifier: Nullifier,
     cmx: ExtractedNoteCommitment,


### PR DESCRIPTION
This PR updates the crate to ensure compatibility with the `zcash_client_backend` crate in `librustzcash` repository. Specifically, it derives the `Clone` trait for the `CompactAction` struct to resolve compilation errors when the `orchard` feature is enabled for `zcash_client_backend` crate (`BatchRunner` struct there requires that).