### PR TITLE
Update zcash_note_encryption crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2726,7 +2726,7 @@ dependencies = [
 [[package]]
 name = "zcash_note_encryption"
 version = "0.4.1"
-source = "git+https://github.com/QED-it/zcash_note_encryption?branch=zsa1#ba58c2964ff8c96830407bdd6ff284b39171ba62"
+source = "git+https://github.com/zcash/zcash_note_encryption?branch=main#668ea44cf59a226715a5f3cb1bf88710a8c188a3"
 dependencies = [
  "chacha20",
  "chacha20poly1305",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,7 +43,7 @@ poseidon = { package = "halo2_poseidon", version = "0.1" }
 serde = { version = "1.0", default-features = false, features = ["derive"] }
 sinsemilla = { git = "https://github.com/zcash/sinsemilla", rev = "aabb707e862bc3d7b803c77d14e5a771bcee3e8c", features = ["test-dependencies"] }
 subtle = { version = "2.3", default-features = false }
-zcash_note_encryption_zsa = { package = "zcash_note_encryption", git = "https://github.com/QED-it/zcash_note_encryption", branch = "zsa1" }
+zcash_note_encryption = { git = "https://github.com/zcash/zcash_note_encryption", branch = "main" }
 incrementalmerkletree = "0.8.1"
 zcash_spec = "0.2.1"
 zip32 = { version = "0.2.0", default-features = false }
@@ -68,13 +68,13 @@ plotters = { version = "0.3.0", optional = true }
 
 # Pinned to versions that still build on MSRV 1.70 (font-kit + half)
 font-kit = { version = "=0.11.0", optional = true }
-half     = { version = "=2.2.1", optional = true }
+half = { version = "=2.2.1", optional = true }
 
 [dev-dependencies]
 criterion = "0.4" # 0.5 depends on clap 4 which has MSRV 1.70
 halo2_gadgets = { git = "https://github.com/QED-it/halo2", branch = "zsa1", features = ["test-dependencies"] }
 proptest = "1.0.0"
-zcash_note_encryption_zsa = { package = "zcash_note_encryption", version = "0.4", git = "https://github.com/QED-it/zcash_note_encryption", branch = "zsa1", features = ["pre-zip-212"] }
+zcash_note_encryption = { git = "https://github.com/zcash/zcash_note_encryption", branch = "main", features = ["pre-zip-212"] }
 incrementalmerkletree = { version = "0.8.1", features = ["test-dependencies"] }
 shardtree = "0.6"
 

--- a/benches/note_decryption.rs
+++ b/benches/note_decryption.rs
@@ -10,7 +10,7 @@ use orchard::{
     Anchor, Bundle,
 };
 use rand::rngs::OsRng;
-use zcash_note_encryption_zsa::{batch, try_compact_note_decryption, try_note_decryption};
+use zcash_note_encryption::{batch, try_compact_note_decryption, try_note_decryption};
 
 #[cfg(unix)]
 use pprof::criterion::{Output, PProfProfiler};

--- a/src/action.rs
+++ b/src/action.rs
@@ -129,7 +129,7 @@ pub(crate) mod testing {
 
     use proptest::prelude::*;
 
-    use zcash_note_encryption_zsa::NoteEncryption;
+    use zcash_note_encryption::NoteEncryption;
 
     use crate::{
         domain::{OrchardDomain, OrchardDomainCommon},

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -9,7 +9,7 @@ use ff::Field;
 use pasta_curves::pallas;
 use rand::{prelude::SliceRandom, CryptoRng, RngCore};
 
-use zcash_note_encryption_zsa::NoteEncryption;
+use zcash_note_encryption::NoteEncryption;
 
 use crate::{
     address::Address,
@@ -641,7 +641,7 @@ impl Builder {
     /// Adds a note to be spent in this transaction.
     ///
     /// - `note` is a spendable note, obtained by trial-decrypting an [`Action`] using the
-    ///   [`zcash_note_encryption_zsa`] crate instantiated with [`OrchardDomain`].
+    ///   [`zcash_note_encryption`] crate instantiated with [`OrchardDomain`].
     /// - `merkle_path` can be obtained using the [`incrementalmerkletree`] crate
     ///   instantiated with [`MerkleHashOrchard`].
     ///

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -14,7 +14,7 @@ use core::fmt;
 
 use blake2b_simd::Hash as Blake2bHash;
 use nonempty::NonEmpty;
-use zcash_note_encryption_zsa::{try_note_decryption, try_output_recovery_with_ovk};
+use zcash_note_encryption::{try_note_decryption, try_output_recovery_with_ovk};
 
 #[cfg(feature = "std")]
 use memuse::DynamicUsage;

--- a/src/domain/compact_action.rs
+++ b/src/domain/compact_action.rs
@@ -2,7 +2,7 @@
 
 use core::fmt;
 
-use zcash_note_encryption_zsa::{note_bytes::NoteBytes, EphemeralKeyBytes, ShieldedOutput};
+use zcash_note_encryption::{note_bytes::NoteBytes, EphemeralKeyBytes, ShieldedOutput};
 
 use crate::{
     action::Action,
@@ -116,7 +116,7 @@ impl<D: OrchardDomainCommon> CompactAction<D> {
 pub mod testing {
     use rand::RngCore;
 
-    use zcash_note_encryption_zsa::{note_bytes::NoteBytes, Domain, NoteEncryption};
+    use zcash_note_encryption::{note_bytes::NoteBytes, Domain, NoteEncryption};
 
     use crate::{
         address::Address,

--- a/src/domain/orchard_domain.rs
+++ b/src/domain/orchard_domain.rs
@@ -4,7 +4,7 @@
 use core::fmt;
 
 use blake2b_simd::{Hash as Blake2bHash, State};
-use zcash_note_encryption_zsa::{note_bytes::NoteBytes, AEAD_TAG_SIZE};
+use zcash_note_encryption::{note_bytes::NoteBytes, AEAD_TAG_SIZE};
 
 use crate::{
     action::Action,

--- a/src/domain/orchard_domain_vanilla.rs
+++ b/src/domain/orchard_domain_vanilla.rs
@@ -2,7 +2,7 @@
 //! `OrchardVanilla` flavor.
 
 use blake2b_simd::Hash as Blake2bHash;
-use zcash_note_encryption_zsa::note_bytes::NoteBytesData;
+use zcash_note_encryption::note_bytes::NoteBytesData;
 
 use crate::{
     bundle::{
@@ -83,7 +83,7 @@ mod tests {
 
     use rand::rngs::OsRng;
 
-    use zcash_note_encryption_zsa::{
+    use zcash_note_encryption::{
         note_bytes::NoteBytesData, try_compact_note_decryption, try_note_decryption,
         try_output_recovery_with_ovk, Domain, EphemeralKeyBytes,
     };
@@ -116,7 +116,7 @@ mod tests {
 
     /// Implementation of in-band secret distribution for Orchard bundles.
     pub type OrchardDomainCommonryptionVanilla =
-        zcash_note_encryption_zsa::NoteEncryption<OrchardDomainVanilla>;
+        zcash_note_encryption::NoteEncryption<OrchardDomainVanilla>;
 
     proptest! {
         #[test]

--- a/src/domain/orchard_domain_zsa.rs
+++ b/src/domain/orchard_domain_zsa.rs
@@ -2,7 +2,7 @@
 //! flavor.
 
 use blake2b_simd::Hash as Blake2bHash;
-use zcash_note_encryption_zsa::note_bytes::NoteBytesData;
+use zcash_note_encryption::note_bytes::NoteBytesData;
 
 use crate::bundle::commitments::{
     ZCASH_ORCHARD_ACTION_GROUPS_SIGS_HASH_PERSONALIZATION, ZCASH_ORCHARD_SIGS_HASH_PERSONALIZATION,
@@ -108,7 +108,7 @@ mod tests {
 
     use rand::rngs::OsRng;
 
-    use zcash_note_encryption_zsa::{
+    use zcash_note_encryption::{
         note_bytes::NoteBytesData, try_compact_note_decryption, try_note_decryption,
         try_output_recovery_with_ovk, Domain, EphemeralKeyBytes,
     };
@@ -141,7 +141,7 @@ mod tests {
 
     /// Implementation of in-band secret distribution for Orchard bundles.
     pub type OrchardDomainCommonryptionZSA =
-        zcash_note_encryption_zsa::NoteEncryption<OrchardDomainZSA>;
+        zcash_note_encryption::NoteEncryption<OrchardDomainZSA>;
 
     proptest! {
         #[test]

--- a/src/domain/zcash_note_encryption_domain.rs
+++ b/src/domain/zcash_note_encryption_domain.rs
@@ -5,7 +5,7 @@ use alloc::vec::Vec;
 use blake2b_simd::{Hash, Params};
 use group::ff::PrimeField;
 
-use zcash_note_encryption_zsa::{
+use zcash_note_encryption::{
     note_bytes::NoteBytes, BatchDomain, Domain, EphemeralKeyBytes, OutPlaintextBytes,
     OutgoingCipherKey, OUT_PLAINTEXT_SIZE,
 };

--- a/src/keys.rs
+++ b/src/keys.rs
@@ -24,7 +24,7 @@ use pasta_curves::{pallas, pallas::Scalar};
 use rand::RngCore;
 use rand_core::CryptoRngCore;
 use subtle::{Choice, ConditionallySelectable, ConstantTimeEq, CtOption};
-use zcash_note_encryption_zsa::EphemeralKeyBytes;
+use zcash_note_encryption::EphemeralKeyBytes;
 
 use crate::{
     address::Address,

--- a/src/pczt.rs
+++ b/src/pczt.rs
@@ -7,8 +7,7 @@ use core::fmt;
 
 use getset::Getters;
 use pasta_curves::pallas;
-use zcash_note_encryption_zsa::note_bytes::NoteBytes;
-use zcash_note_encryption_zsa::OutgoingCipherKey;
+use zcash_note_encryption::{note_bytes::NoteBytes, OutgoingCipherKey};
 use zip32::ChildIndex;
 
 use crate::{

--- a/src/pczt/parse.rs
+++ b/src/pczt/parse.rs
@@ -5,7 +5,7 @@ use alloc::vec::Vec;
 use ff::PrimeField;
 use incrementalmerkletree::Hashable;
 use pasta_curves::pallas;
-use zcash_note_encryption_zsa::OutgoingCipherKey;
+use zcash_note_encryption::OutgoingCipherKey;
 use zip32::ChildIndex;
 
 use super::{Action, Bundle, Output, PcztTransmittedNoteCiphertext, Spend, Zip32Derivation};

--- a/tests/builder.rs
+++ b/tests/builder.rs
@@ -14,7 +14,7 @@ use orchard::{
 use rand::rngs::StdRng;
 use rand::SeedableRng;
 use shardtree::{store::memory::MemoryShardStore, ShardTree};
-use zcash_note_encryption_zsa::try_note_decryption;
+use zcash_note_encryption::try_note_decryption;
 
 pub fn verify_bundle<FL: OrchardFlavor>(
     bundle: &Bundle<Authorized, i64, FL>,

--- a/tests/zsa.rs
+++ b/tests/zsa.rs
@@ -23,7 +23,7 @@ use orchard::{
 use rand::rngs::OsRng;
 use shardtree::store::memory::MemoryShardStore;
 use shardtree::ShardTree;
-use zcash_note_encryption_zsa::try_note_decryption;
+use zcash_note_encryption::try_note_decryption;
 
 #[derive(Debug)]
 struct Keychain {


### PR DESCRIPTION
Update zcash_note_encryption crate
- Point to zcash/zcash_note_encryption repo
- Rename this crate to zcash_note_encryption instead of zcash_note_encryption_zsa