### PR TITLE
Further fixes to make the code usuable in `librustzcash`

### DIFF
--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -250,11 +250,9 @@ impl Signed {
         &self.signature
     }
 
-    /// Constructs a `Signed` from a byte array containing an `IssueAuthSig` in raw bytes.
-    pub fn from_data(data: &[u8]) -> Self {
-        Signed {
-            signature: IssueAuthSig::decode(data).unwrap(),
-        }
+    /// Constructs a `Signed` from an `IssueAuthSig`.
+    pub fn from_sig(signature: IssueAuthSig<ZSASchnorr>) -> Self {
+        Signed { signature }
     }
 }
 

--- a/src/issuance_auth.rs
+++ b/src/issuance_auth.rs
@@ -215,7 +215,7 @@ impl IssueAuthSig<ZSASchnorr> {
     /// defined in [ZIP 227][issueauthsig].
     ///
     /// [issueauthsig]: https://zips.z.cash/zip-0227#issuance-authorization-signing-and-validation
-    pub(crate) fn encode(&self) -> Vec<u8> {
+    pub fn encode(&self) -> Vec<u8> {
         let sig_bytes = self.0.to_bytes().to_vec();
         let mut encoded =
             Vec::with_capacity(size_of_val(&ZSASchnorr::ALGORITHM_BYTE) + sig_bytes.len());
@@ -228,7 +228,7 @@ impl IssueAuthSig<ZSASchnorr> {
     /// in [ZIP 227][issueauthsig].
     ///
     /// [issueauthsig]: https://zips.z.cash/zip-0227#issuance-authorization-signing-and-validation
-    pub(crate) fn decode(bytes: &[u8]) -> Result<Self, Error> {
+    pub fn decode(bytes: &[u8]) -> Result<Self, Error> {
         if let Some((&algorithm_byte, key_bytes)) = bytes.split_first() {
             if algorithm_byte == ZSASchnorr::ALGORITHM_BYTE {
                 return schnorr::Signature::try_from(key_bytes)


### PR DESCRIPTION
Some visibility changes to methods needed for the corresponding encoding change in librustzcash