### PR TITLE
Use the last version of zcash_note_encryption

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2723,8 +2723,8 @@ dependencies = [
 
 [[package]]
 name = "zcash_note_encryption"
-version = "0.4.0"
-source = "git+https://github.com/QED-it/zcash_note_encryption?branch=zsa1#76745f00551d4442dee11ad64a8400b75132d18f"
+version = "0.4.1"
+source = "git+https://github.com/QED-it/zcash_note_encryption?branch=zsa1#ba58c2964ff8c96830407bdd6ff284b39171ba62"
 dependencies = [
  "chacha20",
  "chacha20poly1305",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ poseidon = { package = "halo2_poseidon", version = "0.1" }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 sinsemilla = { git = "https://github.com/zcash/sinsemilla", rev = "aabb707e862bc3d7b803c77d14e5a771bcee3e8c", features = ["test-dependencies"] }
 subtle = { version = "2.3", default-features = false }
-zcash_note_encryption_zsa = { package = "zcash_note_encryption", version = "0.4", git = "https://github.com/QED-it/zcash_note_encryption", branch = "zsa1" }
+zcash_note_encryption_zsa = { package = "zcash_note_encryption", git = "https://github.com/QED-it/zcash_note_encryption", branch = "zsa1" }
 incrementalmerkletree = "0.8.1"
 zcash_spec = "0.2.1"
 zip32 = { version = "0.2.0", default-features = false }


### PR DESCRIPTION
To use our latest version of zcash_note_encryption:
- Remove the version of zcash_note_encryption from Cargo.toml
- Update Cargo.lock