### PR TITLE
Fix fake_compact_action visibility

### DIFF
--- a/src/domain.rs
+++ b/src/domain.rs
@@ -15,3 +15,6 @@ pub use {
     compact_action::CompactAction,
     orchard_domain::{OrchardDomain, OrchardDomainCommon},
 };
+
+#[cfg(feature = "test-dependencies")]
+pub use compact_action::testing::fake_compact_action;


### PR DESCRIPTION
In librustzcash, we would like to use fake_compact_action function in test.