### PR TITLE
Update to orchard_auth_digest computation

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -456,6 +456,9 @@ impl ActionInfo {
 /// This is returned by [`Builder::build`].
 pub type UnauthorizedBundle<V, D> = Bundle<InProgress<Unproven, Unauthorized>, V, D>;
 
+/// Type alias for an authorized bundle that has proofs and signatures.
+pub type AuthorizedBundle<V, D> = Bundle<Authorized, V, D>;
+
 /// Metadata about a bundle created by [`bundle`] or [`Builder::build`] that is not
 /// necessarily recoverable from the bundle itself.
 ///

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -456,9 +456,6 @@ impl ActionInfo {
 /// This is returned by [`Builder::build`].
 pub type UnauthorizedBundle<V, D> = Bundle<InProgress<Unproven, Unauthorized>, V, D>;
 
-/// Type alias for an authorized bundle that has proofs and signatures.
-pub type AuthorizedBundle<V, D> = Bundle<Authorized, V, D>;
-
 /// Metadata about a bundle created by [`bundle`] or [`Builder::build`] that is not
 /// necessarily recoverable from the bundle itself.
 ///

--- a/src/bundle/commitments.rs
+++ b/src/bundle/commitments.rs
@@ -16,7 +16,10 @@ pub(crate) const ZCASH_ORCHARD_ACTIONS_MEMOS_HASH_PERSONALIZATION: &[u8; 16] = b
 pub(crate) const ZCASH_ORCHARD_ACTIONS_NONCOMPACT_HASH_PERSONALIZATION: &[u8; 16] =
     b"ZTxIdOrcActNHash";
 pub(crate) const ZCASH_ORCHARD_ZSA_BURN_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxIdOrcBurnHash";
-const ZCASH_ORCHARD_SIGS_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxAuthOrchaHash";
+pub(crate) const ZCASH_ORCHARD_SIGS_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxAuthOrchaHash";
+pub(crate) const ZCASH_ORCHARD_ACTION_GROUPS_SIGS_HASH_PERSONALIZATION: &[u8; 16] =
+    b"ZTxAuthOrcAGHash";
+
 const ZCASH_ORCHARD_ZSA_ISSUE_PERSONALIZATION: &[u8; 16] = b"ZTxIdSAIssueHash";
 const ZCASH_ORCHARD_ZSA_ISSUE_ACTION_PERSONALIZATION: &[u8; 16] = b"ZTxIdIssuActHash";
 const ZCASH_ORCHARD_ZSA_ISSUE_NOTE_PERSONALIZATION: &[u8; 16] = b"ZTxIdIAcNoteHash";
@@ -60,15 +63,7 @@ pub fn hash_bundle_txid_empty() -> Blake2bHash {
 pub(crate) fn hash_bundle_auth_data<V, D: OrchardDomainCommon>(
     bundle: &Bundle<Authorized, V, D>,
 ) -> Blake2bHash {
-    let mut h = hasher(ZCASH_ORCHARD_SIGS_HASH_PERSONALIZATION);
-    h.update(bundle.authorization().proof().as_ref());
-    for action in bundle.actions().iter() {
-        h.update(&<[u8; 64]>::from(action.authorization()));
-    }
-    h.update(&<[u8; 64]>::from(
-        bundle.authorization().binding_signature(),
-    ));
-    h.finalize()
+    D::hash_bundle_auth_data(bundle)
 }
 
 /// Construct the commitment for an absent bundle as defined in

--- a/src/bundle/commitments.rs
+++ b/src/bundle/commitments.rs
@@ -194,15 +194,13 @@ mod tests {
     fn generate_auth_bundle<FL: OrchardFlavor>(
         bundle_type: BundleType,
     ) -> AuthorizedBundle<i64, FL> {
-        let rng1 = StdRng::seed_from_u64(6);
-        let rng2 = StdRng::seed_from_u64(7);
+        let mut rng = StdRng::seed_from_u64(6);
         let pk = ProvingKey::build::<FL>();
-        generate_bundle(bundle_type)
-            .create_proof(&pk, rng1)
-            .unwrap()
-            .prepare(rng2, [0u8; 32])
-            .finalize()
-            .unwrap()
+        let bundle = generate_bundle(bundle_type)
+            .create_proof(&pk, &mut rng)
+            .unwrap();
+        let sighash = bundle.commitment().into();
+        bundle.prepare(rng, sighash).finalize().unwrap()
     }
 
     /// Verify that the authorizing data commitment for an Orchard Vanilla bundle matches a fixed
@@ -215,7 +213,7 @@ mod tests {
             orchard_auth_digest.to_hex().as_str(),
             // Bundle hash for Orchard (vanilla) generated using
             // Zcash/Orchard commit: 23a167e3972632586dc628ddbdd69d156dfd607b
-            "f2e86b437ea754e31bc4d8396bf5825bfe1254d195645e754b9492eeaebd3353"
+            "2cd424654d8cb770c8dbdf253b6829e25fc70b40157048fd7c6c19f9a9c61f76"
         );
     }
 
@@ -225,10 +223,9 @@ mod tests {
     fn test_hash_bundle_auth_data_for_orchard_zsa() {
         let bundle = generate_auth_bundle::<OrchardZSA>(BundleType::DEFAULT_ZSA);
         let orchard_auth_digest = hash_bundle_auth_data(&bundle);
-        println!("{}", orchard_auth_digest.to_hex().as_str());
         assert_eq!(
             orchard_auth_digest.to_hex().as_str(),
-            "62edd0aa19002dc00ef5bed516a46bfbc645d84c8cc967797eb5a6527dd47dc6"
+            "c765769582c598930b2825224d5d9246196954fe7cbd3a2be9afa3c542c06387"
         );
     }
 }

--- a/src/bundle/commitments.rs
+++ b/src/bundle/commitments.rs
@@ -124,8 +124,11 @@ pub(crate) fn hash_issue_bundle_auth_data(bundle: &IssueBundle<Signed>) -> Blake
 #[cfg(test)]
 mod tests {
     use crate::{
-        builder::{AuthorizedBundle, Builder, BundleType, UnauthorizedBundle},
-        bundle::commitments::{hash_bundle_auth_data, hash_bundle_txid_data},
+        builder::{Builder, BundleType, UnauthorizedBundle},
+        bundle::{
+            commitments::{hash_bundle_auth_data, hash_bundle_txid_data},
+            Authorized, Bundle,
+        },
         circuit::ProvingKey,
         keys::{FullViewingKey, Scope, SpendingKey},
         note::AssetBase,
@@ -193,7 +196,7 @@ mod tests {
 
     fn generate_auth_bundle<FL: OrchardFlavor>(
         bundle_type: BundleType,
-    ) -> AuthorizedBundle<i64, FL> {
+    ) -> Bundle<Authorized, i64, FL> {
         let mut rng = StdRng::seed_from_u64(6);
         let pk = ProvingKey::build::<FL>();
         let bundle = generate_bundle(bundle_type)

--- a/src/domain/orchard_domain.rs
+++ b/src/domain/orchard_domain.rs
@@ -6,6 +6,7 @@ use core::fmt;
 use blake2b_simd::{Hash as Blake2bHash, State};
 use zcash_note_encryption_zsa::{note_bytes::NoteBytes, AEAD_TAG_SIZE};
 
+use crate::bundle::Authorized;
 use crate::{
     action::Action,
     bundle::{
@@ -110,6 +111,16 @@ pub trait OrchardDomainCommon: fmt::Debug + Clone {
         main_hasher.update(mh.finalize().as_bytes());
         main_hasher.update(nh.finalize().as_bytes());
     }
+
+    /// Evaluate `orchard_auth_digest` for the bundle as defined in
+    /// [ZIP-244: Transaction Identifier Non-Malleability][zip244]
+    /// for OrchardVanilla and as defined in
+    /// [ZIP-226: Transfer and Burn of Zcash Shielded Assets][zip226]
+    /// for OrchardZSA
+    ///
+    /// [zip244]: https://zips.z.cash/zip-0244
+    /// [zip226]: https://zips.z.cash/zip-0226
+    fn hash_bundle_auth_data<V>(bundle: &Bundle<Authorized, V, Self>) -> Blake2bHash;
 }
 
 /// Orchard-specific note encryption logic.

--- a/src/domain/orchard_domain.rs
+++ b/src/domain/orchard_domain.rs
@@ -6,7 +6,6 @@ use core::fmt;
 use blake2b_simd::{Hash as Blake2bHash, State};
 use zcash_note_encryption_zsa::{note_bytes::NoteBytes, AEAD_TAG_SIZE};
 
-use crate::bundle::Authorized;
 use crate::{
     action::Action,
     bundle::{
@@ -15,7 +14,7 @@ use crate::{
             ZCASH_ORCHARD_ACTIONS_MEMOS_HASH_PERSONALIZATION,
             ZCASH_ORCHARD_ACTIONS_NONCOMPACT_HASH_PERSONALIZATION,
         },
-        Authorization,
+        Authorization, Authorized,
     },
     domain::{
         compact_action::CompactAction,


### PR DESCRIPTION
This PR updates the code to perform the computation differently for OrchardVanilla and OrchardZSA, similar to the txid_data changes