### PR TITLE
Move burn to ActionGroup in OrchardZSA

### DIFF
--- a/src/bundle/commitments.rs
+++ b/src/bundle/commitments.rs
@@ -190,7 +190,7 @@ mod tests {
         let sighash = hash_bundle_txid_data(&bundle);
         assert_eq!(
             sighash.to_hex().as_str(),
-            "43cfaab1ffcd8d4752e5e7479fd619c769e3ab459b6f10bbba80533608f546b0"
+            "9491b1104eb2c6f2437f3b20be84be94f94f98a7a19b7aa3a7bc681f6ceb9664"
         );
     }
 
@@ -228,7 +228,7 @@ mod tests {
         let orchard_auth_digest = hash_bundle_auth_data(&bundle);
         assert_eq!(
             orchard_auth_digest.to_hex().as_str(),
-            "c765769582c598930b2825224d5d9246196954fe7cbd3a2be9afa3c542c06387"
+            "4533f1ed5fcc4aa77f9ca3d7352e0f537eaaebb85bc43edc52e6ce33249fcdb3"
         );
     }
 }

--- a/src/domain/orchard_domain_zsa.rs
+++ b/src/domain/orchard_domain_zsa.rs
@@ -71,14 +71,13 @@ impl OrchardDomainCommon for OrchardZSA {
         agh.update(&bundle.anchor().to_bytes());
         agh.update(&bundle.expiry_height().to_le_bytes());
 
-        h.update(agh.finalize().as_bytes());
-
         let mut burn_hasher = hasher(ZCASH_ORCHARD_ZSA_BURN_HASH_PERSONALIZATION);
         for burn_item in bundle.burn() {
             burn_hasher.update(&burn_item.0.to_bytes());
             burn_hasher.update(&burn_item.1.to_bytes());
         }
-        h.update(burn_hasher.finalize().as_bytes());
+        agh.update(burn_hasher.finalize().as_bytes());
+        h.update(agh.finalize().as_bytes());
 
         h.update(&(*bundle.value_balance()).into().to_le_bytes());
         h.finalize()


### PR DESCRIPTION
Commitment structure is reorganized to reflect the change in location of burn field