### PR TITLE
Extend Orchard protocol flavor derives

### DIFF
--- a/src/orchard_flavor.rs
+++ b/src/orchard_flavor.rs
@@ -3,11 +3,11 @@
 use crate::{circuit::OrchardCircuit, domain::OrchardDomainCommon};
 
 /// Represents the "Vanilla" variation ("flavor") of the Orchard protocol.  
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct OrchardVanilla;
 
 /// Represents the "ZSA" variation ("flavor") of the Orchard protocol.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct OrchardZSA;
 
 /// Represents the flavor of the Orchard protocol.


### PR DESCRIPTION
This PR extends the derives for orchard protocol marker types ("flavors") by adding `PartialEq` and `Eq` to `OrchardVanilla` and `OrchardZSA`. This is needed to reuse these marker types directly in Zebra without introducing duplicated types.