### PR TITLE
Update circuit implementation

### DIFF
--- a/benches/circuit.rs
+++ b/benches/circuit.rs
@@ -68,7 +68,7 @@ fn criterion_benchmark<FL: OrchardFlavorBench>(c: &mut Criterion) {
                 b.iter(|| {
                     bundle
                         .authorization()
-                        .create_proof(&pk, &instances, rng)
+                        .create_proof::<FL>(&pk, &instances, rng)
                         .unwrap()
                 });
             });

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1155,6 +1155,9 @@ pub struct Unproven {
 #[cfg(feature = "circuit")]
 impl<S: InProgressSignatures> InProgress<Unproven, S> {
     /// Creates the proof for this bundle.
+    ///
+    /// The `OrchardCircuit` type parameter must match the circuit used when generating the witnesses
+    /// contained in this `Unproven` structure to ensure consistency and correctness of the proof.
     pub fn create_proof<C: OrchardCircuit>(
         &self,
         pk: &ProvingKey,

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -113,7 +113,6 @@ pub trait OrchardCircuit: Sized + Default {
 
     /// Builds the ZSA-specific witnesses for the circuit.
     /// For OrchardVanilla circuits, all fields in `ZsaWitnesses` are `Unknown`.
-    #[allow(clippy::type_complexity)]
     fn build_zsa_witnesses(
         psi_nf: pallas::Base,
         asset: AssetBase,

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -112,7 +112,7 @@ pub trait OrchardCircuit: Sized + Default {
     ) -> Result<(), plonk::Error>;
 
     /// Builds the ZSA-specific witnesses for the circuit.
-    /// For OrchardVanilla circuits, it should return `Value::Unknown()`.
+    /// For OrchardVanilla circuits, it should return `Value::unknown()`.
     fn build_additional_zsa_witnesses(
         psi_nf: pallas::Base,
         asset: AssetBase,

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -113,7 +113,7 @@ pub trait OrchardCircuit: Sized + Default {
 
     /// Builds the ZSA-specific witnesses for the circuit.
     /// For OrchardVanilla circuits, it should return `Unknown`.
-    fn build_zsa_witnesses(
+    fn build_zsa_additional_witnesses(
         psi_nf: pallas::Base,
         asset: AssetBase,
         split_flag: bool,
@@ -156,7 +156,7 @@ pub struct ZsaAdditionalWitnesses {
     pub(crate) split_flag: bool,
 }
 
-pub(crate) fn get_zsa_witnesses_values(
+pub(crate) fn unpack_zsa_additional_witnesses(
     zsa_values: Value<ZsaAdditionalWitnesses>,
 ) -> (Value<pallas::Base>, Value<AssetBase>, Value<bool>) {
     (
@@ -239,7 +239,7 @@ impl Witnesses {
         let rcm_new = output_note.rseed().rcm(&rho_new);
 
         let zsa_additional_witnesses =
-            C::build_zsa_witnesses(psi_nf, spend.note.asset(), spend.split_flag);
+            C::build_zsa_additional_witnesses(psi_nf, spend.note.asset(), spend.split_flag);
 
         Witnesses {
             path: Value::known(spend.merkle_path.auth_path()),

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -149,12 +149,22 @@ pub struct Circuit<C: OrchardCircuit> {
 }
 
 /// The ZSA-specific witnesses.
-///
-/// `ZsaAdditionalWitnesses` is a tuple containing:
-/// - psi_nf
-/// - asset
-/// -split_flag
-pub(crate) type ZsaAdditionalWitnesses = ((pallas::Base, AssetBase), bool);
+#[derive(Clone, Debug)]
+pub struct ZsaAdditionalWitnesses {
+    pub(crate) psi_nf: pallas::Base,
+    pub(crate) asset: AssetBase,
+    pub(crate) split_flag: bool,
+}
+
+pub(crate) fn get_zsa_witnesses_values(
+    zsa_values: Value<ZsaAdditionalWitnesses>,
+) -> (Value<pallas::Base>, Value<AssetBase>, Value<bool>) {
+    (
+        zsa_values.clone().map(|values| values.psi_nf),
+        zsa_values.clone().map(|values| values.asset),
+        zsa_values.clone().map(|values| values.split_flag),
+    )
+}
 
 /// The Orchard Action witnesses
 #[derive(Clone, Debug, Default)]

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -156,7 +156,7 @@ pub struct ZsaAdditionalWitnesses {
     pub(crate) split_flag: bool,
 }
 
-pub(crate) fn unpack_zsa_additional_witnesses(
+fn unpack_zsa_additional_witnesses(
     zsa_values: Value<ZsaAdditionalWitnesses>,
 ) -> (Value<pallas::Base>, Value<AssetBase>, Value<bool>) {
     (

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -117,7 +117,7 @@ pub trait OrchardCircuit: Sized + Default {
         psi_nf: pallas::Base,
         asset: AssetBase,
         split_flag: bool,
-    ) -> ZsaWitnesses;
+    ) -> Option<ZsaWitnesses>;
 }
 
 impl<C: OrchardCircuit> plonk::Circuit<pallas::Base> for Circuit<C> {
@@ -149,12 +149,11 @@ pub struct Circuit<C: OrchardCircuit> {
 }
 
 /// The ZSA-specific witnesses.
-/// For OrchardVanilla circuits, all fields in `ZsaWitnesses` are `Unknown`.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct ZsaWitnesses {
-    pub(crate) psi_nf: Value<pallas::Base>,
-    pub(crate) asset: Value<AssetBase>,
-    pub(crate) split_flag: Value<bool>,
+    pub(crate) psi_nf: pallas::Base,
+    pub(crate) asset: AssetBase,
+    pub(crate) split_flag: bool,
 }
 
 /// The Orchard Action witnesses
@@ -180,9 +179,8 @@ pub struct Witnesses {
     pub(crate) rcm_new: Value<NoteCommitTrapdoor>,
     pub(crate) rcv: Value<ValueCommitTrapdoor>,
 
-    // The fields inside `zsa_witnesses` are only populated for OrchardZSA circuits.
-    // They are `Unknown` in OrchardVanilla circuits.
-    pub(crate) zsa_witnesses: ZsaWitnesses,
+    // TODO
+    pub(crate) zsa_witnesses: Option<ZsaWitnesses>,
 }
 
 impl Witnesses {

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -6,12 +6,6 @@
 use alloc::vec::Vec;
 
 use group::{Curve, GroupEncoding};
-use halo2_gadgets::{
-    ecc::chip::EccConfig,
-    poseidon::Pow5Config as PoseidonConfig,
-    sinsemilla::{chip::SinsemillaConfig, merkle::chip::MerkleConfig},
-    utilities::lookup_range_check::PallasLookupRangeCheck,
-};
 use halo2_proofs::{
     circuit::{floor_planner, Layouter, Value},
     plonk::{
@@ -43,6 +37,12 @@ use crate::{
     spec::NonIdentityPallasPoint,
     tree::{Anchor, MerkleHashOrchard},
     value::{NoteValue, ValueCommitTrapdoor, ValueCommitment},
+};
+use halo2_gadgets::{
+    ecc::chip::EccConfig,
+    poseidon::Pow5Config as PoseidonConfig,
+    sinsemilla::{chip::SinsemillaConfig, merkle::chip::MerkleConfig},
+    utilities::lookup_range_check::PallasLookupRangeCheck,
 };
 
 mod circuit_vanilla;

--- a/src/circuit/circuit_vanilla.rs
+++ b/src/circuit/circuit_vanilla.rs
@@ -38,8 +38,8 @@ use super::{
     commit_ivk::CommitIvkChip,
     gadget::{add_chip::AddChip, assign_free_advice},
     note_commit::NoteCommitChip,
-    OrchardCircuit, ZsaWitnesses, ANCHOR, CMX, CV_NET_X, CV_NET_Y, ENABLE_OUTPUT, ENABLE_SPEND,
-    NF_OLD, RK_X, RK_Y,
+    OrchardCircuit, ZsaAdditionalWitnesses, ANCHOR, CMX, CV_NET_X, CV_NET_Y, ENABLE_OUTPUT,
+    ENABLE_SPEND, NF_OLD, RK_X, RK_Y,
 };
 
 impl OrchardCircuit for OrchardVanilla {
@@ -611,7 +611,7 @@ impl OrchardCircuit for OrchardVanilla {
         Ok(())
     }
 
-    /// For OrchardVanilla circuits, `build_zsa_witnesses` returns None.
+    /// For OrchardVanilla circuits, `build_zsa_witnesses` returns `Unknown`.
     ///
     /// # Panics
     /// Panics if the asset is not a native asset or if `split_flag` is true.
@@ -619,14 +619,14 @@ impl OrchardCircuit for OrchardVanilla {
         _: pallas::Base,
         asset: AssetBase,
         split_flag: bool,
-    ) -> Option<ZsaWitnesses> {
+    ) -> Value<ZsaAdditionalWitnesses> {
         if !(bool::from(asset.is_native())) {
             panic!("asset must be native asset in OrchardVanilla circuit");
         }
         if split_flag {
             panic!("split_flag must be false in OrchardVanilla circuit");
         }
-        None
+        Value::unknown()
     }
 }
 
@@ -696,7 +696,7 @@ mod tests {
                     rcm_new: Value::known(output_note.rseed().rcm(&output_note.rho())),
                     rcv: Value::known(rcv),
 
-                    zsa_witnesses: None,
+                    zsa_additional_witnesses: Value::unknown(),
                 },
                 phantom: core::marker::PhantomData,
             },

--- a/src/circuit/circuit_vanilla.rs
+++ b/src/circuit/circuit_vanilla.rs
@@ -611,11 +611,11 @@ impl OrchardCircuit for OrchardVanilla {
         Ok(())
     }
 
-    /// For OrchardVanilla circuits, `build_zsa_witnesses` returns `Unknown`.
+    /// For OrchardVanilla circuits, `build_zsa_additional_witnesses` returns `Unknown`.
     ///
     /// # Panics
     /// Panics if the asset is not a native asset or if `split_flag` is true.
-    fn build_zsa_witnesses(
+    fn build_zsa_additional_witnesses(
         _: pallas::Base,
         asset: AssetBase,
         split_flag: bool,

--- a/src/circuit/circuit_vanilla.rs
+++ b/src/circuit/circuit_vanilla.rs
@@ -674,7 +674,7 @@ mod tests {
         let anchor = path.root(spent_note.commitment().into());
 
         (
-            Circuit::<OrchardVanilla> {
+            Circuit {
                 witnesses: Witnesses {
                     path: Value::known(path.auth_path()),
                     pos: Value::known(path.position()),

--- a/src/circuit/circuit_vanilla.rs
+++ b/src/circuit/circuit_vanilla.rs
@@ -30,6 +30,7 @@ use crate::{
     circuit::value_commit_orchard::gadgets::value_commit_orchard,
     circuit::{Config, Witnesses},
     constants::{OrchardFixedBases, OrchardFixedBasesFull, OrchardHashDomains},
+    note::AssetBase,
     orchard_flavor::OrchardVanilla,
 };
 
@@ -40,7 +41,6 @@ use super::{
     OrchardCircuit, ZsaWitnesses, ANCHOR, CMX, CV_NET_X, CV_NET_Y, ENABLE_OUTPUT, ENABLE_SPEND,
     NF_OLD, RK_X, RK_Y,
 };
-use crate::note::AssetBase;
 
 impl OrchardCircuit for OrchardVanilla {
     type Config = Config<PallasLookupRangeCheckConfig>;
@@ -611,6 +611,11 @@ impl OrchardCircuit for OrchardVanilla {
         Ok(())
     }
 
+    /// For OrchardVanilla circuits, `build_zsa_witnesses` returns a `ZsaWitnesses` with `Unknown`
+    /// values.
+    ///
+    /// # Panics
+    /// Panics if the asset is not a native asset or if `split_flag` is true.
     fn build_zsa_witnesses(_: pallas::Base, asset: AssetBase, split_flag: bool) -> ZsaWitnesses {
         if !(bool::from(asset.is_native())) {
             panic!("asset must be native asset in OrchardVanilla circuit");

--- a/src/circuit/circuit_vanilla.rs
+++ b/src/circuit/circuit_vanilla.rs
@@ -380,7 +380,7 @@ impl OrchardCircuit for OrchardVanilla {
         // Nullifier integrity (https://p.z.cash/ZKS:action-nullifier-integrity).
         let nf_old = {
             let nf_old = derive_nullifier(
-                &mut layouter.namespace(|| "nf_old = DeriveNullifier_nk(rho_old, psi_old, cm_old)"),
+                layouter.namespace(|| "nf_old = DeriveNullifier_nk(rho_old, psi_old, cm_old)"),
                 config.poseidon_chip(),
                 config.add_chip(),
                 ecc_chip.clone(),
@@ -652,9 +652,7 @@ mod tests {
         value::{ValueCommitTrapdoor, ValueCommitment},
     };
 
-    type OrchardCircuitVanilla = Circuit<OrchardVanilla>;
-
-    fn generate_circuit_instance<R: RngCore>(mut rng: R) -> (OrchardCircuitVanilla, Instance) {
+    fn generate_circuit_instance<R: RngCore>(mut rng: R) -> (Circuit<OrchardVanilla>, Instance) {
         let (_, fvk, spent_note) = Note::dummy(&mut rng, None, AssetBase::native());
 
         let sender_address = spent_note.recipient();
@@ -677,7 +675,7 @@ mod tests {
         let anchor = path.root(spent_note.commitment().into());
 
         (
-            OrchardCircuitVanilla {
+            Circuit::<OrchardVanilla> {
                 witnesses: Witnesses {
                     path: Value::known(path.auth_path()),
                     pos: Value::known(path.position()),
@@ -880,7 +878,7 @@ mod tests {
             .titled("Orchard Action Circuit", ("sans-serif", 60))
             .unwrap();
 
-        let circuit = OrchardCircuitVanilla {
+        let circuit = Circuit::<OrchardVanilla> {
             witnesses: Witnesses::default(),
             phantom: core::marker::PhantomData,
         };

--- a/src/circuit/circuit_vanilla.rs
+++ b/src/circuit/circuit_vanilla.rs
@@ -38,7 +38,7 @@ use super::{
     commit_ivk::CommitIvkChip,
     gadget::{add_chip::AddChip, assign_free_advice},
     note_commit::NoteCommitChip,
-    OrchardCircuit, ZsaAdditionalWitnesses, ANCHOR, CMX, CV_NET_X, CV_NET_Y, ENABLE_OUTPUT,
+    AdditionalZsaWitnesses, OrchardCircuit, ANCHOR, CMX, CV_NET_X, CV_NET_Y, ENABLE_OUTPUT,
     ENABLE_SPEND, NF_OLD, RK_X, RK_Y,
 };
 
@@ -611,15 +611,15 @@ impl OrchardCircuit for OrchardVanilla {
         Ok(())
     }
 
-    /// For OrchardVanilla circuits, `build_zsa_additional_witnesses` returns `Unknown`.
+    /// For OrchardVanilla circuits, `build_additional_zsa_witnesses` returns `Value::unknown()`.
     ///
     /// # Panics
     /// Panics if the asset is not a native asset or if `split_flag` is true.
-    fn build_zsa_additional_witnesses(
+    fn build_additional_zsa_witnesses(
         _: pallas::Base,
         asset: AssetBase,
         split_flag: bool,
-    ) -> Value<ZsaAdditionalWitnesses> {
+    ) -> Value<AdditionalZsaWitnesses> {
         if !(bool::from(asset.is_native())) {
             panic!("asset must be native asset in OrchardVanilla circuit");
         }
@@ -696,7 +696,7 @@ mod tests {
                     rcm_new: Value::known(output_note.rseed().rcm(&output_note.rho())),
                     rcv: Value::known(rcv),
 
-                    zsa_additional_witnesses: Value::unknown(),
+                    ..Witnesses::default()
                 },
                 phantom: core::marker::PhantomData,
             },

--- a/src/circuit/circuit_vanilla.rs
+++ b/src/circuit/circuit_vanilla.rs
@@ -611,23 +611,22 @@ impl OrchardCircuit for OrchardVanilla {
         Ok(())
     }
 
-    /// For OrchardVanilla circuits, `build_zsa_witnesses` returns a `ZsaWitnesses` with `Unknown`
-    /// values.
+    /// For OrchardVanilla circuits, `build_zsa_witnesses` returns None.
     ///
     /// # Panics
     /// Panics if the asset is not a native asset or if `split_flag` is true.
-    fn build_zsa_witnesses(_: pallas::Base, asset: AssetBase, split_flag: bool) -> ZsaWitnesses {
+    fn build_zsa_witnesses(
+        _: pallas::Base,
+        asset: AssetBase,
+        split_flag: bool,
+    ) -> Option<ZsaWitnesses> {
         if !(bool::from(asset.is_native())) {
             panic!("asset must be native asset in OrchardVanilla circuit");
         }
         if split_flag {
             panic!("split_flag must be false in OrchardVanilla circuit");
         }
-        ZsaWitnesses {
-            psi_nf: Value::unknown(),
-            asset: Value::unknown(),
-            split_flag: Value::unknown(),
-        }
+        None
     }
 }
 
@@ -641,7 +640,7 @@ mod tests {
     use pasta_curves::pallas;
     use rand::{rngs::OsRng, RngCore};
 
-    use crate::circuit::{Witnesses, ZsaWitnesses};
+    use crate::circuit::Witnesses;
     use crate::{
         bundle::Flags,
         circuit::{Circuit, Instance, Proof, ProvingKey, VerifyingKey, K},
@@ -697,11 +696,7 @@ mod tests {
                     rcm_new: Value::known(output_note.rseed().rcm(&output_note.rho())),
                     rcv: Value::known(rcv),
 
-                    zsa_witnesses: ZsaWitnesses {
-                        psi_nf: Value::unknown(),
-                        asset: Value::unknown(),
-                        split_flag: Value::unknown(),
-                    },
+                    zsa_witnesses: None,
                 },
                 phantom: core::marker::PhantomData,
             },

--- a/src/circuit/circuit_zsa.rs
+++ b/src/circuit/circuit_zsa.rs
@@ -526,7 +526,7 @@ impl OrchardCircuit for OrchardZSA {
         // [zip226]: https://zips.z.cash/zip-0226
         let nf_old = {
             let nf_old = derive_nullifier(
-                &mut layouter.namespace(|| "nf_old = DeriveNullifier_nk(rho_old, psi_nf, cm_old)"),
+                layouter.namespace(|| "nf_old = DeriveNullifier_nk(rho_old, psi_nf, cm_old)"),
                 config.poseidon_chip(),
                 config.add_chip(),
                 ecc_chip.clone(),
@@ -878,11 +878,10 @@ mod tests {
     use rand::{rngs::OsRng, RngCore};
     use rand_core::CryptoRngCore;
 
-    use crate::circuit::Witnesses;
     use crate::{
         builder::SpendInfo,
         bundle::Flags,
-        circuit::{Circuit, Instance, Proof, ProvingKey, VerifyingKey, ZsaWitnesses, K},
+        circuit::{Circuit, Instance, Proof, ProvingKey, VerifyingKey, Witnesses, ZsaWitnesses, K},
         keys::{FullViewingKey, Scope, SpendValidatingKey, SpendingKey},
         note::{commitment::NoteCommitTrapdoor, AssetBase, Note, NoteCommitment, Nullifier, Rho},
         orchard_flavor::OrchardZSA,
@@ -891,9 +890,7 @@ mod tests {
         value::{NoteValue, ValueCommitTrapdoor, ValueCommitment},
     };
 
-    type OrchardCircuitZSA = Circuit<OrchardZSA>;
-
-    fn generate_dummy_circuit_instance<R: RngCore>(mut rng: R) -> (OrchardCircuitZSA, Instance) {
+    fn generate_dummy_circuit_instance<R: RngCore>(mut rng: R) -> (Circuit<OrchardZSA>, Instance) {
         let (_, fvk, spent_note) = Note::dummy(&mut rng, None, AssetBase::native());
 
         let sender_address = spent_note.recipient();
@@ -918,7 +915,7 @@ mod tests {
         let psi_old = spent_note.rseed().psi(&spent_note.rho());
 
         (
-            OrchardCircuitZSA {
+            Circuit::<OrchardZSA> {
                 witnesses: Witnesses {
                     path: Value::known(path.auth_path()),
                     pos: Value::known(path.position()),
@@ -1125,7 +1122,7 @@ mod tests {
             .titled("Orchard Action Circuit", ("sans-serif", 60))
             .unwrap();
 
-        let circuit = OrchardCircuitZSA {
+        let circuit = Circuit::<OrchardZSA> {
             witnesses: Witnesses::default(),
             phantom: core::marker::PhantomData,
         };
@@ -1137,7 +1134,7 @@ mod tests {
     }
 
     fn check_proof_of_orchard_circuit(
-        circuit: &OrchardCircuitZSA,
+        circuit: &Circuit<OrchardZSA>,
         instance: &Instance,
         should_pass: bool,
     ) {
@@ -1163,7 +1160,7 @@ mod tests {
         is_native_asset: bool,
         split_flag: bool,
         mut rng: R,
-    ) -> (OrchardCircuitZSA, Instance) {
+    ) -> (Circuit<OrchardZSA>, Instance) {
         // Create asset
         let asset_base = if is_native_asset {
             AssetBase::native()
@@ -1243,7 +1240,7 @@ mod tests {
         };
 
         (
-            OrchardCircuitZSA {
+            Circuit::<OrchardZSA> {
                 witnesses: Witnesses::from_action_context_unchecked::<OrchardZSA>(
                     spend_info,
                     output_note,
@@ -1321,7 +1318,7 @@ mod tests {
 
                 // Set cm_old to be a random NoteCommitment
                 // The proof should fail
-                let circuit_wrong_cm_old = OrchardCircuitZSA {
+                let circuit_wrong_cm_old = Circuit::<OrchardZSA> {
                     witnesses: Witnesses {
                         path: circuit.witnesses.path,
                         pos: circuit.witnesses.pos,
@@ -1384,7 +1381,7 @@ mod tests {
                 // If split_flag = 0 , set psi_nf to be a random Pallas base element
                 // The proof should fail
                 if !split_flag {
-                    let circuit_wrong_psi_nf = OrchardCircuitZSA {
+                    let circuit_wrong_psi_nf = Circuit::<OrchardZSA> {
                         witnesses: Witnesses {
                             path: circuit.witnesses.path,
                             pos: circuit.witnesses.pos,

--- a/src/circuit/circuit_zsa.rs
+++ b/src/circuit/circuit_zsa.rs
@@ -920,7 +920,7 @@ mod tests {
         let psi_old = spent_note.rseed().psi(&spent_note.rho());
 
         (
-            Circuit::<OrchardZSA> {
+            Circuit {
                 witnesses: Witnesses {
                     path: Value::known(path.auth_path()),
                     pos: Value::known(path.position()),

--- a/src/circuit/circuit_zsa.rs
+++ b/src/circuit/circuit_zsa.rs
@@ -31,8 +31,8 @@ use super::{
     commit_ivk::CommitIvkChip,
     derive_nullifier::ZsaNullifierParams,
     gadget::{add_chip::AddChip, assign_free_advice, assign_is_native_asset, assign_split_flag},
-    get_zsa_witnesses_values,
     note_commit::NoteCommitChip,
+    unpack_zsa_additional_witnesses,
     value_commit_orchard::ZsaValueCommitParams,
     OrchardCircuit, ZsaAdditionalWitnesses, ANCHOR, CMX, CV_NET_X, CV_NET_Y, ENABLE_OUTPUT,
     ENABLE_SPEND, ENABLE_ZSA, NF_OLD, RK_X, RK_Y,
@@ -338,7 +338,7 @@ impl OrchardCircuit for OrchardZSA {
 
         // Unzip the ZSA witnesses.
         let (psi_nf_value, asset_value, split_flag_value) =
-            get_zsa_witnesses_values(circuit.zsa_additional_witnesses.clone());
+            unpack_zsa_additional_witnesses(circuit.zsa_additional_witnesses.clone());
 
         // Construct the ECC chip.
         let ecc_chip = config.ecc_chip();
@@ -855,7 +855,7 @@ impl OrchardCircuit for OrchardZSA {
         Ok(())
     }
 
-    fn build_zsa_witnesses(
+    fn build_zsa_additional_witnesses(
         psi_nf: pallas::Base,
         asset: AssetBase,
         split_flag: bool,

--- a/src/circuit/circuit_zsa.rs
+++ b/src/circuit/circuit_zsa.rs
@@ -336,7 +336,7 @@ impl OrchardCircuit for OrchardZSA {
         // Load the Sinsemilla generator lookup table used by the whole circuit.
         SinsemillaChip::load(config.sinsemilla_config_1.clone(), &mut layouter)?;
 
-        // Unzip the ZSA witnesses.
+        // Unpack the ZSA witnesses.
         let (psi_nf_value, asset_value, split_flag_value) =
             unpack_zsa_additional_witnesses(circuit.zsa_additional_witnesses.clone());
 

--- a/src/circuit/derive_nullifier.rs
+++ b/src/circuit/derive_nullifier.rs
@@ -40,7 +40,7 @@ pub(in crate::circuit) mod gadgets {
             Var = AssignedCell<pallas::Base, pallas::Base>,
         >,
     >(
-        layouter: &mut impl Layouter<pallas::Base>,
+        mut layouter: impl Layouter<pallas::Base>,
         poseidon_chip: PoseidonChip,
         add_chip: AddChip,
         ecc_chip: EccChip,

--- a/src/circuit/gadget.rs
+++ b/src/circuit/gadget.rs
@@ -1,37 +1,25 @@
 //! Common gadgets and functions used in the Orchard circuit.
 
 use ff::Field;
+use pasta_curves::pallas;
+
+use super::{commit_ivk::CommitIvkChip, note_commit::NoteCommitChip, Config};
+use crate::{
+    constants::{OrchardCommitDomains, OrchardFixedBases, OrchardHashDomains},
+    note::AssetBase,
+};
 use halo2_gadgets::{
     ecc::chip::EccChip,
     poseidon::Pow5Chip as PoseidonChip,
     sinsemilla::{chip::SinsemillaChip, merkle::chip::MerkleChip},
     utilities::{cond_swap::CondSwapChip, lookup_range_check::PallasLookupRangeCheck},
 };
-use pasta_curves::pallas;
-
-use crate::{
-    circuit::{commit_ivk::CommitIvkChip, note_commit::NoteCommitChip, Config},
-    constants::{OrchardCommitDomains, OrchardFixedBases, OrchardHashDomains},
-    note::AssetBase,
-};
 use halo2_proofs::{
-    circuit::Value,
-    circuit::{AssignedCell, Chip, Layouter},
+    circuit::{AssignedCell, Chip, Layouter, Value},
     plonk::{self, Advice, Assigned, Column},
 };
 
 pub(in crate::circuit) mod add_chip;
-
-/// An instruction set for adding two circuit words (field elements).
-pub(in crate::circuit) trait AddInstruction<F: Field>: Chip<F> {
-    /// Constraints `a + b` and returns the sum.
-    fn add(
-        &self,
-        layouter: impl Layouter<F>,
-        a: &AssignedCell<F, F>,
-        b: &AssignedCell<F, F>,
-    ) -> Result<AssignedCell<F, F>, plonk::Error>;
-}
 
 impl<Lookup: PallasLookupRangeCheck> Config<Lookup> {
     pub(super) fn add_chip(&self) -> add_chip::AddChip {
@@ -85,6 +73,17 @@ impl<Lookup: PallasLookupRangeCheck> Config<Lookup> {
     pub(super) fn cond_swap_chip(&self) -> CondSwapChip<pallas::Base> {
         CondSwapChip::construct(self.merkle_config_1.cond_swap_config.clone())
     }
+}
+
+/// An instruction set for adding two circuit words (field elements).
+pub(in crate::circuit) trait AddInstruction<F: Field>: Chip<F> {
+    /// Constraints `a + b` and returns the sum.
+    fn add(
+        &self,
+        layouter: impl Layouter<F>,
+        a: &AssignedCell<F, F>,
+        b: &AssignedCell<F, F>,
+    ) -> Result<AssignedCell<F, F>, plonk::Error>;
 }
 
 /// Witnesses the given value in a standalone region.

--- a/src/circuit/gadget/add_chip.rs
+++ b/src/circuit/gadget/add_chip.rs
@@ -1,4 +1,4 @@
-//! 'Add' chip implemetation.
+//! `Add` chip implemetation.
 
 use halo2_proofs::{
     circuit::{AssignedCell, Chip, Layouter},

--- a/src/orchard_flavor.rs
+++ b/src/orchard_flavor.rs
@@ -11,30 +11,12 @@ pub struct OrchardVanilla;
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct OrchardZSA;
 
-/// Represents the flavor of the Orchard protocol.
-///
-/// This enables conditional execution during runtime based on the flavor of the Orchard protocol.
-#[derive(Clone, Debug)]
-pub enum Flavor {
-    /// The "Vanilla" flavor of the Orchard protocol.
-    OrchardVanillaFlavor,
-    /// The "ZSA" flavor of the Orchard protocol.
-    OrchardZSAFlavor,
-}
-
 /// A trait binding the common functionality between different Orchard protocol flavors.
 #[cfg(feature = "circuit")]
-pub trait OrchardFlavor: OrchardDomainCommon + OrchardCircuit {
-    /// Flavor of the Orchard protocol.
-    const FLAVOR: Flavor;
-}
+pub trait OrchardFlavor: OrchardDomainCommon + OrchardCircuit {}
 
 #[cfg(feature = "circuit")]
-impl OrchardFlavor for OrchardVanilla {
-    const FLAVOR: Flavor = Flavor::OrchardVanillaFlavor;
-}
+impl OrchardFlavor for OrchardVanilla {}
 
 #[cfg(feature = "circuit")]
-impl OrchardFlavor for OrchardZSA {
-    const FLAVOR: Flavor = Flavor::OrchardZSAFlavor;
-}
+impl OrchardFlavor for OrchardZSA {}

--- a/src/pczt/prover.rs
+++ b/src/pczt/prover.rs
@@ -86,7 +86,7 @@ impl super::Bundle {
                     .ok_or(ProverError::MissingSpendAuthRandomizer)?;
                 let rcv = action.rcv.ok_or(ProverError::MissingValueCommitTrapdoor)?;
 
-                Witnesses::from_action_context(spend, output_note, alpha, rcv)
+                Witnesses::from_action_context::<FL>(spend, output_note, alpha, rcv)
                     .ok_or(ProverError::RhoMismatch)
                     .map(|witnesses| Circuit::<FL> {
                         witnesses,


### PR DESCRIPTION
OrchardFlavor modifications:
- Remove circuit_flavor field from Unproven struct
- Remove const FLAVOR from OrchardFlavor trait

OrchardCircuit modifications:
- Create ZsaAdditionalWitnesses struct.
- When creating witnesses from OrchardVanilla circuits, panic if the asset is not the native asset or if split_flag is not false.

Other modifications:
- Reduce diff with upstream
- Remove some types to improve readability