### PR TITLE
Add a reference note for each first issuance

### DIFF
--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,5 +1,6 @@
 //! Constants used in the Orchard protocol.
 pub mod fixed_bases;
+pub mod reference_keys;
 pub mod sinsemilla;
 pub mod util;
 

--- a/src/constants/reference_keys.rs
+++ b/src/constants/reference_keys.rs
@@ -1,0 +1,48 @@
+//! Orchard reference keys (spending key and recipient address) used for reference notes.
+use crate::{
+    address::Address,
+    keys::{FullViewingKey, SpendingKey},
+};
+
+/// Raw bytes representation of the reference recipient address.
+pub const RAW_REFERENCE_RECIPIENT: [u8; 43] = [
+    204, 54, 96, 25, 89, 33, 59, 107, 12, 219, 150, 167, 92, 23, 195, 166, 104, 169, 127, 13, 106,
+    140, 92, 225, 100, 165, 24, 234, 155, 169, 165, 14, 167, 81, 145, 253, 134, 27, 15, 241, 14,
+    98, 176,
+];
+
+/// Reference keys (spending key and recipient address) are used for reference notes.
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+pub struct ReferenceKeys;
+
+impl ReferenceKeys {
+    /// Returns the spending key for reference notes.
+    pub fn sk() -> SpendingKey {
+        SpendingKey::from_bytes([0; 32]).unwrap()
+    }
+
+    /// Returns the recipient address for reference notes.
+    pub fn recipient() -> Address {
+        Address::from_raw_address_bytes(&RAW_REFERENCE_RECIPIENT).unwrap()
+    }
+
+    /// Returns the full viewing key for reference notes.
+    pub fn fvk() -> FullViewingKey {
+        FullViewingKey::from(&Self::sk())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::keys::{FullViewingKey, Scope};
+
+    #[test]
+    fn recipient() {
+        let sk = SpendingKey::from_bytes([0; 32]).unwrap();
+        let fvk = FullViewingKey::from(&sk);
+        let recipient = fvk.address_at(0u32, Scope::External);
+
+        assert_eq!(recipient, ReferenceKeys::recipient());
+    }
+}

--- a/src/constants/reference_keys.rs
+++ b/src/constants/reference_keys.rs
@@ -1,4 +1,10 @@
-//! Orchard reference keys (spending key and recipient address) used for reference notes.
+//! Orchard reference keys, including the spending key and recipient address, used for reference notes.
+//!
+//! The reference SpendingKey is a placeholder key with all bytes set to zero.
+//! Using this SpendingKey, we derive the FullViewingKey, and the recipient address.
+//! To avoid repeating the derivation process whenever the recipient address is required, we store
+//! its raw encoding.
+
 use crate::{
     address::Address,
     keys::{FullViewingKey, SpendingKey},

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -495,18 +495,6 @@ fn create_reference_note(asset: AssetBase, mut rng: impl RngCore) -> Note {
     )
 }
 
-/// Validation for reference note
-///
-/// The following checks are performed:
-/// - the note value of the reference note is equal to 0
-/// - the asset of the reference note is equal to the provided asset
-/// - the recipient of the reference note is equal to the reference recipient
-pub fn verify_reference_note(note: &Note, asset: AssetBase) {
-    assert_eq!(note.value(), NoteValue::from_raw(0));
-    assert_eq!(note.asset(), asset);
-    assert_eq!(note.recipient(), ReferenceKeys::recipient());
-}
-
 impl IssueBundle<Prepared> {
     /// Sign the `IssueBundle`.
     /// The call makes sure that the provided `isk` matches the `ik` and the derived `asset` for each note in the bundle.
@@ -697,14 +685,13 @@ impl fmt::Display for Error {
 #[cfg(test)]
 mod tests {
     use super::{AssetSupply, IssueBundle, IssueInfo};
+    use crate::constants::reference_keys::ReferenceKeys;
     use crate::issuance::Error::{
         AssetBaseCannotBeIdentityPoint, IssueActionNotFound,
         IssueActionPreviouslyFinalizedAssetBase, IssueBundleIkMismatchAssetBase,
         IssueBundleInvalidSignature, WrongAssetDescSize,
     };
-    use crate::issuance::{
-        verify_issue_bundle, verify_reference_note, IssueAction, Signed, Unauthorized,
-    };
+    use crate::issuance::{verify_issue_bundle, IssueAction, Signed, Unauthorized};
     use crate::keys::{
         FullViewingKey, IssuanceAuthorizingKey, IssuanceValidatingKey, Scope, SpendingKey,
     };
@@ -717,6 +704,18 @@ mod tests {
     use rand::rngs::OsRng;
     use rand::RngCore;
     use std::collections::HashSet;
+
+    /// Validation for reference note
+    ///
+    /// The following checks are performed:
+    /// - the note value of the reference note is equal to 0
+    /// - the asset of the reference note is equal to the provided asset
+    /// - the recipient of the reference note is equal to the reference recipient
+    fn verify_reference_note(note: &Note, asset: AssetBase) {
+        assert_eq!(note.value(), NoteValue::from_raw(0));
+        assert_eq!(note.asset(), asset);
+        assert_eq!(note.recipient(), ReferenceKeys::recipient());
+    }
 
     fn setup_params() -> (
         OsRng,

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -942,7 +942,7 @@ mod tests {
         assert_eq!(action2_vec.len(), 1);
         let action2 = action2_vec[0];
         assert_eq!(action2.notes.len(), 2);
-        let reference_note = action.notes.get(0).unwrap();
+        let reference_note = action2.notes.get(0).unwrap();
         verify_reference_note(reference_note, AssetBase::derive(&ik, str2.as_bytes()));
         let first_note = action2.notes().get(1).unwrap();
         assert_eq!(first_note.value().inner(), 15);

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -4,10 +4,11 @@ use group::Group;
 use k256::schnorr;
 use nonempty::NonEmpty;
 use rand::RngCore;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::fmt;
 
 use crate::bundle::commitments::{hash_issue_bundle_auth_data, hash_issue_bundle_txid_data};
+use crate::constants::reference_keys::ReferenceKeys;
 use crate::issuance::Error::{
     AssetBaseCannotBeIdentityPoint, IssueActionNotFound, IssueActionPreviouslyFinalizedAssetBase,
     IssueActionWithoutNoteNotFinalized, IssueBundleIkMismatchAssetBase,
@@ -29,6 +30,8 @@ pub struct IssueBundle<T: IssueAuth> {
     ik: IssuanceValidatingKey,
     /// The list of issue actions that make up this bundle.
     actions: NonEmpty<IssueAction>,
+    /// The list of reference notes created in this bundle.
+    reference_notes: HashMap<AssetBase, Note>,
     /// The authorization for this action.
     authorization: T,
 }
@@ -246,11 +249,13 @@ impl<T: IssueAuth> IssueBundle<T> {
     pub fn from_parts(
         ik: IssuanceValidatingKey,
         actions: NonEmpty<IssueAction>,
+        reference_notes: HashMap<AssetBase, Note>,
         authorization: T,
     ) -> Self {
         IssueBundle {
             ik,
             actions,
+            reference_notes,
             authorization,
         }
     }
@@ -264,6 +269,7 @@ impl<T: IssueAuth> IssueBundle<T> {
         IssueBundle {
             ik: self.ik,
             actions: self.actions,
+            reference_notes: self.reference_notes,
             authorization: map_auth(authorization),
         }
     }
@@ -278,6 +284,9 @@ impl IssueBundle<Unauthorized> {
     /// issue_info values and with `finalize` set to false. In this created note, rho will be
     /// randomly sampled, similar to dummy note generation.
     ///
+    /// If `first_issuance` is true, the `IssueBundle` will contain a reference note for the asset
+    /// defined by (`asset_desc`, `ik`).
+    ///
     /// # Errors
     ///
     /// This function may return an error in any of the following cases:
@@ -287,6 +296,7 @@ impl IssueBundle<Unauthorized> {
         ik: IssuanceValidatingKey,
         asset_desc: Vec<u8>,
         issue_info: Option<IssueInfo>,
+        first_issuance: bool,
         mut rng: impl RngCore,
     ) -> Result<(IssueBundle<Unauthorized>, AssetBase), Error> {
         if !is_asset_desc_of_valid_size(&asset_desc) {
@@ -295,10 +305,23 @@ impl IssueBundle<Unauthorized> {
 
         let asset = AssetBase::derive(&ik, &asset_desc);
 
+        let reference_note = Note::new(
+            ReferenceKeys::recipient(),
+            NoteValue::zero(),
+            asset,
+            Rho::from_nf_old(Nullifier::dummy(&mut rng)),
+            &mut rng,
+        );
+
+        let mut notes = vec![];
+        if first_issuance {
+            notes.push(reference_note);
+        }
+
         let action = match issue_info {
             None => IssueAction {
                 asset_desc,
-                notes: vec![],
+                notes,
                 finalize: true,
             },
             Some(issue_info) => {
@@ -310,18 +333,27 @@ impl IssueBundle<Unauthorized> {
                     &mut rng,
                 );
 
+                notes.push(note);
+
                 IssueAction {
                     asset_desc,
-                    notes: vec![note],
+                    notes,
                     finalize: false,
                 }
             }
+        };
+
+        let reference_notes = if first_issuance {
+            HashMap::from([(asset, reference_note)])
+        } else {
+            HashMap::new()
         };
 
         Ok((
             IssueBundle {
                 ik,
                 actions: NonEmpty::new(action),
+                reference_notes,
                 authorization: Unauthorized,
             },
             asset,
@@ -331,6 +363,8 @@ impl IssueBundle<Unauthorized> {
     /// Add a new note to the `IssueBundle`.
     ///
     /// Rho will be randomly sampled, similar to dummy note generation.
+    /// If `first_issuance` is true, we will also add a reference note for the asset defined by
+    /// (`asset_desc`, `ik`).
     ///
     /// # Errors
     ///
@@ -342,6 +376,7 @@ impl IssueBundle<Unauthorized> {
         asset_desc: &[u8],
         recipient: Address,
         value: NoteValue,
+        first_issuance: bool,
         mut rng: impl RngCore,
     ) -> Result<AssetBase, Error> {
         if !is_asset_desc_of_valid_size(asset_desc) {
@@ -349,6 +384,14 @@ impl IssueBundle<Unauthorized> {
         }
 
         let asset = AssetBase::derive(&self.ik, asset_desc);
+
+        let reference_note = Note::new(
+            ReferenceKeys::recipient(),
+            NoteValue::zero(),
+            asset,
+            Rho::from_nf_old(Nullifier::dummy(&mut rng)),
+            &mut rng,
+        );
 
         let note = Note::new(
             recipient,
@@ -367,16 +410,28 @@ impl IssueBundle<Unauthorized> {
             Some(action) => {
                 // Append to an existing IssueAction.
                 action.notes.push(note);
+                if first_issuance {
+                    action.notes.push(reference_note);
+                }
             }
             None => {
                 // Insert a new IssueAction.
+                let notes = if first_issuance {
+                    vec![reference_note, note]
+                } else {
+                    vec![note]
+                };
                 self.actions.push(IssueAction {
                     asset_desc: Vec::from(asset_desc),
-                    notes: vec![note],
+                    notes,
                     finalize: false,
                 });
             }
         };
+
+        if first_issuance {
+            self.reference_notes.insert(asset, reference_note);
+        }
 
         Ok(asset)
     }
@@ -412,6 +467,7 @@ impl IssueBundle<Unauthorized> {
         IssueBundle {
             ik: self.ik,
             actions: self.actions,
+            reference_notes: self.reference_notes,
             authorization: Prepared { sighash },
         }
     }
@@ -437,6 +493,7 @@ impl IssueBundle<Prepared> {
         Ok(IssueBundle {
             ik: self.ik,
             actions: self.actions,
+            reference_notes: self.reference_notes,
             authorization: Signed { signature },
         })
     }
@@ -624,7 +681,7 @@ mod tests {
     use pasta_curves::pallas::{Point, Scalar};
     use rand::rngs::OsRng;
     use rand::RngCore;
-    use std::collections::HashSet;
+    use std::collections::{HashMap, HashSet};
 
     fn setup_params() -> (
         OsRng,
@@ -722,7 +779,8 @@ mod tests {
         let action =
             IssueAction::from_parts("arbitrary asset_desc".into(), vec![note1, note2], false);
 
-        let bundle = IssueBundle::from_parts(ik, NonEmpty::new(action), Unauthorized);
+        let bundle =
+            IssueBundle::from_parts(ik, NonEmpty::new(action), HashMap::new(), Unauthorized);
 
         (isk, bundle, sighash)
     }
@@ -803,6 +861,7 @@ mod tests {
                     recipient,
                     value: NoteValue::unsplittable()
                 }),
+                true,
                 rng,
             )
             .unwrap_err(),
@@ -817,6 +876,7 @@ mod tests {
                     recipient,
                     value: NoteValue::unsplittable()
                 }),
+                true,
                 rng,
             )
             .unwrap_err(),
@@ -830,17 +890,30 @@ mod tests {
                 recipient,
                 value: NoteValue::from_raw(5),
             }),
+            true,
             rng,
         )
         .unwrap();
 
         let another_asset = bundle
-            .add_recipient(&str.into_bytes(), recipient, NoteValue::from_raw(10), rng)
+            .add_recipient(
+                &str.into_bytes(),
+                recipient,
+                NoteValue::from_raw(10),
+                false,
+                rng,
+            )
             .unwrap();
         assert_eq!(asset, another_asset);
 
         let third_asset = bundle
-            .add_recipient(str2.as_bytes(), recipient, NoteValue::from_raw(15), rng)
+            .add_recipient(
+                str2.as_bytes(),
+                recipient,
+                NoteValue::from_raw(15),
+                true,
+                rng,
+            )
             .unwrap();
         assert_ne!(asset, third_asset);
 
@@ -850,21 +923,26 @@ mod tests {
         let actions_vec = bundle.get_actions_by_asset(&asset);
         assert_eq!(actions_vec.len(), 1);
         let action = actions_vec[0];
-        assert_eq!(action.notes.len(), 2);
-        assert_eq!(action.notes.first().unwrap().value().inner(), 5);
-        assert_eq!(action.notes.first().unwrap().asset(), asset);
-        assert_eq!(action.notes.first().unwrap().recipient(), recipient);
+        assert_eq!(action.notes.len(), 3);
+        // The note at index 0 is the reference note.
+        let first_note = action.notes.get(1).unwrap();
+        assert_eq!(first_note.value().inner(), 5);
+        assert_eq!(first_note.asset(), asset);
+        assert_eq!(first_note.recipient(), recipient);
 
-        assert_eq!(action.notes.get(1).unwrap().value().inner(), 10);
-        assert_eq!(action.notes.get(1).unwrap().asset(), asset);
-        assert_eq!(action.notes.get(1).unwrap().recipient(), recipient);
+        let second_note = action.notes.get(2).unwrap();
+        assert_eq!(second_note.value().inner(), 10);
+        assert_eq!(second_note.asset(), asset);
+        assert_eq!(second_note.recipient(), recipient);
 
         let action2_vec = bundle.get_actions_by_desc(str2.as_bytes());
         assert_eq!(action2_vec.len(), 1);
         let action2 = action2_vec[0];
-        assert_eq!(action2.notes.len(), 1);
-        assert_eq!(action2.notes().first().unwrap().value().inner(), 15);
-        assert_eq!(action2.notes().first().unwrap().asset(), third_asset);
+        assert_eq!(action2.notes.len(), 2);
+        // The note at index 0 is the reference note.
+        let first_note = action2.notes().get(1).unwrap();
+        assert_eq!(first_note.value().inner(), 15);
+        assert_eq!(first_note.asset(), third_asset);
     }
 
     #[test]
@@ -878,6 +956,7 @@ mod tests {
                 recipient,
                 value: NoteValue::from_raw(u64::MIN),
             }),
+            true,
             rng,
         )
         .expect("Should properly add recipient");
@@ -910,6 +989,7 @@ mod tests {
                 recipient,
                 value: NoteValue::from_raw(5),
             }),
+            true,
             rng,
         )
         .unwrap();
@@ -929,6 +1009,7 @@ mod tests {
                 recipient,
                 value: NoteValue::from_raw(5),
             }),
+            true,
             rng,
         )
         .unwrap();
@@ -950,6 +1031,7 @@ mod tests {
                 recipient,
                 value: NoteValue::from_raw(5),
             }),
+            true,
             rng,
         )
         .unwrap();
@@ -976,6 +1058,7 @@ mod tests {
                 recipient,
                 value: NoteValue::from_raw(5),
             }),
+            true,
             rng,
         )
         .unwrap();
@@ -1009,6 +1092,7 @@ mod tests {
                 recipient,
                 value: NoteValue::from_raw(5),
             }),
+            true,
             rng,
         )
         .unwrap();
@@ -1034,6 +1118,7 @@ mod tests {
                 recipient,
                 value: NoteValue::from_raw(7),
             }),
+            true,
             rng,
         )
         .unwrap();
