### PR TITLE
Simplify compute_asset_desc_hash function

### DIFF
--- a/src/bundle/burn_validation.rs
+++ b/src/bundle/burn_validation.rs
@@ -85,7 +85,7 @@ mod tests {
     ///
     /// A tuple `(AssetBase, Amount)` representing the burn list item.
     ///
-    pub fn get_burn_tuple(asset_desc_hash: &[u8; 32], value: u64) -> (AssetBase, NoteValue) {
+    fn get_burn_tuple(asset_desc_hash: &[u8; 32], value: u64) -> (AssetBase, NoteValue) {
         use crate::keys::{IssuanceAuthorizingKey, IssuanceValidatingKey};
 
         let isk = IssuanceAuthorizingKey::from_bytes([1u8; 32]).unwrap();

--- a/src/bundle/burn_validation.rs
+++ b/src/bundle/burn_validation.rs
@@ -71,32 +71,27 @@ mod tests {
 
     use super::*;
 
-    /// Creates an item of bundle burn list for a given asset description and value.
+    /// Creates an item of bundle burn list for a given asset description hash and value.
     ///
     /// This function is deterministic and guarantees that each call with the same parameters
     /// will return the same result. It achieves determinism by using a static `IssuanceAuthorizingKey`.
     ///
     /// # Arguments
     ///
-    /// * `asset_desc` - The asset description string.
+    /// * `asset_desc_hash` - The asset description hash.
     /// * `value` - The value for the burn.
     ///
     /// # Returns
     ///
     /// A tuple `(AssetBase, Amount)` representing the burn list item.
     ///
-    pub fn get_burn_tuple(asset_desc: &[u8], value: u64) -> (AssetBase, NoteValue) {
+    pub fn get_burn_tuple(asset_desc_hash: &[u8; 32], value: u64) -> (AssetBase, NoteValue) {
         use crate::keys::{IssuanceAuthorizingKey, IssuanceValidatingKey};
 
         let isk = IssuanceAuthorizingKey::from_bytes([1u8; 32]).unwrap();
 
         (
-            AssetBase::derive(
-                &IssuanceValidatingKey::from(&isk),
-                &compute_asset_desc_hash(
-                    &NonEmpty::from_slice(asset_desc).expect("asset_desc must not be empty"),
-                ),
-            ),
+            AssetBase::derive(&IssuanceValidatingKey::from(&isk), asset_desc_hash),
             NoteValue::from_raw(value),
         )
     }
@@ -104,9 +99,18 @@ mod tests {
     #[test]
     fn validate_bundle_burn_success() {
         let bundle_burn = vec![
-            get_burn_tuple(b"Asset 1", 10),
-            get_burn_tuple(b"Asset 2", 20),
-            get_burn_tuple(b"Asset 3", 10),
+            get_burn_tuple(
+                &compute_asset_desc_hash(&NonEmpty::from_slice(b"Asset 1").unwrap()),
+                10,
+            ),
+            get_burn_tuple(
+                &compute_asset_desc_hash(&NonEmpty::from_slice(b"Asset 2").unwrap()),
+                20,
+            ),
+            get_burn_tuple(
+                &compute_asset_desc_hash(&NonEmpty::from_slice(b"Asset 3").unwrap()),
+                10,
+            ),
         ];
 
         let result = validate_bundle_burn(&bundle_burn);
@@ -117,9 +121,18 @@ mod tests {
     #[test]
     fn validate_bundle_burn_duplicate_asset() {
         let bundle_burn = vec![
-            get_burn_tuple(b"Asset 1", 10),
-            get_burn_tuple(b"Asset 1", 20),
-            get_burn_tuple(b"Asset 3", 10),
+            get_burn_tuple(
+                &compute_asset_desc_hash(&NonEmpty::from_slice(b"Asset 1").unwrap()),
+                10,
+            ),
+            get_burn_tuple(
+                &compute_asset_desc_hash(&NonEmpty::from_slice(b"Asset 1").unwrap()),
+                20,
+            ),
+            get_burn_tuple(
+                &compute_asset_desc_hash(&NonEmpty::from_slice(b"Asset 3").unwrap()),
+                10,
+            ),
         ];
 
         let result = validate_bundle_burn(&bundle_burn);
@@ -130,9 +143,15 @@ mod tests {
     #[test]
     fn validate_bundle_burn_native_asset() {
         let bundle_burn = vec![
-            get_burn_tuple(b"Asset 1", 10),
+            get_burn_tuple(
+                &compute_asset_desc_hash(&NonEmpty::from_slice(b"Asset 1").unwrap()),
+                10,
+            ),
             (AssetBase::native(), NoteValue::from_raw(20)),
-            get_burn_tuple(b"Asset 3", 10),
+            get_burn_tuple(
+                &compute_asset_desc_hash(&NonEmpty::from_slice(b"Asset 3").unwrap()),
+                10,
+            ),
         ];
 
         let result = validate_bundle_burn(&bundle_burn);
@@ -143,9 +162,18 @@ mod tests {
     #[test]
     fn validate_bundle_burn_zero_value() {
         let bundle_burn = vec![
-            get_burn_tuple(b"Asset 1", 10),
-            get_burn_tuple(b"Asset 2", 0),
-            get_burn_tuple(b"Asset 3", 10),
+            get_burn_tuple(
+                &compute_asset_desc_hash(&NonEmpty::from_slice(b"Asset 1").unwrap()),
+                10,
+            ),
+            get_burn_tuple(
+                &compute_asset_desc_hash(&NonEmpty::from_slice(b"Asset 2").unwrap()),
+                0,
+            ),
+            get_burn_tuple(
+                &compute_asset_desc_hash(&NonEmpty::from_slice(b"Asset 3").unwrap()),
+                10,
+            ),
         ];
 
         let result = validate_bundle_burn(&bundle_burn);

--- a/src/bundle/burn_validation.rs
+++ b/src/bundle/burn_validation.rs
@@ -67,6 +67,7 @@ impl fmt::Display for BurnError {
 mod tests {
     use crate::issuance::compute_asset_desc_hash;
     use crate::value::NoteValue;
+    use nonempty::NonEmpty;
 
     use super::*;
 
@@ -92,7 +93,9 @@ mod tests {
         (
             AssetBase::derive(
                 &IssuanceValidatingKey::from(&isk),
-                &compute_asset_desc_hash(asset_desc).unwrap(),
+                &compute_asset_desc_hash(
+                    &NonEmpty::from_slice(asset_desc).expect("asset_desc must not be empty"),
+                ),
             ),
             NoteValue::from_raw(value),
         )

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -87,10 +87,8 @@ pub struct IssueInfo {
 ///
 /// Panics if `asset_desc` is not well-formed as per Unicode 15.0 specification, Section 3.9, D92.
 pub fn compute_asset_desc_hash(asset_desc: &NonEmpty<u8>) -> [u8; 32] {
-    // Check that asset_desc is well-formed as per Unicode 15.0 specification, Section 3.9, D92
-    let asset_desc_vec = asset_desc.iter().copied().collect::<Vec<u8>>();
-    if String::from_utf8(asset_desc_vec).is_err() {
-        panic!("asset_desc is not well-formed as per Unicode 15.0 specification, Section 3.9, D92");
+    if String::from_utf8(asset_desc.iter().copied().collect::<Vec<u8>>()).is_err() {
+        panic!("asset_desc is not a well-formed Unicode string");
     }
     let mut ah = Params::new()
         .hash_length(32)
@@ -1778,9 +1776,7 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(
-        expected = "asset_desc is not well-formed as per Unicode 15.0 specification, Section 3.9, D92"
-    )]
+    #[should_panic(expected = "asset_desc is not a well-formed Unicode string")]
     fn not_well_formed_utf8() {
         // Not well-formed as per Unicode 15.0 specification, Section 3.9, D92
         let asset_desc: Vec<u8> = vec![0xc0, 0xaf];

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -86,8 +86,8 @@ pub fn compute_asset_desc_hash(asset_desc: &NonEmpty<u8>) -> [u8; 32] {
         .hash_length(32)
         .personal(b"ZSA-AssetDescCRH")
         .to_state();
-    let asset_desc_vec = asset_desc.iter().copied().collect::<Vec<u8>>();
-    ah.update(asset_desc_vec.as_slice());
+    ah.update(&[asset_desc.head]);
+    ah.update(asset_desc.tail.as_slice());
     ah.finalize()
         .as_bytes()
         .try_into()
@@ -763,8 +763,7 @@ mod tests {
         Address, Anchor, Bundle, Note,
     };
     use alloc::collections::BTreeMap;
-    use alloc::string::{String, ToString};
-    use alloc::vec::Vec;
+    use alloc::string::ToString;
     use group::{Group, GroupEncoding};
     use incrementalmerkletree::{Marking, Retention};
     use nonempty::NonEmpty;
@@ -837,16 +836,13 @@ mod tests {
             ..
         } = setup_params();
 
-        let note1_asset_desc_hash = compute_asset_desc_hash(
-            &NonEmpty::from_slice(note1_asset_desc).expect("asset_desc must not be empty"),
-        );
+        let note1_asset_desc_hash =
+            compute_asset_desc_hash(&NonEmpty::from_slice(note1_asset_desc).unwrap());
         let asset = AssetBase::derive(&ik, &note1_asset_desc_hash);
         let note2_asset = note2_asset_desc.map_or(asset, |desc| {
             AssetBase::derive(
                 &ik,
-                &compute_asset_desc_hash(
-                    &NonEmpty::from_slice(desc).expect("asset_desc must not be empty"),
-                ),
+                &compute_asset_desc_hash(&NonEmpty::from_slice(desc).unwrap()),
             )
         });
 
@@ -919,10 +915,7 @@ mod tests {
         );
 
         let action = IssueAction::from_parts(
-            compute_asset_desc_hash(
-                &NonEmpty::from_slice(b"arbitrary asset_desc")
-                    .expect("asset_desc must not be empty"),
-            ),
+            compute_asset_desc_hash(&NonEmpty::from_slice(b"arbitrary asset_desc").unwrap()),
             vec![note1, note2],
             false,
         );
@@ -998,12 +991,8 @@ mod tests {
             ..
         } = setup_params();
 
-        let asset_desc_hash_1 = compute_asset_desc_hash(
-            &NonEmpty::from_slice(b"Halo").expect("asset_desc must not be empty"),
-        );
-        let asset_desc_hash_2 = compute_asset_desc_hash(
-            &NonEmpty::from_slice(b"Halo2").expect("asset_desc must not be empty"),
-        );
+        let asset_desc_hash_1 = compute_asset_desc_hash(&NonEmpty::from_slice(b"Halo").unwrap());
+        let asset_desc_hash_2 = compute_asset_desc_hash(&NonEmpty::from_slice(b"Halo2").unwrap());
 
         let (mut bundle, asset) = IssueBundle::new(
             ik.clone(),
@@ -1089,12 +1078,9 @@ mod tests {
             rng, ik, recipient, ..
         } = setup_params();
 
-        let nft_asset_desc_hash = compute_asset_desc_hash(
-            &NonEmpty::from_slice(b"NFT").expect("asset_desc must not be empty"),
-        );
-        let another_nft_asset_desc_hash = compute_asset_desc_hash(
-            &NonEmpty::from_slice(b"Another NFT").expect("asset_desc must not be empty"),
-        );
+        let nft_asset_desc_hash = compute_asset_desc_hash(&NonEmpty::from_slice(b"NFT").unwrap());
+        let another_nft_asset_desc_hash =
+            compute_asset_desc_hash(&NonEmpty::from_slice(b"Another NFT").unwrap());
 
         let (mut bundle, _) = IssueBundle::new(
             ik,
@@ -1130,9 +1116,7 @@ mod tests {
             ..
         } = setup_params();
 
-        let asset_desc_hash = compute_asset_desc_hash(
-            &NonEmpty::from_slice(b"Frost").expect("asset_desc must not be empty"),
-        );
+        let asset_desc_hash = compute_asset_desc_hash(&NonEmpty::from_slice(b"Frost").unwrap());
 
         let (bundle, _) = IssueBundle::new(
             ik,
@@ -1160,9 +1144,7 @@ mod tests {
             first_nullifier,
         } = setup_params();
 
-        let asset_desc_hash = compute_asset_desc_hash(
-            &NonEmpty::from_slice(b"Sign").expect("asset_desc must not be empty"),
-        );
+        let asset_desc_hash = compute_asset_desc_hash(&NonEmpty::from_slice(b"Sign").unwrap());
 
         let (bundle, _) = IssueBundle::new(
             ik.clone(),
@@ -1195,9 +1177,8 @@ mod tests {
             ..
         } = setup_params();
 
-        let asset_desc_hash = compute_asset_desc_hash(
-            &NonEmpty::from_slice(b"IssueBundle").expect("asset_desc must not be empty"),
-        );
+        let asset_desc_hash =
+            compute_asset_desc_hash(&NonEmpty::from_slice(b"IssueBundle").unwrap());
 
         let (bundle, _) = IssueBundle::new(
             ik,
@@ -1235,9 +1216,7 @@ mod tests {
         // Create a bundle with "normal" note
         let (mut bundle, _) = IssueBundle::new(
             ik,
-            compute_asset_desc_hash(
-                &NonEmpty::from_slice(b"IssueBundle").expect("asset_desc must not be empty"),
-            ),
+            compute_asset_desc_hash(&NonEmpty::from_slice(b"IssueBundle").unwrap()),
             Some(IssueInfo {
                 recipient,
                 value: NoteValue::from_raw(5),
@@ -1252,9 +1231,7 @@ mod tests {
             NoteValue::from_raw(5),
             AssetBase::derive(
                 bundle.ik(),
-                &compute_asset_desc_hash(
-                    &NonEmpty::from_slice(b"zsa_asset").expect("asset_desc must not be empty"),
-                ),
+                &compute_asset_desc_hash(&NonEmpty::from_slice(b"zsa_asset").unwrap()),
             ),
             Rho::zero(),
             &mut rng,
@@ -1281,9 +1258,7 @@ mod tests {
             first_nullifier,
         } = setup_params();
 
-        let asset_desc_hash = compute_asset_desc_hash(
-            &NonEmpty::from_slice(b"Verify").expect("asset_desc must not be empty"),
-        );
+        let asset_desc_hash = compute_asset_desc_hash(&NonEmpty::from_slice(b"Verify").unwrap());
 
         let (bundle, _) = IssueBundle::new(
             ik.clone(),
@@ -1325,9 +1300,8 @@ mod tests {
             first_nullifier,
         } = setup_params();
 
-        let asset_desc_hash = compute_asset_desc_hash(
-            &NonEmpty::from_slice(b"Verify with finalize").expect("asset_desc must not be empty"),
-        );
+        let asset_desc_hash =
+            compute_asset_desc_hash(&NonEmpty::from_slice(b"Verify with finalize").unwrap());
 
         let (mut bundle, _) = IssueBundle::new(
             ik.clone(),
@@ -1371,18 +1345,12 @@ mod tests {
             first_nullifier,
         } = setup_params();
 
-        let asset1_desc_hash = compute_asset_desc_hash(
-            &NonEmpty::from_slice(b"Verify with issued assets 1")
-                .expect("asset_desc must not be empty"),
-        );
-        let asset2_desc_hash = compute_asset_desc_hash(
-            &NonEmpty::from_slice(b"Verify with issued assets 2")
-                .expect("asset_desc must not be empty"),
-        );
-        let asset3_desc_hash = compute_asset_desc_hash(
-            &NonEmpty::from_slice(b"Verify with issued assets 3")
-                .expect("asset_desc must not be empty"),
-        );
+        let asset1_desc_hash =
+            compute_asset_desc_hash(&NonEmpty::from_slice(b"Verify with issued assets 1").unwrap());
+        let asset2_desc_hash =
+            compute_asset_desc_hash(&NonEmpty::from_slice(b"Verify with issued assets 2").unwrap());
+        let asset3_desc_hash =
+            compute_asset_desc_hash(&NonEmpty::from_slice(b"Verify with issued assets 3").unwrap());
 
         let asset1_base = AssetBase::derive(&ik, &asset1_desc_hash);
         let asset2_base = AssetBase::derive(&ik, &asset2_desc_hash);
@@ -1484,9 +1452,8 @@ mod tests {
             first_nullifier,
         } = setup_params();
 
-        let asset_desc_hash = compute_asset_desc_hash(
-            &NonEmpty::from_slice(b"already final").expect("asset_desc must not be empty"),
-        );
+        let asset_desc_hash =
+            compute_asset_desc_hash(&NonEmpty::from_slice(b"already final").unwrap());
 
         let (bundle, _) = IssueBundle::new(
             ik.clone(),
@@ -1551,9 +1518,7 @@ mod tests {
 
         let (bundle, _) = IssueBundle::new(
             ik,
-            crate::issuance::compute_asset_desc_hash(
-                &NonEmpty::from_slice(b"bad sig").expect("asset_desc must not be empty"),
-            ),
+            crate::issuance::compute_asset_desc_hash(&NonEmpty::from_slice(b"bad sig").unwrap()),
             Some(IssueInfo {
                 recipient,
                 value: NoteValue::from_raw(5),
@@ -1593,9 +1558,7 @@ mod tests {
 
         let (bundle, _) = IssueBundle::new(
             ik,
-            compute_asset_desc_hash(
-                &NonEmpty::from_slice(b"Asset description").expect("asset_desc must not be empty"),
-            ),
+            compute_asset_desc_hash(&NonEmpty::from_slice(b"Asset description").unwrap()),
             Some(IssueInfo {
                 recipient,
                 value: NoteValue::from_raw(5),
@@ -1630,9 +1593,7 @@ mod tests {
 
         let (bundle, _) = IssueBundle::new(
             ik,
-            compute_asset_desc_hash(
-                &NonEmpty::from_slice(b"Asset description").expect("asset_desc must not be empty"),
-            ),
+            compute_asset_desc_hash(&NonEmpty::from_slice(b"Asset description").unwrap()),
             Some(IssueInfo {
                 recipient,
                 value: NoteValue::from_raw(5),
@@ -1653,9 +1614,7 @@ mod tests {
             NoteValue::from_raw(5),
             AssetBase::derive(
                 signed.ik(),
-                &compute_asset_desc_hash(
-                    &NonEmpty::from_slice(b"zsa_asset").expect("asset_desc must not be empty"),
-                ),
+                &compute_asset_desc_hash(&NonEmpty::from_slice(b"zsa_asset").unwrap()),
             ),
             Rho::zero(),
             &mut rng,
@@ -1671,9 +1630,7 @@ mod tests {
 
     #[test]
     fn issue_bundle_verify_fail_incorrect_ik() {
-        let asset_desc_hash = compute_asset_desc_hash(
-            &NonEmpty::from_slice(b"Asset").expect("asset_desc must not be empty"),
-        );
+        let asset_desc_hash = compute_asset_desc_hash(&NonEmpty::from_slice(b"Asset").unwrap());
 
         let TestParams {
             mut rng,
@@ -1758,9 +1715,8 @@ mod tests {
         let mut rng = OsRng;
         let (_, _, note) = Note::dummy(&mut rng, None, AssetBase::native());
 
-        let asset_desc_hash = compute_asset_desc_hash(
-            &NonEmpty::from_slice(b"Asset description").expect("asset_desc must not be empty"),
-        );
+        let asset_desc_hash =
+            compute_asset_desc_hash(&NonEmpty::from_slice(b"Asset description").unwrap());
 
         let action = IssueAction::new_with_flags(asset_desc_hash, vec![note], 0u8).unwrap();
         assert_eq!(action.flags(), 0b0000_0000);
@@ -1773,7 +1729,7 @@ mod tests {
     }
 
     #[test]
-    fn issue_bundle_asset_desc_roundtrip() {
+    fn test_get_action_by_desc_hash() {
         let TestParams {
             rng, ik, recipient, ..
         } = setup_params();
@@ -1784,21 +1740,10 @@ mod tests {
             .as_bytes()
             .to_vec();
 
-        let asset_desc_hash_1 = compute_asset_desc_hash(
-            &NonEmpty::from_slice(&asset_desc_1).expect("asset_desc must not be empty"),
-        );
+        let asset_desc_hash_1 =
+            compute_asset_desc_hash(&NonEmpty::from_slice(&asset_desc_1).unwrap());
 
-        // Not well-formed as per Unicode 15.0 specification, Section 3.9, D92
-        let asset_desc_2: Vec<u8> = vec![0xc0, 0xaf];
-
-        let asset_desc_hash_2 = compute_asset_desc_hash(
-            &NonEmpty::from_slice(&asset_desc_2).expect("asset_desc must not be empty"),
-        );
-
-        // Confirm not valid UTF-8
-        assert!(String::from_utf8(asset_desc_2.clone()).is_err());
-
-        let (mut bundle, asset_base_1) = IssueBundle::new(
+        let (bundle, asset_base_1) = IssueBundle::new(
             ik,
             asset_desc_hash_1,
             Some(IssueInfo {
@@ -1809,16 +1754,6 @@ mod tests {
             rng,
         );
 
-        let asset_base_2 = bundle
-            .add_recipient(
-                asset_desc_hash_2,
-                recipient,
-                NoteValue::from_raw(10),
-                true,
-                rng,
-            )
-            .unwrap();
-
         // Checks for the case of UTF-8 encoded asset description.
         let action = bundle.get_action_by_asset(&asset_base_1).unwrap();
         assert_eq!(action.asset_desc_hash(), &asset_desc_hash_1);
@@ -1828,17 +1763,6 @@ mod tests {
         assert_eq!(
             bundle.get_action_by_desc_hash(&asset_desc_hash_1).unwrap(),
             action
-        );
-
-        // Checks for the case on non-UTF-8 encoded asset description.
-        let action2 = bundle.get_action_by_asset(&asset_base_2).unwrap();
-        assert_eq!(action2.asset_desc_hash(), &asset_desc_hash_2);
-        let reference_note = action2.notes.first().unwrap();
-        verify_reference_note(reference_note, asset_base_2);
-        assert_eq!(action2.notes.get(1).unwrap().value().inner(), 10);
-        assert_eq!(
-            bundle.get_action_by_desc_hash(&asset_desc_hash_2).unwrap(),
-            action2
         );
     }
 
@@ -1856,9 +1780,7 @@ mod tests {
         let mut rng = OsRng;
         let asset1 = AssetBase::derive(
             &ik,
-            &compute_asset_desc_hash(
-                &NonEmpty::from_slice(b"zsa_asset1").expect("asset_desc must not be empty"),
-            ),
+            &compute_asset_desc_hash(&NonEmpty::from_slice(b"zsa_asset1").unwrap()),
         );
         let note1 = Note::new(
             recipient,
@@ -1909,12 +1831,8 @@ mod tests {
             .unwrap();
 
         // Create an issue bundle
-        let asset_desc_hash_2 = compute_asset_desc_hash(
-            &NonEmpty::from_slice(b"asset2").expect("asset_desc must not be empty"),
-        );
-        let asset_desc_hash_3 = compute_asset_desc_hash(
-            &NonEmpty::from_slice(b"asset3").expect("asset_desc must not be empty"),
-        );
+        let asset_desc_hash_2 = compute_asset_desc_hash(&NonEmpty::from_slice(b"asset2").unwrap());
+        let asset_desc_hash_3 = compute_asset_desc_hash(&NonEmpty::from_slice(b"asset3").unwrap());
         let (mut bundle, asset) = IssueBundle::new(
             ik,
             asset_desc_hash_2,

--- a/src/note/asset_base.rs
+++ b/src/note/asset_base.rs
@@ -3,6 +3,7 @@ use blake2b_simd::{Hash as Blake2bHash, Params};
 use core::cmp::Ordering;
 use core::hash::{Hash, Hasher};
 use group::{Curve, Group, GroupEncoding};
+use nonempty::NonEmpty;
 use pasta_curves::arithmetic::CurveAffine;
 use pasta_curves::{arithmetic::CurveExt, pallas};
 use rand_core::CryptoRngCore;
@@ -37,8 +38,6 @@ impl Ord for AssetBase {
             .then_with(|| self_coord.y().cmp(other_coord.y()))
     }
 }
-
-pub const MAX_ASSET_DESCRIPTION_SIZE: usize = 512;
 
 /// Personalization for the ZSA asset digest generator
 pub const ZSA_ASSET_DIGEST_PERSONALIZATION: &[u8; 16] = b"ZSA-Asset-Digest";
@@ -121,7 +120,12 @@ impl AssetBase {
     pub(crate) fn random(rng: &mut impl CryptoRngCore) -> Self {
         let isk = IssuanceAuthorizingKey::random(rng);
         let ik = IssuanceValidatingKey::from(&isk);
-        AssetBase::derive(&ik, &compute_asset_desc_hash(b"zsa_asset").unwrap())
+        AssetBase::derive(
+            &ik,
+            &compute_asset_desc_hash(
+                &NonEmpty::from_slice(b"zsa_asset").expect("asset_desc must not be empty"),
+            ),
+        )
     }
 }
 
@@ -130,11 +134,6 @@ impl Hash for AssetBase {
         h.write(&self.to_bytes());
         h.finish();
     }
-}
-
-/// Check that `asset_desc` is of valid size.
-pub fn is_asset_desc_of_valid_size(asset_desc: &[u8]) -> bool {
-    !asset_desc.is_empty() && asset_desc.len() <= MAX_ASSET_DESCRIPTION_SIZE
 }
 
 impl PartialEq for AssetBase {
@@ -200,8 +199,10 @@ pub mod testing {
         let test_vectors = crate::test_vectors::asset_base::TEST_VECTORS;
 
         for tv in test_vectors {
-            let asset_desc_hash =
-                crate::issuance::compute_asset_desc_hash(&tv.description).unwrap();
+            let asset_desc_hash = crate::issuance::compute_asset_desc_hash(
+                &nonempty::NonEmpty::from_slice(&tv.description)
+                    .expect("asset_desc must not be empty"),
+            );
             let calculated_asset_base = AssetBase::derive(
                 &IssuanceValidatingKey::from_bytes(&tv.key).unwrap(),
                 &asset_desc_hash,

--- a/src/note/asset_base.rs
+++ b/src/note/asset_base.rs
@@ -122,9 +122,7 @@ impl AssetBase {
         let ik = IssuanceValidatingKey::from(&isk);
         AssetBase::derive(
             &ik,
-            &compute_asset_desc_hash(
-                &NonEmpty::from_slice(b"zsa_asset").expect("asset_desc must not be empty"),
-            ),
+            &compute_asset_desc_hash(&NonEmpty::from_slice(b"zsa_asset").unwrap()),
         )
     }
 }
@@ -200,8 +198,7 @@ pub mod testing {
 
         for tv in test_vectors {
             let asset_desc_hash = crate::issuance::compute_asset_desc_hash(
-                &nonempty::NonEmpty::from_slice(&tv.description)
-                    .expect("asset_desc must not be empty"),
+                &nonempty::NonEmpty::from_slice(&tv.description).unwrap(),
             );
             let calculated_asset_base = AssetBase::derive(
                 &IssuanceValidatingKey::from_bytes(&tv.key).unwrap(),

--- a/tests/issuance_global_state.rs
+++ b/tests/issuance_global_state.rs
@@ -128,9 +128,7 @@ fn build_issue_bundle(params: &TestParams, data: &[IssueTestNote]) -> IssueBundl
         first_issuance,
     } = data.first().unwrap().clone();
 
-    let asset_desc_hash = compute_asset_desc_hash(
-        &NonEmpty::from_slice(&asset_desc).expect("asset_desc must not be empty"),
-    );
+    let asset_desc_hash = compute_asset_desc_hash(&NonEmpty::from_slice(&asset_desc).unwrap());
 
     let (mut bundle, _) = IssueBundle::new(
         ik.clone(),
@@ -154,9 +152,7 @@ fn build_issue_bundle(params: &TestParams, data: &[IssueTestNote]) -> IssueBundl
         first_issuance,
     } in data.iter().skip(1).cloned()
     {
-        let asset_desc_hash = compute_asset_desc_hash(
-            &NonEmpty::from_slice(&asset_desc).expect("asset_desc must not be empty"),
-        );
+        let asset_desc_hash = compute_asset_desc_hash(&NonEmpty::from_slice(&asset_desc).unwrap());
         bundle
             .add_recipient(
                 asset_desc_hash,
@@ -194,27 +190,19 @@ fn issue_bundle_verify_with_global_state() {
 
     let asset1_base = AssetBase::derive(
         &ik,
-        &compute_asset_desc_hash(
-            &NonEmpty::from_slice(&asset1_desc).expect("asset_desc must not be empty"),
-        ),
+        &compute_asset_desc_hash(&NonEmpty::from_slice(&asset1_desc).unwrap()),
     );
     let asset2_base = AssetBase::derive(
         &ik,
-        &compute_asset_desc_hash(
-            &NonEmpty::from_slice(&asset2_desc).expect("asset_desc must not be empty"),
-        ),
+        &compute_asset_desc_hash(&NonEmpty::from_slice(&asset2_desc).unwrap()),
     );
     let asset3_base = AssetBase::derive(
         &ik,
-        &compute_asset_desc_hash(
-            &NonEmpty::from_slice(&asset3_desc).expect("asset_desc must not be empty"),
-        ),
+        &compute_asset_desc_hash(&NonEmpty::from_slice(&asset3_desc).unwrap()),
     );
     let asset4_base = AssetBase::derive(
         &ik,
-        &compute_asset_desc_hash(
-            &NonEmpty::from_slice(&asset4_desc).expect("asset_desc must not be empty"),
-        ),
+        &compute_asset_desc_hash(&NonEmpty::from_slice(&asset4_desc).unwrap()),
     );
 
     let mut global_state = BTreeMap::new();

--- a/tests/issuance_global_state.rs
+++ b/tests/issuance_global_state.rs
@@ -1,7 +1,7 @@
 extern crate alloc;
 
 use alloc::collections::BTreeMap;
-
+use nonempty::NonEmpty;
 use rand::{rngs::OsRng, RngCore};
 
 use orchard::{
@@ -128,7 +128,9 @@ fn build_issue_bundle(params: &TestParams, data: &[IssueTestNote]) -> IssueBundl
         first_issuance,
     } = data.first().unwrap().clone();
 
-    let asset_desc_hash = compute_asset_desc_hash(&asset_desc).unwrap();
+    let asset_desc_hash = compute_asset_desc_hash(
+        &NonEmpty::from_slice(&asset_desc).expect("asset_desc must not be empty"),
+    );
 
     let (mut bundle, _) = IssueBundle::new(
         ik.clone(),
@@ -152,7 +154,9 @@ fn build_issue_bundle(params: &TestParams, data: &[IssueTestNote]) -> IssueBundl
         first_issuance,
     } in data.iter().skip(1).cloned()
     {
-        let asset_desc_hash = compute_asset_desc_hash(&asset_desc).unwrap();
+        let asset_desc_hash = compute_asset_desc_hash(
+            &NonEmpty::from_slice(&asset_desc).expect("asset_desc must not be empty"),
+        );
         bundle
             .add_recipient(
                 asset_desc_hash,
@@ -188,10 +192,30 @@ fn issue_bundle_verify_with_global_state() {
     let asset3_desc = b"Verify with issued assets 3".to_vec();
     let asset4_desc = b"Verify with issued assets 4".to_vec();
 
-    let asset1_base = AssetBase::derive(&ik, &compute_asset_desc_hash(&asset1_desc).unwrap());
-    let asset2_base = AssetBase::derive(&ik, &compute_asset_desc_hash(&asset2_desc).unwrap());
-    let asset3_base = AssetBase::derive(&ik, &compute_asset_desc_hash(&asset3_desc).unwrap());
-    let asset4_base = AssetBase::derive(&ik, &compute_asset_desc_hash(&asset4_desc).unwrap());
+    let asset1_base = AssetBase::derive(
+        &ik,
+        &compute_asset_desc_hash(
+            &NonEmpty::from_slice(&asset1_desc).expect("asset_desc must not be empty"),
+        ),
+    );
+    let asset2_base = AssetBase::derive(
+        &ik,
+        &compute_asset_desc_hash(
+            &NonEmpty::from_slice(&asset2_desc).expect("asset_desc must not be empty"),
+        ),
+    );
+    let asset3_base = AssetBase::derive(
+        &ik,
+        &compute_asset_desc_hash(
+            &NonEmpty::from_slice(&asset3_desc).expect("asset_desc must not be empty"),
+        ),
+    );
+    let asset4_base = AssetBase::derive(
+        &ik,
+        &compute_asset_desc_hash(
+            &NonEmpty::from_slice(&asset4_desc).expect("asset_desc must not be empty"),
+        ),
+    );
 
     let mut global_state = BTreeMap::new();
 

--- a/tests/zsa.rs
+++ b/tests/zsa.rs
@@ -2,6 +2,7 @@ mod builder;
 
 use crate::builder::verify_bundle;
 use incrementalmerkletree::{Hashable, Marking, Retention};
+use nonempty::NonEmpty;
 use orchard::bundle::Authorized;
 use orchard::issuance::{
     compute_asset_desc_hash, verify_issue_bundle, AwaitingNullifier, IssueBundle, IssueInfo, Signed,
@@ -160,7 +161,9 @@ fn issue_zsa_notes(
 ) -> (Note, Note, Note) {
     let mut rng = OsRng;
     // Create a issuance bundle
-    let asset_desc_hash = compute_asset_desc_hash(asset_descr).unwrap();
+    let asset_desc_hash = compute_asset_desc_hash(
+        &NonEmpty::from_slice(asset_descr).expect("asset_desc must not be empty"),
+    );
     let (mut awaiting_nullifier_bundle, _) = IssueBundle::new(
         keys.ik().clone(),
         asset_desc_hash,

--- a/tests/zsa.rs
+++ b/tests/zsa.rs
@@ -161,9 +161,7 @@ fn issue_zsa_notes(
 ) -> (Note, Note, Note) {
     let mut rng = OsRng;
     // Create a issuance bundle
-    let asset_desc_hash = compute_asset_desc_hash(
-        &NonEmpty::from_slice(asset_descr).expect("asset_desc must not be empty"),
-    );
+    let asset_desc_hash = compute_asset_desc_hash(&NonEmpty::from_slice(asset_descr).unwrap());
     let (mut awaiting_nullifier_bundle, _) = IssueBundle::new(
         keys.ik().clone(),
         asset_desc_hash,


### PR DESCRIPTION
Update compute_asset_desc_hash function
- Now accepts &NonEmpty\<u8\> instead of &[u8]
- Returns [u8; 32] directly (no longer wrapped in Result)
- Panics if asset_desc is not valid UTF-8

Update get_burn_tuple function
- Now takes asset_desc_hash as input instead of asset_desc
- Changes the function’s visibility to private

Cleanup unused code
- Removed unused errors: WrongAssetDescSize, InvalidAssetDescHashLength
- Removed unused constant: MAX_ASSET_DESCRIPTION_SIZE
- Removed unused function: is_asset_desc_of_valid_size