### PR TITLE
Add NULLIFIER_L constant

### DIFF
--- a/src/circuit/derive_nullifier.rs
+++ b/src/circuit/derive_nullifier.rs
@@ -1,8 +1,9 @@
 //! Derive nullifier logic for the Orchard circuit.
 
+use crate::NULLIFIER_L;
 use halo2_gadgets::utilities::cond_swap::CondSwapChip;
 use halo2_proofs::circuit::AssignedCell;
-use pasta_curves::{arithmetic::CurveExt, pallas};
+use pasta_curves::{arithmetic::CurveAffine, pallas};
 
 pub struct ZsaNullifierParams {
     pub cond_swap_chip: CondSwapChip<pallas::Base>,
@@ -11,8 +12,6 @@ pub struct ZsaNullifierParams {
 
 pub(in crate::circuit) mod gadgets {
     use super::*;
-
-    use group::Curve;
 
     use crate::{
         circuit::gadget::AddInstruction,
@@ -92,7 +91,7 @@ pub(in crate::circuit) mod gadgets {
                 let nullifier_l = Point::new_from_constant(
                     ecc_chip.clone(),
                     layouter.namespace(|| "witness NullifierL constant"),
-                    pallas::Point::hash_to_curve("z.cash:Orchard")(b"L").to_affine(),
+                    pallas::Affine::from_xy(NULLIFIER_L.0, NULLIFIER_L.1).unwrap(),
                 )?;
                 let split_note_nf = nullifier_l.add(layouter.namespace(|| "split_note_nf"), &nf)?;
 

--- a/src/circuit/derive_nullifier.rs
+++ b/src/circuit/derive_nullifier.rs
@@ -1,9 +1,9 @@
 //! Derive nullifier logic for the Orchard circuit.
 
-use crate::NULLIFIER_L;
+use crate::constants::nullifier_l::nullifier_l;
 use halo2_gadgets::utilities::cond_swap::CondSwapChip;
 use halo2_proofs::circuit::AssignedCell;
-use pasta_curves::{arithmetic::CurveAffine, pallas};
+use pasta_curves::pallas;
 
 pub struct ZsaNullifierParams {
     pub cond_swap_chip: CondSwapChip<pallas::Base>,
@@ -91,7 +91,7 @@ pub(in crate::circuit) mod gadgets {
                 let nullifier_l = Point::new_from_constant(
                     ecc_chip.clone(),
                     layouter.namespace(|| "witness NullifierL constant"),
-                    pallas::Affine::from_xy(NULLIFIER_L.0, NULLIFIER_L.1).unwrap(),
+                    nullifier_l(),
                 )?;
                 let split_note_nf = nullifier_l.add(layouter.namespace(|| "split_note_nf"), &nf)?;
 

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -1,5 +1,6 @@
 //! Constants used in the Orchard protocol.
 pub mod fixed_bases;
+pub mod nullifier_l;
 pub mod reference_keys;
 pub mod sinsemilla;
 pub mod util;

--- a/src/constants/nullifier_l.rs
+++ b/src/constants/nullifier_l.rs
@@ -1,0 +1,40 @@
+//! $\mathcal{L}^{\mathsf{Orchard}}$ constant.
+//!
+//! This constant is used to evaluate the nullifier of a split note (ZIP 226).
+
+use pasta_curves::pallas;
+
+/// Constant used as $\mathcal{L}^{\mathsf{Orchard}}$ in DeriveNullifier.
+pub const NULLIFIER_L: (pallas::Base, pallas::Base) = (
+    pallas::Base::from_raw([
+        0x7956_0ba9_2372_5d67,
+        0xcb79_efc2_91c1_b0c8,
+        0xbbed_d606_d1df_737e,
+        0x032e_6e8c_f01d_3ea1,
+    ]),
+    pallas::Base::from_raw([
+        0x8838_95de_f68a_1265,
+        0xd861_4d8d_ab43_e39e,
+        0xf9e6_ebb2_b7b5_6640,
+        0x093c_af7e_c368_376e,
+    ]),
+);
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use group::Curve;
+    use pasta_curves::arithmetic::CurveAffine;
+    use pasta_curves::arithmetic::CurveExt;
+
+    #[test]
+    fn nullifier_l() {
+        let expected_nullifier_l = pallas::Point::hash_to_curve("z.cash:Orchard")(b"L")
+            .to_affine()
+            .coordinates()
+            .unwrap();
+
+        assert_eq!(*expected_nullifier_l.x(), NULLIFIER_L.0);
+        assert_eq!(*expected_nullifier_l.y(), NULLIFIER_L.1);
+    }
+}

--- a/src/constants/nullifier_l.rs
+++ b/src/constants/nullifier_l.rs
@@ -2,7 +2,7 @@
 //!
 //! This constant is used to evaluate the nullifier of a split note (ZIP 226).
 
-use pasta_curves::pallas;
+use pasta_curves::{arithmetic::CurveAffine, pallas};
 
 /// Constant used as $\mathcal{L}^{\mathsf{Orchard}}$ in DeriveNullifier.
 pub const NULLIFIER_L: (pallas::Base, pallas::Base) = (
@@ -19,6 +19,10 @@ pub const NULLIFIER_L: (pallas::Base, pallas::Base) = (
         0x093c_af7e_c368_376e,
     ]),
 );
+
+pub fn nullifier_l() -> pallas::Affine {
+    pallas::Affine::from_xy(NULLIFIER_L.0, NULLIFIER_L.1).unwrap()
+}
 
 #[cfg(test)]
 mod tests {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,7 +41,6 @@ pub use action::Action;
 pub use address::Address;
 pub use bundle::Bundle;
 pub use circuit::Proof;
-pub use constants::nullifier_l::NULLIFIER_L;
 pub use constants::reference_keys::ReferenceKeys;
 pub use constants::MERKLE_DEPTH_ORCHARD as NOTE_COMMITMENT_TREE_DEPTH;
 pub use note::Note;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,7 @@ pub use action::Action;
 pub use address::Address;
 pub use bundle::Bundle;
 pub use circuit::Proof;
+pub use constants::nullifier_l::NULLIFIER_L;
 pub use constants::reference_keys::ReferenceKeys;
 pub use constants::MERKLE_DEPTH_ORCHARD as NOTE_COMMITMENT_TREE_DEPTH;
 pub use note::Note;

--- a/src/note/nullifier.rs
+++ b/src/note/nullifier.rs
@@ -1,15 +1,15 @@
 use group::{ff::PrimeField, Group};
 use halo2_proofs::arithmetic::CurveExt;
 use memuse::DynamicUsage;
-use pasta_curves::{arithmetic::CurveAffine, pallas};
+use pasta_curves::pallas;
 use rand::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
 use super::NoteCommitment;
 use crate::{
+    constants::nullifier_l::nullifier_l,
     keys::NullifierDerivingKey,
     spec::{extract_p, mod_r_p},
-    NULLIFIER_L,
 };
 
 /// A unique nullifier for a note.
@@ -61,8 +61,7 @@ impl Nullifier {
         let k = pallas::Point::hash_to_curve("z.cash:Orchard")(b"K");
 
         let nullifier = k * mod_r_p(nk.prf_nf(rho) + psi) + cm.0;
-        let split_note_nullifier =
-            nullifier + pallas::Affine::from_xy(NULLIFIER_L.0, NULLIFIER_L.1).unwrap();
+        let split_note_nullifier = nullifier + nullifier_l();
 
         let selected_nullifier =
             pallas::Point::conditional_select(&nullifier, &split_note_nullifier, is_split_note);

--- a/src/note/nullifier.rs
+++ b/src/note/nullifier.rs
@@ -1,7 +1,7 @@
 use group::{ff::PrimeField, Group};
 use halo2_proofs::arithmetic::CurveExt;
 use memuse::DynamicUsage;
-use pasta_curves::pallas;
+use pasta_curves::{arithmetic::CurveAffine, pallas};
 use rand::RngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
 
@@ -9,6 +9,7 @@ use super::NoteCommitment;
 use crate::{
     keys::NullifierDerivingKey,
     spec::{extract_p, mod_r_p},
+    NULLIFIER_L,
 };
 
 /// A unique nullifier for a note.
@@ -58,10 +59,10 @@ impl Nullifier {
         is_split_note: Choice,
     ) -> Self {
         let k = pallas::Point::hash_to_curve("z.cash:Orchard")(b"K");
-        let l = pallas::Point::hash_to_curve("z.cash:Orchard")(b"L");
 
         let nullifier = k * mod_r_p(nk.prf_nf(rho) + psi) + cm.0;
-        let split_note_nullifier = nullifier + l;
+        let split_note_nullifier =
+            nullifier + pallas::Affine::from_xy(NULLIFIER_L.0, NULLIFIER_L.1).unwrap();
 
         let selected_nullifier =
             pallas::Point::conditional_select(&nullifier, &split_note_nullifier, is_split_note);


### PR DESCRIPTION
Create a constant NULLIFIER_L to avoid re-evaluating the hash of this constant during each nullifier evaluation.