@@ -1070,24 +1155,25 @@ mod tests {
                 recipient,
                 value: NoteValue::from_raw(7),
             }),
+            true,
             rng,
         )
         .unwrap();
 
         bundle
-            .add_recipient(&asset1_desc, recipient, NoteValue::from_raw(8), rng)
+            .add_recipient(&asset1_desc, recipient, NoteValue::from_raw(8), false, rng)
             .unwrap();
 
         bundle.finalize_action(&asset1_desc).unwrap();
 
         bundle
-            .add_recipient(&asset2_desc, recipient, NoteValue::from_raw(10), rng)
+            .add_recipient(&asset2_desc, recipient, NoteValue::from_raw(10), true, rng)
             .unwrap();
 
         bundle.finalize_action(&asset2_desc).unwrap();
 
         bundle
-            .add_recipient(&asset3_desc, recipient, NoteValue::from_raw(5), rng)
+            .add_recipient(&asset3_desc, recipient, NoteValue::from_raw(5), true, rng)
             .unwrap();
 
         let signed = bundle.prepare(sighash).sign(&isk).unwrap();
@@ -1130,6 +1216,7 @@ mod tests {
                 recipient,
                 value: NoteValue::from_raw(5),
             }),
+            true,
             rng,
         )
         .unwrap();
