### PR TITLE
Simplify bundle function return type

### DIFF
--- a/benches/circuit.rs
+++ b/benches/circuit.rs
@@ -46,7 +46,7 @@ fn criterion_benchmark<FL: OrchardFlavorBench>(c: &mut Criterion) {
                 )
                 .unwrap();
         }
-        let bundle: Bundle<_, i64, FL> = builder.build(rng).unwrap().unwrap().0;
+        let bundle: Bundle<_, i64, FL> = builder.build(rng).unwrap().0;
 
         let instances: Vec<_> = bundle
             .actions()

--- a/benches/note_decryption.rs
+++ b/benches/note_decryption.rs
@@ -74,7 +74,7 @@ fn bench_note_decryption<FL: OrchardFlavorBench>(c: &mut Criterion) {
                 None,
             )
             .unwrap();
-        let bundle: Bundle<_, i64, FL> = builder.build(rng).unwrap().unwrap().0;
+        let bundle: Bundle<_, i64, FL> = builder.build(rng).unwrap().0;
         bundle
             .create_proof(&pk, rng)
             .unwrap()

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -654,7 +654,7 @@ impl Builder {
     pub fn build<V: TryFrom<i64>, FL: OrchardFlavor>(
         self,
         rng: impl RngCore,
-    ) -> Result<Option<UnauthorizedBundleWithMetadata<V, FL>>, BuildError> {
+    ) -> Result<UnauthorizedBundleWithMetadata<V, FL>, BuildError> {
         bundle(
             rng,
             self.anchor,
@@ -745,7 +745,7 @@ pub fn bundle<V: TryFrom<i64>, FL: OrchardFlavor>(
     spends: Vec<SpendInfo>,
     outputs: Vec<OutputInfo>,
     burn: HashMap<AssetBase, NoteValue>,
-) -> Result<Option<UnauthorizedBundleWithMetadata<V, FL>>, BuildError> {
+) -> Result<UnauthorizedBundleWithMetadata<V, FL>, BuildError> {
     let flags = bundle_type.flags();
 
     let num_requested_spends = spends.len();
@@ -884,25 +884,24 @@ pub fn bundle<V: TryFrom<i64>, FL: OrchardFlavor>(
     let bvk = derive_bvk(&actions, native_value_balance, burn.iter().cloned());
     assert_eq!(redpallas::VerificationKey::from(&bsk), bvk);
 
-    Ok(NonEmpty::from_vec(actions).map(|actions| {
-        (
-            Bundle::from_parts(
-                actions,
-                flags,
-                result_value_balance,
-                burn,
-                anchor,
-                InProgress {
-                    proof: Unproven {
-                        witnesses,
-                        circuit_flavor: FL::FLAVOR,
-                    },
-                    sigs: Unauthorized { bsk },
+    Ok((
+        Bundle::from_parts(
+            // `actions` is never empty. It contains at least MIN_ACTIONS=2 actions.
+            NonEmpty::from_vec(actions).unwrap(),
+            flags,
+            result_value_balance,
+            burn,
+            anchor,
+            InProgress {
+                proof: Unproven {
+                    witnesses,
+                    circuit_flavor: FL::FLAVOR,
                 },
-            ),
-            bundle_meta,
-        )
-    }))
+                sigs: Unauthorized { bsk },
+            },
+        ),
+        bundle_meta,
+    ))
 }
 
 /// Marker trait representing bundle signatures in the process of being created.
@@ -1302,7 +1301,6 @@ pub mod testing {
             builder
                 .build(&mut self.rng)
                 .unwrap()
-                .unwrap()
                 .0
                 .create_proof(&pk, &mut self.rng)
                 .unwrap()
@@ -1433,7 +1431,6 @@ mod tests {
 
         let bundle: Bundle<Authorized, i64, FL> = builder
             .build(&mut rng)
-            .unwrap()
             .unwrap()
             .0
             .create_proof(&pk, &mut rng)

--- a/src/bundle/commitments.rs
+++ b/src/bundle/commitments.rs
@@ -166,7 +166,7 @@ mod tests {
             )
             .unwrap();
 
-        builder.build::<i64, FL>(rng).unwrap().unwrap().0
+        builder.build::<i64, FL>(rng).unwrap().0
     }
 
     /// Verify that the hash for an Orchard Vanilla bundle matches a fixed reference value

--- a/tests/builder.rs
+++ b/tests/builder.rs
@@ -93,7 +93,7 @@ fn bundle_chain<FL: BundleOrchardFlavor>() {
             builder.add_output(None, recipient, note_value, AssetBase::native(), None),
             Ok(())
         );
-        let (unauthorized, bundle_meta) = builder.build(&mut rng).unwrap().unwrap();
+        let (unauthorized, bundle_meta) = builder.build(&mut rng).unwrap();
 
         assert_eq!(
             unauthorized
@@ -163,7 +163,7 @@ fn bundle_chain<FL: BundleOrchardFlavor>() {
             ),
             Ok(())
         );
-        let (unauthorized, _) = builder.build(&mut rng).unwrap().unwrap();
+        let (unauthorized, _) = builder.build(&mut rng).unwrap();
         let sighash = unauthorized.commitment().into();
         let proven = unauthorized.create_proof(&pk, &mut rng).unwrap();
         proven

--- a/tests/zsa.rs
+++ b/tests/zsa.rs
@@ -88,7 +88,7 @@ fn build_and_sign_bundle(
     pk: &ProvingKey,
     sk: &SpendingKey,
 ) -> Bundle<Authorized, i64, OrchardZSA> {
-    let unauthorized = builder.build(&mut rng).unwrap().unwrap().0;
+    let unauthorized = builder.build(&mut rng).unwrap().0;
     let sighash = unauthorized.commitment().into();
     let proven = unauthorized.create_proof(pk, &mut rng).unwrap();
     proven
@@ -205,7 +205,7 @@ fn create_native_note(keys: &Keychain) -> Note {
             ),
             Ok(())
         );
-        let unauthorized = builder.build(&mut rng).unwrap().unwrap().0;
+        let unauthorized = builder.build(&mut rng).unwrap().0;
         let sighash = unauthorized.commitment().into();
         let proven = unauthorized.create_proof(keys.pk(), &mut rng).unwrap();
         proven.apply_signatures(rng, sighash, &[]).unwrap()


### PR DESCRIPTION
Previously, the bundle function returns a `Result<Option<UnauthorizedBundleWithMetadata<V, FL>>, BuildError>` but the `Option` was never `None` because the actions vector could not be empty.
Now, the bundle function returns a `Result<UnauthorizedBundleWithMetadata<V, FL>, BuildError>`.