### PR TITLE
Update with new version of Sinsemilla

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1575,7 +1575,7 @@ dependencies = [
  "reddsa",
  "serde",
  "shardtree",
- "sinsemilla 0.1.0 (git+https://github.com/QED-it/sinsemilla?rev=3542e897d42187878ff9da714f3221cc1774caa7)",
+ "sinsemilla 0.1.0 (git+https://github.com/zcash/sinsemilla?rev=aabb707e862bc3d7b803c77d14e5a771bcee3e8c)",
  "subtle",
  "tracing",
  "visibility",
@@ -2203,7 +2203,7 @@ dependencies = [
 [[package]]
 name = "sinsemilla"
 version = "0.1.0"
-source = "git+https://github.com/QED-it/sinsemilla?rev=3542e897d42187878ff9da714f3221cc1774caa7#3542e897d42187878ff9da714f3221cc1774caa7"
+source = "git+https://github.com/zcash/sinsemilla?rev=aabb707e862bc3d7b803c77d14e5a771bcee3e8c#aabb707e862bc3d7b803c77d14e5a771bcee3e8c"
 dependencies = [
  "group",
  "pasta_curves",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ reddsa = { version = "0.5", default-features = false }
 nonempty = { version = "0.11", default-features = false }
 poseidon = { package = "halo2_poseidon", version = "0.1" }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
-sinsemilla = { git = "https://github.com/QED-it/sinsemilla", rev = "3542e897d42187878ff9da714f3221cc1774caa7", features = ["test-dependencies"] }
+sinsemilla = { git = "https://github.com/zcash/sinsemilla", rev = "aabb707e862bc3d7b803c77d14e5a771bcee3e8c", features = ["test-dependencies"] }
 subtle = { version = "2.3", default-features = false }
 zcash_note_encryption_zsa = { package = "zcash_note_encryption", version = "0.4", git = "https://github.com/QED-it/zcash_note_encryption", branch = "zsa1" }
 incrementalmerkletree = "0.8.1"

--- a/src/note/commitment.rs
+++ b/src/note/commitment.rs
@@ -71,27 +71,25 @@ impl NoteCommitment {
             .into_iter()
             .chain(type_bits.iter().by_vals());
 
+        // Evaluate ZEC note commitment
         let zec_domain = sinsemilla::CommitDomain::new(NOTE_COMMITMENT_PERSONALIZATION);
-        let zsa_domain = sinsemilla::CommitDomain::new_with_personalization(
+        let commit_with_zec_domain = zec_domain.commit(zec_note_bits, &rcm.0);
+
+        // Evaluate ZSA note commitment
+        let zsa_domain = sinsemilla::CommitDomain::new_with_separate_domains(
             NOTE_ZSA_COMMITMENT_PERSONALIZATION,
             NOTE_COMMITMENT_PERSONALIZATION,
         );
+        let commit_with_zsa_domain = zsa_domain.commit(zsa_note_bits, &rcm.0);
 
-        let zec_hash_point = zec_domain.hash_to_point(zec_note_bits);
-        let zsa_hash_point = zsa_domain.hash_to_point(zsa_note_bits);
-
-        // Select the desired hash point in constant-time
-        let hash_point = zsa_hash_point.and_then(|zsa_hash| {
-            zec_hash_point.map(|zec_hash| {
-                pallas::Point::conditional_select(&zsa_hash, &zec_hash, asset.is_native())
+        // Select the desired commitment in constant-time
+        let commit = commit_with_zsa_domain.and_then(|zsa_commit| {
+            commit_with_zec_domain.map(|zec_commit| {
+                pallas::Point::conditional_select(&zsa_commit, &zec_commit, asset.is_native())
             })
         });
 
-        // To evaluate the commitment from the hash_point, we could use either zec_domain or
-        // zsa_domain because they have both the same `R` constant.
-        zec_domain
-            .commit_from_hash_point(hash_point, &rcm.0)
-            .map(NoteCommitment)
+        commit.map(NoteCommitment)
     }
 }
 
@@ -147,40 +145,3 @@ impl PartialEq for ExtractedNoteCommitment {
 }
 
 impl Eq for ExtractedNoteCommitment {}
-
-#[cfg(test)]
-mod tests {
-    use crate::constants::fixed_bases::{
-        NOTE_COMMITMENT_PERSONALIZATION, NOTE_ZSA_COMMITMENT_PERSONALIZATION,
-    };
-    use crate::note::commitment::NoteCommitTrapdoor;
-    use alloc::vec::Vec;
-    use ff::Field;
-    use pasta_curves::pallas;
-    use rand::{rngs::OsRng, Rng};
-
-    #[test]
-    fn test_commit_in_several_steps() {
-        let mut os_rng = OsRng;
-        let msg: Vec<bool> = (0..36).map(|_| os_rng.gen::<bool>()).collect();
-
-        let rcm = NoteCommitTrapdoor(pallas::Scalar::random(&mut os_rng));
-
-        let domain_zec = sinsemilla::CommitDomain::new(NOTE_COMMITMENT_PERSONALIZATION);
-        let domain_zsa = sinsemilla::CommitDomain::new_with_personalization(
-            NOTE_ZSA_COMMITMENT_PERSONALIZATION,
-            NOTE_COMMITMENT_PERSONALIZATION,
-        );
-
-        let expected_commit = domain_zsa.commit(msg.clone().into_iter(), &rcm.0);
-
-        // Evaluating the commitment in one step with `commit` or in two steps with `hash_to_point`
-        // and `commit_from_hash_point` must give the same commitment.
-        let hash_point = domain_zsa.hash_to_point(msg.into_iter());
-        let commit_r_zsa = domain_zsa.commit_from_hash_point(hash_point, &rcm.0);
-        assert_eq!(expected_commit.unwrap(), commit_r_zsa.unwrap());
-
-        // ZEC and ZSA note commitments must use the same R constant
-        assert_eq!(domain_zec.R(), domain_zsa.R());
-    }
-}


### PR DESCRIPTION
- Direct evaluation of note commitments (outside the circuit)
- Rename new_with_personalization by new_with_separate_domains