@@ -1165,6 +1252,7 @@ mod tests {
                 recipient,
                 value: NoteValue::from_raw(5),
             }),
+            true,
             rng,
         )
         .unwrap();
@@ -1195,6 +1283,7 @@ mod tests {
                 recipient,
                 value: NoteValue::from_raw(5),
             }),
+            true,
             rng,
         )
         .unwrap();
@@ -1220,6 +1309,7 @@ mod tests {
                 recipient,
                 value: NoteValue::from_raw(5),
             }),
+            true,
             rng,
         )
         .unwrap();
@@ -1258,6 +1348,7 @@ mod tests {
                 recipient,
                 value: NoteValue::from_raw(5),
             }),
+            true,
             rng,
         )
         .unwrap();
@@ -1304,6 +1395,7 @@ mod tests {
                 recipient,
                 value: NoteValue::from_raw(5),
             }),
+            true,
             rng,
         )
         .unwrap();
@@ -1345,6 +1437,7 @@ mod tests {
         let signed = IssueBundle {
             ik: bundle.ik,
             actions: bundle.actions,
+            reference_notes: bundle.reference_notes,
             authorization: Signed {
                 signature: isk.try_sign(&sighash).unwrap(),
             },
@@ -1396,12 +1489,13 @@ mod tests {
                 recipient,
                 value: NoteValue::from_raw(5),
             }),
+            true,
             rng,
         )
         .unwrap();
 
         let asset_base_2 = bundle
