### PR TITLE
Pczt without domain

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -27,6 +27,9 @@ use crate::{
     Proof,
 };
 
+use crate::domain::OrchardDomainCommon;
+use crate::note::TransmittedNoteCiphertext;
+use crate::pczt::PcztTransmittedNoteCiphertext;
 #[cfg(feature = "circuit")]
 use {
     crate::{
@@ -37,9 +40,6 @@ use {
     },
     nonempty::NonEmpty,
 };
-use crate::domain::OrchardDomainCommon;
-use crate::note::TransmittedNoteCiphertext;
-use crate::pczt::PcztTransmittedNoteCiphertext;
 
 const MIN_ACTIONS: usize = 2;
 
@@ -448,8 +448,9 @@ impl OutputInfo {
     ) -> crate::pczt::Output {
         let (note, cmx, encrypted_note) = self.build::<D>(cv_net, nf_old, rng);
 
-        let encrypted_note = PcztTransmittedNoteCiphertext::from_transmitted_note_ciphertext(encrypted_note);
-        
+        let encrypted_note =
+            PcztTransmittedNoteCiphertext::from_transmitted_note_ciphertext(encrypted_note);
+
         crate::pczt::Output {
             cmx,
             encrypted_note,
@@ -537,10 +538,7 @@ impl ActionInfo {
         )
     }
 
-    fn build_for_pczt<D: OrchardDomainCommon>(
-        self,
-        mut rng: impl RngCore,
-    ) -> crate::pczt::Action {
+    fn build_for_pczt<D: OrchardDomainCommon>(self, mut rng: impl RngCore) -> crate::pczt::Action {
         assert_eq!(
             self.spend.note.asset(),
             self.output.asset,
@@ -550,7 +548,9 @@ impl ActionInfo {
         let cv_net = ValueCommitment::derive(v_net, self.rcv, self.spend.note.asset());
 
         let spend = self.spend.into_pczt(&mut rng);
-        let output = self.output.into_pczt::<D>(&cv_net, spend.nullifier, &mut rng);
+        let output = self
+            .output
+            .into_pczt::<D>(&cv_net, spend.nullifier, &mut rng);
 
         crate::pczt::Action {
             cv_net,

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -217,6 +217,12 @@ impl IssueAction {
 /// Defines the authorization type of an Issue bundle.
 pub trait IssueAuth: fmt::Debug + Clone {}
 
+/// Marker type for a bundle that contains no authorizing data.
+#[derive(Clone, Debug)]
+pub struct EffectsOnly;
+
+impl IssueAuth for EffectsOnly {}
+
 /// Marker for an unsigned bundle with no nullifier and no sighash injected.
 #[derive(Debug, Clone)]
 pub struct AwaitingNullifier;

--- a/src/pczt.rs
+++ b/src/pczt.rs
@@ -15,9 +15,7 @@ use crate::{
     bundle::Flags,
     domain::OrchardDomainCommon,
     keys::{FullViewingKey, SpendingKey},
-    note::{
-        AssetBase, ExtractedNoteCommitment, Nullifier, RandomSeed, Rho,
-    },
+    note::{AssetBase, ExtractedNoteCommitment, Nullifier, RandomSeed, Rho},
     primitives::redpallas::{self, Binding, SpendAuth},
     tree::MerklePath,
     value::{NoteValue, ValueCommitTrapdoor, ValueCommitment, ValueSum},
@@ -45,8 +43,8 @@ mod signer;
 pub use signer::SignerError;
 
 mod tx_extractor;
-pub use tx_extractor::{TxExtractorError, Unbound};
 use crate::note::TransmittedNoteCiphertext;
+pub use tx_extractor::{TxExtractorError, Unbound};
 
 /// PCZT fields that are specific to producing the transaction's Orchard bundle (if any).
 ///
@@ -379,9 +377,10 @@ pub struct PcztTransmittedNoteCiphertext {
 }
 
 impl PcztTransmittedNoteCiphertext {
-    
     /// Converts `TransmittedNoteCiphertext` into `PcztTransmittedNoteCiphertext`
-    pub fn from_transmitted_note_ciphertext<D: OrchardDomainCommon>(transmitted: TransmittedNoteCiphertext<D>) -> Self {
+    pub fn from_transmitted_note_ciphertext<D: OrchardDomainCommon>(
+        transmitted: TransmittedNoteCiphertext<D>,
+    ) -> Self {
         PcztTransmittedNoteCiphertext {
             epk_bytes: transmitted.epk_bytes,
             enc_ciphertext: transmitted.enc_ciphertext.as_ref().to_vec(),
@@ -390,10 +389,13 @@ impl PcztTransmittedNoteCiphertext {
     }
 
     /// Converts `PcztTransmittedNoteCiphertext` into `TransmittedNoteCiphertext`
-    pub fn into_transmitted_note_ciphertext<D: OrchardDomainCommon>(self) -> TransmittedNoteCiphertext<D> {
+    pub fn into_transmitted_note_ciphertext<D: OrchardDomainCommon>(
+        self,
+    ) -> TransmittedNoteCiphertext<D> {
         TransmittedNoteCiphertext {
             epk_bytes: self.epk_bytes,
-            enc_ciphertext: D::NoteCiphertextBytes::from_slice(self.enc_ciphertext.as_ref()).expect("enc_ciphertext is corrupt"),
+            enc_ciphertext: D::NoteCiphertextBytes::from_slice(self.enc_ciphertext.as_ref())
+                .expect("enc_ciphertext is corrupt"),
             out_ciphertext: self.out_ciphertext,
         }
     }

--- a/src/pczt/io_finalizer.rs
+++ b/src/pczt/io_finalizer.rs
@@ -4,8 +4,8 @@ use rand::{CryptoRng, RngCore};
 
 use super::SignerError;
 use crate::{
-    bundle::derive_bvk_raw, keys::SpendAuthorizingKey,
-    primitives::redpallas, value::ValueCommitTrapdoor,
+    bundle::derive_bvk_raw, keys::SpendAuthorizingKey, primitives::redpallas,
+    value::ValueCommitTrapdoor,
 };
 
 impl super::Bundle {

--- a/src/pczt/io_finalizer.rs
+++ b/src/pczt/io_finalizer.rs
@@ -4,11 +4,11 @@ use rand::{CryptoRng, RngCore};
 
 use super::SignerError;
 use crate::{
-    bundle::derive_bvk_raw, domain::OrchardDomainCommon, keys::SpendAuthorizingKey,
+    bundle::derive_bvk_raw, keys::SpendAuthorizingKey,
     primitives::redpallas, value::ValueCommitTrapdoor,
 };
 
-impl<D: OrchardDomainCommon> super::Bundle<D> {
+impl super::Bundle {
     /// Finalizes the IO for this bundle.
     pub fn finalize_io<R: RngCore + CryptoRng>(
         &mut self,

--- a/src/pczt/parse.rs
+++ b/src/pczt/parse.rs
@@ -5,16 +5,15 @@ use alloc::vec::Vec;
 use ff::PrimeField;
 use incrementalmerkletree::Hashable;
 use pasta_curves::pallas;
-use zcash_note_encryption_zsa::{note_bytes::NoteBytes, OutgoingCipherKey};
+use zcash_note_encryption_zsa::{OutgoingCipherKey};
 use zip32::ChildIndex;
 
-use super::{Action, Bundle, Output, Spend, Zip32Derivation};
+use super::{Action, Bundle, Output, Spend, PcztTransmittedNoteCiphertext, Zip32Derivation};
 use crate::{
     bundle::Flags,
-    domain::OrchardDomainCommon,
     keys::{FullViewingKey, SpendingKey},
     note::{
-        AssetBase, ExtractedNoteCommitment, Nullifier, RandomSeed, Rho, TransmittedNoteCiphertext,
+        AssetBase, ExtractedNoteCommitment, Nullifier, RandomSeed, Rho, 
     },
     primitives::redpallas::{self, SpendAuth},
     tree::{MerkleHashOrchard, MerklePath},
@@ -22,12 +21,12 @@ use crate::{
     Address, Anchor, Proof, NOTE_COMMITMENT_TREE_DEPTH,
 };
 
-impl<D: OrchardDomainCommon> Bundle<D> {
+impl Bundle {
     /// Parses a PCZT bundle from its component parts.
     /// `value_sum` is represented as `(magnitude, is_negative)`.
     #[allow(clippy::too_many_arguments)]
     pub fn parse(
-        actions: Vec<Action<D>>,
+        actions: Vec<Action>,
         flags: u8,
         value_sum: (u64, bool),
         anchor: [u8; 32],
@@ -85,12 +84,12 @@ impl<D: OrchardDomainCommon> Bundle<D> {
     }
 }
 
-impl<D: OrchardDomainCommon> Action<D> {
+impl Action {
     /// Parses a PCZT action from its component parts.
     pub fn parse(
         cv_net: [u8; 32],
         spend: Spend,
-        output: Output<D>,
+        output: Output,
         rcv: Option<[u8; 32]>,
     ) -> Result<Self, ParseError> {
         let cv_net = ValueCommitment::from_bytes(&cv_net)
@@ -240,7 +239,7 @@ impl Spend {
     }
 }
 
-impl<D: OrchardDomainCommon> Output<D> {
+impl Output {
     /// Parses a PCZT output from its component parts, and the corresponding `Spend`'s
     /// nullifier.
     #[allow(clippy::too_many_arguments)]
@@ -262,10 +261,9 @@ impl<D: OrchardDomainCommon> Output<D> {
             .into_option()
             .ok_or(ParseError::InvalidExtractedNoteCommitment)?;
 
-        let encrypted_note = TransmittedNoteCiphertext {
+        let encrypted_note = PcztTransmittedNoteCiphertext {
             epk_bytes: ephemeral_key,
-            enc_ciphertext: D::NoteCiphertextBytes::from_slice(enc_ciphertext.as_slice())
-                .ok_or(ParseError::InvalidEncCiphertext)?,
+            enc_ciphertext: enc_ciphertext.to_vec(),
             out_ciphertext: out_ciphertext
                 .as_slice()
                 .try_into()

--- a/src/pczt/parse.rs
+++ b/src/pczt/parse.rs
@@ -5,16 +5,14 @@ use alloc::vec::Vec;
 use ff::PrimeField;
 use incrementalmerkletree::Hashable;
 use pasta_curves::pallas;
-use zcash_note_encryption_zsa::{OutgoingCipherKey};
+use zcash_note_encryption_zsa::OutgoingCipherKey;
 use zip32::ChildIndex;
 
-use super::{Action, Bundle, Output, Spend, PcztTransmittedNoteCiphertext, Zip32Derivation};
+use super::{Action, Bundle, Output, PcztTransmittedNoteCiphertext, Spend, Zip32Derivation};
 use crate::{
     bundle::Flags,
     keys::{FullViewingKey, SpendingKey},
-    note::{
-        AssetBase, ExtractedNoteCommitment, Nullifier, RandomSeed, Rho, 
-    },
+    note::{AssetBase, ExtractedNoteCommitment, Nullifier, RandomSeed, Rho},
     primitives::redpallas::{self, SpendAuth},
     tree::{MerkleHashOrchard, MerklePath},
     value::{NoteValue, Sign, ValueCommitTrapdoor, ValueCommitment, ValueSum},

--- a/src/pczt/prover.rs
+++ b/src/pczt/prover.rs
@@ -6,13 +6,12 @@ use rand::{CryptoRng, RngCore};
 use crate::{
     builder::SpendInfo,
     circuit::{Circuit, Instance, ProvingKey, Witnesses},
-    domain::OrchardDomainCommon,
     note::Rho,
     orchard_flavor::OrchardFlavor,
     Note, Proof,
 };
 
-impl<D: OrchardDomainCommon> super::Bundle<D> {
+impl super::Bundle {
     /// Adds a proof to this PCZT bundle.
     pub fn create_proof<FL: OrchardFlavor, R: RngCore + CryptoRng>(
         &mut self,

--- a/src/pczt/signer.rs
+++ b/src/pczt/signer.rs
@@ -1,8 +1,8 @@
 use rand::{CryptoRng, RngCore};
 
-use crate::{domain::OrchardDomainCommon, keys::SpendAuthorizingKey, primitives::redpallas};
+use crate::{keys::SpendAuthorizingKey, primitives::redpallas};
 
-impl<D: OrchardDomainCommon> super::Action<D> {
+impl super::Action {
     /// Signs the Orchard spend with the given spend authorizing key.
     ///
     /// It is the caller's responsibility to perform any semantic validity checks on the

--- a/src/pczt/tx_extractor.rs
+++ b/src/pczt/tx_extractor.rs
@@ -63,7 +63,7 @@ impl super::Bundle {
         F: Fn(&Action) -> Result<<A as Authorization>::SpendAuth, E>,
         G: FnOnce(&Self) -> Result<A, E>,
         V: TryFrom<i64>,
-        D: OrchardDomainCommon
+        D: OrchardDomainCommon,
     {
         let actions = self
             .actions
@@ -75,7 +75,11 @@ impl super::Bundle {
                     action.spend.nullifier,
                     action.spend.rk.clone(),
                     action.output.cmx,
-                    action.output.encrypted_note.clone().into_transmitted_note_ciphertext(),
+                    action
+                        .output
+                        .encrypted_note
+                        .clone()
+                        .into_transmitted_note_ciphertext(),
                     action.cv_net.clone(),
                     authorization,
                 ))

--- a/src/pczt/tx_extractor.rs
+++ b/src/pczt/tx_extractor.rs
@@ -9,13 +9,13 @@ use crate::{
     Proof,
 };
 
-impl<D: OrchardDomainCommon> super::Bundle<D> {
+impl super::Bundle {
     /// Extracts the effects of this PCZT bundle as a [regular `Bundle`].
     ///
     /// This is used by the Signer role to produce the transaction sighash.
     ///
     /// [regular `Bundle`]: crate::Bundle
-    pub fn extract_effects<V: TryFrom<i64>>(
+    pub fn extract_effects<V: TryFrom<i64>, D: OrchardDomainCommon>(
         &self,
     ) -> Result<Option<crate::Bundle<EffectsOnly, V, D>>, TxExtractorError> {
         self.to_tx_data(|_| Ok(()), |_| Ok(EffectsOnly))
@@ -26,7 +26,7 @@ impl<D: OrchardDomainCommon> super::Bundle<D> {
     /// This is used by the Transaction Extractor role to produce the final transaction.
     ///
     /// [regular `Bundle`]: crate::Bundle
-    pub fn extract<V: TryFrom<i64>>(
+    pub fn extract<V: TryFrom<i64>, D: OrchardDomainCommon>(
         self,
     ) -> Result<Option<crate::Bundle<Unbound, V, D>>, TxExtractorError> {
         self.to_tx_data(
@@ -52,7 +52,7 @@ impl<D: OrchardDomainCommon> super::Bundle<D> {
     }
 
     /// Converts this PCZT bundle into a regular bundle with the given authorizations.
-    fn to_tx_data<A, V, E, F, G>(
+    fn to_tx_data<A, V, E, F, G, D>(
         &self,
         action_auth: F,
         bundle_auth: G,
@@ -60,9 +60,10 @@ impl<D: OrchardDomainCommon> super::Bundle<D> {
     where
         A: Authorization,
         E: From<TxExtractorError>,
-        F: Fn(&Action<D>) -> Result<<A as Authorization>::SpendAuth, E>,
+        F: Fn(&Action) -> Result<<A as Authorization>::SpendAuth, E>,
         G: FnOnce(&Self) -> Result<A, E>,
         V: TryFrom<i64>,
+        D: OrchardDomainCommon
     {
         let actions = self
             .actions
@@ -74,7 +75,7 @@ impl<D: OrchardDomainCommon> super::Bundle<D> {
                     action.spend.nullifier,
                     action.spend.rk.clone(),
                     action.output.cmx,
-                    action.output.encrypted_note.clone(),
+                    action.output.encrypted_note.clone().into_transmitted_note_ciphertext(),
                     action.cv_net.clone(),
                     authorization,
                 ))

--- a/src/pczt/updater.rs
+++ b/src/pczt/updater.rs
@@ -1,13 +1,12 @@
 use super::{Action, Bundle, Zip32Derivation};
-use crate::domain::OrchardDomainCommon;
 use alloc::string::String;
 use alloc::vec::Vec;
 
-impl<D: OrchardDomainCommon> Bundle<D> {
+impl Bundle {
     /// Updates the bundle with information provided in the given closure.
     pub fn update_with<F>(&mut self, f: F) -> Result<(), UpdaterError>
     where
-        F: FnOnce(Updater<'_, D>) -> Result<(), UpdaterError>,
+        F: FnOnce(Updater<'_>) -> Result<(), UpdaterError>,
     {
         f(Updater(self))
     }
@@ -15,11 +14,11 @@ impl<D: OrchardDomainCommon> Bundle<D> {
 
 /// An updater for an Orchard PCZT bundle.
 #[derive(Debug)]
-pub struct Updater<'a, D: OrchardDomainCommon>(&'a mut Bundle<D>);
+pub struct Updater<'a>(&'a mut Bundle);
 
-impl<D: OrchardDomainCommon> Updater<'_, D> {
+impl Updater<'_> {
     /// Provides read access to the bundle being updated.
-    pub fn bundle(&self) -> &Bundle<D> {
+    pub fn bundle(&self) -> &Bundle {
         self.0
     }
 
@@ -27,7 +26,7 @@ impl<D: OrchardDomainCommon> Updater<'_, D> {
     /// closure.
     pub fn update_action_with<F>(&mut self, index: usize, f: F) -> Result<(), UpdaterError>
     where
-        F: FnOnce(ActionUpdater<'_, D>) -> Result<(), UpdaterError>,
+        F: FnOnce(ActionUpdater<'_>) -> Result<(), UpdaterError>,
     {
         f(ActionUpdater(
             self.0
@@ -40,9 +39,9 @@ impl<D: OrchardDomainCommon> Updater<'_, D> {
 
 /// An updater for an Orchard PCZT action.
 #[derive(Debug)]
-pub struct ActionUpdater<'a, D: OrchardDomainCommon>(&'a mut Action<D>);
+pub struct ActionUpdater<'a>(&'a mut Action);
 
-impl<D: OrchardDomainCommon> ActionUpdater<'_, D> {
+impl ActionUpdater<'_> {
     /// Sets the ZIP 32 derivation path for the spent note's signing key.
     pub fn set_spend_zip32_derivation(&mut self, derivation: Zip32Derivation) {
         self.0.spend.zip32_derivation = Some(derivation);

--- a/src/pczt/verify.rs
+++ b/src/pczt/verify.rs
@@ -1,12 +1,11 @@
 use crate::{
-    domain::OrchardDomainCommon,
     keys::{FullViewingKey, SpendValidatingKey},
     note::{ExtractedNoteCommitment, Rho},
     value::ValueCommitment,
     Note,
 };
 
-impl<D: OrchardDomainCommon> super::Action<D> {
+impl super::Action {
     /// Verifies that the `cv_net` field is consistent with the note fields.
     ///
     /// Requires that the following optional fields are set:
@@ -117,7 +116,7 @@ impl super::Spend {
     }
 }
 
-impl<D: OrchardDomainCommon> super::Output<D> {
+impl super::Output {
     /// Verifies that the `cmx` field is consistent with the note fields.
     ///
     /// Requires that the following optional fields are set:


### PR DESCRIPTION
This PR removes generic type parameter from Orchard PCZT bundle simplifying the flow in librustzcash