### PR TITLE
Adopt proptest version range (>=1.0,<1.7) and roll back Cargo.lock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1823,19 +1823,19 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.4.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31b476131c3c86cb68032fdc5cb6d5a1045e3e42d96b69fa599fd77701e1f5bf"
+checksum = "4e35c06b98bf36aba164cc17cb25f7e232f5c4aeea73baa14b8a9f0d92dbfa65"
 dependencies = [
  "bit-set",
- "bit-vec",
- "bitflags 2.4.0",
+ "bitflags 1.3.2",
+ "byteorder",
  "lazy_static",
  "num-traits",
  "rand",
  "rand_chacha",
  "rand_xorshift",
- "regex-syntax 0.8.5",
+ "regex-syntax 0.6.29",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -2004,15 +2004,15 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.7.5"
+version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.5"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
+checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
 name = "rgb"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ k256 = { version = "0.13.0", default-features = false, features = ["arithmetic",
 lazy_static = "1"
 memuse = { version = "0.2.2", default-features = false }
 pasta_curves = "0.5"
-proptest = { version = "=1.4.0", optional = true }
+proptest = { version = ">=1.0.0, <1.7.0", optional = true }
 rand = { version = "0.8", default-features = false }
 rand_core = { version = "0.6", default-features = false }
 reddsa = { version = "0.5", default-features = false }
@@ -73,7 +73,7 @@ half = { version = "=2.2.1", optional = true }
 [dev-dependencies]
 criterion = "0.4" # 0.5 depends on clap 4 which has MSRV 1.70
 halo2_gadgets = { git = "https://github.com/QED-it/halo2", branch = "zsa1", features = ["test-dependencies"] }
-proptest = "=1.4.0"
+proptest = ">=1.0.0, <1.7.0"
 zcash_note_encryption = { git = "https://github.com/zcash/zcash_note_encryption", branch = "main", features = ["pre-zip-212"] }
 incrementalmerkletree = { version = "0.8.1", features = ["test-dependencies"] }
 shardtree = "0.6"


### PR DESCRIPTION
### Context

* The last change (#175) fixed a Zebra version clash by pinning `proptest` to **1.4.0**.
* That exact pin conflicts with **librustzcash**’s `cargo-vet` policy, which has an exemption only for **1.2.0**.
* Orchard is actually compatible with every 1.x release up to—but not including—1.7 (1.7 introduces the `rand` 0.9 break).

### What this PR does

* **Cargo.toml** now allows any `proptest` version **≥ 1.0.0 and < 1.7.0**.  
* **Cargo.lock** is rolled back to the version that existed before PR #175 (uses `proptest` 1.2.0).