-            .add_recipient(&asset_desc_2, recipient, NoteValue::from_raw(10), rng)
+            .add_recipient(&asset_desc_2, recipient, NoteValue::from_raw(10), true, rng)
             .unwrap();
 
         // Checks for the case of UTF-8 encoded asset description.
@@ -1410,7 +1504,8 @@ mod tests {
 
         let action = actions_vec[0];
         assert_eq!(action.asset_desc(), &asset_desc_1);
-        assert_eq!(action.notes.first().unwrap().value().inner(), 5);
+        // The note at index 0 is the reference note.
+        assert_eq!(action.notes.get(1).unwrap().value().inner(), 5);
         assert_eq!(bundle.get_actions_by_desc(&asset_desc_1), actions_vec);
 
         // Checks for the case on non-UTF-8 encoded asset description.
@@ -1419,7 +1514,8 @@ mod tests {
 
         let action2 = action2_vec[0];
         assert_eq!(action2.asset_desc(), &asset_desc_2);
-        assert_eq!(action2.notes.first().unwrap().value().inner(), 10);
+        // The note at index 0 is the reference note.
+        assert_eq!(action2.notes.get(1).unwrap().value().inner(), 10);
         assert_eq!(bundle.get_actions_by_desc(&asset_desc_2), action2_vec);
     }
 }
