### PR TITLE
Updates to property testing

### DIFF
--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -1975,9 +1975,9 @@ pub mod testing {
             AwaitingNullifier, IssueAction, IssueBundle, Prepared, Signed, VerBIP340IssueAuthSig,
         },
         issuance_auth::{
-            testing::arb_issuance_validating_key, IssueAuthSig, IssueAuthSigScheme, ZSASchnorr,
+            testing::arb_issuance_validating_key, IssueAuthSig, IssueAuthSigScheme,
+            IssueValidatingKey, ZSASchnorr,
         },
-        note::asset_base::testing::zsa_asset_base,
         note::testing::arb_zsa_note,
     };
     use nonempty::NonEmpty;
@@ -2000,12 +2000,13 @@ pub mod testing {
 
     prop_compose! {
         /// Generate an issue action
-        pub fn arb_issue_action(asset_desc_hash: [u8; 32])
+        pub fn arb_issue_action(ik: IssueValidatingKey<ZSASchnorr>)
         (
-            asset in zsa_asset_base(asset_desc_hash),
+            asset_desc_hash in prop::array::uniform32(prop::num::u8::ANY),
         )
         (
-            note in arb_zsa_note(asset),
+            note in arb_zsa_note(ik.clone(), asset_desc_hash),
+            asset_desc_hash in Just(asset_desc_hash),
         )-> IssueAction {
             IssueAction{
                 asset_desc_hash,
@@ -2019,8 +2020,11 @@ pub mod testing {
         /// Generate an arbitrary issue bundle with fake authorization data.
         pub fn arb_awaiting_nullifier_issue_bundle(n_actions: usize)
         (
-            actions in vec(arb_issue_action([1u8; 32]), n_actions),
             ik in arb_issuance_validating_key()
+        )
+        (
+            actions in vec(arb_issue_action(ik.clone()), n_actions),
+            ik in Just(ik),
         ) -> IssueBundle<AwaitingNullifier> {
             let actions = NonEmpty::from_vec(actions).unwrap();
             IssueBundle {
@@ -2036,8 +2040,11 @@ pub mod testing {
         /// necessarily respect consensus rules
         pub fn arb_prepared_issue_bundle(n_actions: usize)
         (
-            actions in vec(arb_issue_action([1u8; 32]), n_actions),
-            ik in arb_issuance_validating_key(),
+            ik in arb_issuance_validating_key()
+        )
+        (
+            actions in vec(arb_issue_action(ik.clone()), n_actions),
+            ik in Just(ik),
             fake_sighash in prop::array::uniform32(prop::num::u8::ANY)
         ) -> IssueBundle<Prepared> {
             let actions = NonEmpty::from_vec(actions).unwrap();
@@ -2054,8 +2061,11 @@ pub mod testing {
         /// necessarily respect consensus rules
         pub fn arb_signed_issue_bundle(n_actions: usize)
         (
-            actions in vec(arb_issue_action([1u8; 32]), n_actions),
-            ik in arb_issuance_validating_key(),
+            ik in arb_issuance_validating_key()
+        )
+        (
+            actions in vec(arb_issue_action(ik.clone()), n_actions),
+            ik in Just(ik),
             fake_sig in arb_signature(),
         ) -> IssueBundle<Signed> {
             let actions = NonEmpty::from_vec(actions).unwrap();

--- a/src/note.rs
+++ b/src/note.rs
@@ -425,6 +425,7 @@ pub mod testing {
 
     use crate::{
         address::testing::arb_address,
+        issuance_auth::{IssueValidatingKey, ZSASchnorr},
         note::{asset_base::testing::arb_asset_base, nullifier::testing::arb_nullifier, AssetBase},
         value::{testing::arb_note_value, NoteValue},
     };
@@ -480,7 +481,7 @@ pub mod testing {
 
     prop_compose! {
         /// Generate an arbitrary zsa note
-        pub fn arb_zsa_note(asset: AssetBase)(
+        pub fn arb_zsa_note(ik: IssueValidatingKey<ZSASchnorr>, asset_desc_hash: [u8; 32])(
             recipient in arb_address(),
             value in arb_note_value(),
             rho in arb_nullifier().prop_map(Rho::from_nf_old),
@@ -489,7 +490,7 @@ pub mod testing {
             Note {
                 recipient,
                 value,
-                asset,
+                asset: AssetBase::derive(&ik, &asset_desc_hash),
                 rho,
                 rseed,
                 rseed_split_note: CtOption::new(rseed, 0u8.into()),

--- a/src/note/asset_base.rs
+++ b/src/note/asset_base.rs
@@ -164,7 +164,9 @@ pub mod testing {
 
     use proptest::prelude::*;
 
-    use crate::issuance_auth::{testing::arb_issuance_authorizing_key, IssueValidatingKey};
+    use crate::issuance_auth::{
+        testing::arb_issuance_authorizing_key, IssueValidatingKey, ZSASchnorr,
+    };
 
     prop_compose! {
         /// Generate a uniformly distributed note type
@@ -192,11 +194,11 @@ pub mod testing {
     }
 
     prop_compose! {
-        /// Generate an asset ID using a specific description
-        pub fn zsa_asset_base(asset_desc_hash: [u8; 32])(
-            isk in arb_issuance_authorizing_key(),
+        /// Generate an asset base using a specific issuance validating key
+        pub fn zsa_asset_base(ik: IssueValidatingKey<ZSASchnorr>)(
+            asset_desc_hash in prop::array::uniform32(prop::num::u8::ANY),
         ) -> AssetBase {
-            AssetBase::derive(&IssueValidatingKey::from(&isk), &asset_desc_hash)
+            AssetBase::derive(&ik, &asset_desc_hash)
         }
     }
 }


### PR DESCRIPTION
This makes updates to the `prop_compose` strategies to more correctly reflect how arbitrary issuance components are constructed.