@@ -1437,6 +1533,7 @@ pub mod testing {
     use proptest::collection::vec;
     use proptest::prelude::*;
     use proptest::prop_compose;
+    use std::collections::HashMap;
 
     prop_compose! {
         /// Generate a uniformly distributed signature
@@ -1475,6 +1572,7 @@ pub mod testing {
             IssueBundle {
                 ik,
                 actions,
+                reference_notes: HashMap::new(),
                 authorization: Unauthorized
             }
         }
@@ -1493,6 +1591,7 @@ pub mod testing {
             IssueBundle {
                 ik,
                 actions,
+                reference_notes: HashMap::new(),
                 authorization: Prepared { sighash: fake_sighash }
             }
         }
@@ -1511,6 +1610,7 @@ pub mod testing {
             IssueBundle {
                 ik,
                 actions,
+                reference_notes: HashMap::new(),
                 authorization: Signed { signature: fake_sig },
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,17 +22,14 @@ pub mod builder;
 pub mod bundle;
 pub mod circuit;
 mod constants;
+pub mod domain;
 pub mod issuance;
 pub mod keys;
 pub mod note;
-pub mod supply_info;
-
-pub mod domain;
-
 pub mod orchard_flavor;
-
 pub mod primitives;
 mod spec;
+pub mod supply_info;
 pub mod tree;
 pub mod value;
 pub mod zip32;
@@ -44,6 +41,7 @@ pub use action::Action;
 pub use address::Address;
 pub use bundle::Bundle;
 pub use circuit::Proof;
+pub use constants::reference_keys::ReferenceKeys;
 pub use constants::MERKLE_DEPTH_ORCHARD as NOTE_COMMITMENT_TREE_DEPTH;
 pub use note::Note;
 pub use tree::Anchor;

--- a/tests/zsa.rs
+++ b/tests/zsa.rs
@@ -302,7 +302,8 @@ fn zsa_issue_and_transfer() {
     let asset_descr = b"zsa_asset".to_vec();
 
     // Prepare ZSA
-    let (_, zsa_note_1, zsa_note_2) = issue_zsa_notes(&asset_descr, &keys);
+    let (reference_note, zsa_note_1, zsa_note_2) = issue_zsa_notes(&asset_descr, &keys);
+    verify_reference_note(&reference_note, zsa_note_1.asset());
 
     let (merkle_path1, merkle_path2, anchor) =
         build_merkle_path_with_two_leaves(&zsa_note_1, &zsa_note_2);
@@ -455,7 +456,8 @@ fn zsa_issue_and_transfer() {
     .unwrap();
 
     // 7. Spend ZSA notes of different asset types
-    let (_, zsa_note_t7, _) = issue_zsa_notes(b"zsa_asset2", &keys);
+    let (reference_note, zsa_note_t7, _) = issue_zsa_notes(b"zsa_asset2", &keys);
+    verify_reference_note(&reference_note, zsa_note_t7.asset());
     let (merkle_path_t7_1, merkle_path_t7_2, anchor_t7) =
         build_merkle_path_with_two_leaves(&zsa_note_t7, &zsa_note_2);
     let zsa_spend_t7_1: TestSpendInfo = TestSpendInfo {

--- a/tests/zsa.rs
+++ b/tests/zsa.rs
@@ -13,7 +13,6 @@ use orchard::{
     builder::{Builder, BundleType},
     circuit::{ProvingKey, VerifyingKey},
     domain::OrchardDomain,
-    issuance::verify_reference_note,
     keys::{FullViewingKey, PreparedIncomingViewingKey, Scope, SpendAuthorizingKey, SpendingKey},
     orchard_flavor::OrchardZSA,
     value::NoteValue,
@@ -291,6 +290,21 @@ fn verify_unique_spent_nullifiers(bundle: &Bundle<Authorized, i64, OrchardZSA>) 
         // position of the item is equal to the current index i.
         unique_nulifiers.iter().position(|x| x == item) == Some(i)
     })
+}
+
+/// Validation for reference note
+///
+/// The following checks are performed:
+/// - the note value of the reference note is equal to 0
+/// - the asset of the reference note is equal to the provided asset
+/// - the recipient of the reference note is equal to the reference recipient
+fn verify_reference_note(note: &Note, asset: AssetBase) {
+    let reference_sk = SpendingKey::from_bytes([0; 32]).unwrap();
+    let reference_fvk = FullViewingKey::from(&reference_sk);
+    let reference_recipient = reference_fvk.address_at(0u32, Scope::External);
+    assert_eq!(note.value(), NoteValue::from_raw(0));
+    assert_eq!(note.asset(), asset);
+    assert_eq!(note.recipient(), reference_recipient);
 }
 
 /// Issue several ZSA and native notes and spend them in different combinations, e.g. split and join

--- a/tests/zsa.rs
+++ b/tests/zsa.rs
@@ -13,6 +13,7 @@ use orchard::{
     builder::{Builder, BundleType},
     circuit::{ProvingKey, VerifyingKey},
     domain::OrchardDomain,
+    issuance::verify_reference_note,
     keys::{FullViewingKey, PreparedIncomingViewingKey, Scope, SpendAuthorizingKey, SpendingKey},
     orchard_flavor::OrchardZSA,
     value::NoteValue,
@@ -172,11 +173,9 @@ fn issue_zsa_notes(asset_descr: &[u8], keys: &Keychain) -> (Note, Note, Note) {
     let note1 = notes[1];
     let note2 = notes[2];
 
-    // Check reference_note
-    assert_eq!(reference_note.value(), NoteValue::from_raw(0));
-    assert_eq!(
-        reference_note.asset(),
-        AssetBase::derive(&keys.ik().clone(), asset_descr)
+    verify_reference_note(
+        reference_note,
+        AssetBase::derive(&keys.ik().clone(), asset_descr),
     );
 
     assert!(verify_issue_bundle(

--- a/tests/zsa.rs
+++ b/tests/zsa.rs
@@ -136,7 +136,7 @@ pub fn build_merkle_path_with_two_leaves(
     (merkle_path1, merkle_path2, anchor)
 }
 
-fn issue_zsa_notes(asset_descr: &[u8], keys: &Keychain) -> (Note, Note) {
+fn issue_zsa_notes(asset_descr: &[u8], keys: &Keychain) -> (Note, Note, Note) {
     let mut rng = OsRng;
     // Create a issuance bundle
     let unauthorized_asset = IssueBundle::new(
@@ -168,8 +168,9 @@ fn issue_zsa_notes(asset_descr: &[u8], keys: &Keychain) -> (Note, Note) {
 
     // Take notes from first action
     let notes = issue_bundle.get_all_notes();
-    let note1 = notes[0];
-    let note2 = notes[1];
+    let reference_note = notes[0];
+    let note1 = notes[1];
+    let note2 = notes[2];
 
     assert!(verify_issue_bundle(
         &issue_bundle,
@@ -178,7 +179,7 @@ fn issue_zsa_notes(asset_descr: &[u8], keys: &Keychain) -> (Note, Note) {
     )
     .is_ok());
 
-    (*note1, *note2)
+    (*reference_note, *note1, *note2)
 }
 
 fn create_native_note(keys: &Keychain) -> Note {
@@ -295,7 +296,7 @@ fn zsa_issue_and_transfer() {
     let asset_descr = b"zsa_asset".to_vec();
 
     // Prepare ZSA
-    let (zsa_note_1, zsa_note_2) = issue_zsa_notes(&asset_descr, &keys);
+    let (_, zsa_note_1, zsa_note_2) = issue_zsa_notes(&asset_descr, &keys);
 
     let (merkle_path1, merkle_path2, anchor) =
         build_merkle_path_with_two_leaves(&zsa_note_1, &zsa_note_2);
@@ -448,7 +449,7 @@ fn zsa_issue_and_transfer() {
     .unwrap();
 
     // 7. Spend ZSA notes of different asset types
-    let (zsa_note_t7, _) = issue_zsa_notes(b"zsa_asset2", &keys);
+    let (_, zsa_note_t7, _) = issue_zsa_notes(b"zsa_asset2", &keys);
     let (merkle_path_t7_1, merkle_path_t7_2, anchor_t7) =
         build_merkle_path_with_two_leaves(&zsa_note_t7, &zsa_note_2);
     let zsa_spend_t7_1: TestSpendInfo = TestSpendInfo {

--- a/tests/zsa.rs
+++ b/tests/zsa.rs
@@ -146,6 +146,7 @@ fn issue_zsa_notes(asset_descr: &[u8], keys: &Keychain) -> (Note, Note) {
             recipient: keys.recipient,
             value: NoteValue::from_raw(40),
         }),
+        true,
         &mut rng,
     );
 
@@ -158,6 +159,7 @@ fn issue_zsa_notes(asset_descr: &[u8], keys: &Keychain) -> (Note, Note) {
             asset_descr,
             keys.recipient,
             NoteValue::from_raw(2),
+            false,
             &mut rng,
         )
         .is_ok());

--- a/tests/zsa.rs
+++ b/tests/zsa.rs
@@ -172,6 +172,13 @@ fn issue_zsa_notes(asset_descr: &[u8], keys: &Keychain) -> (Note, Note, Note) {
     let note1 = notes[1];
     let note2 = notes[2];
 
+    // Check reference_note
+    assert_eq!(reference_note.value(), NoteValue::from_raw(0));
+    assert_eq!(
+        reference_note.asset(),
+        AssetBase::derive(&keys.ik().clone(), asset_descr)
+    );
+
     assert!(verify_issue_bundle(
         &issue_bundle,
         issue_bundle.commitment().into(),


### PR DESCRIPTION
When an asset is issue for the first time, we create a reference note which is a note with a value equal to zero and a recipient address equal to the reference recipient address.