### PR TITLE
Remove PCZT v2

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -351,6 +351,9 @@ impl SpendInfo {
     }
 
     fn into_pczt(self, rng: impl RngCore) -> crate::pczt::Spend {
+        assert!(!self.split_flag);
+        assert_eq!(self.note.asset(), AssetBase::native());
+
         let (nf_old, _, alpha, rk) = self.build(rng);
 
         crate::pczt::Spend {
@@ -442,6 +445,8 @@ impl OutputInfo {
         nf_old: Nullifier,
         rng: impl RngCore,
     ) -> crate::pczt::Output {
+        assert_eq!(self.asset, AssetBase::native());
+
         let (note, cmx, encrypted_note) = self.build::<OrchardVanilla>(cv_net, nf_old, rng);
 
         crate::pczt::Output {

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -20,6 +20,7 @@ use crate::{
         SpendingKey,
     },
     note::{AssetBase, ExtractedNoteCommitment, Note, Nullifier, Rho, TransmittedNoteCiphertext},
+    orchard_flavor::OrchardVanilla,
     orchard_sighash_versioning::{VerBindingSig, VerSpendAuthSig},
     primitives::redpallas::{self, Binding, SpendAuth},
     primitives::{OrchardDomain, OrchardPrimitives},
@@ -358,14 +359,11 @@ impl SpendInfo {
             spend_auth_sig: None,
             recipient: Some(self.note.recipient()),
             value: Some(self.note.value()),
-            asset: Some(self.note.asset()),
             rho: Some(self.note.rho()),
             rseed: Some(*self.note.rseed()),
-            rseed_split_note: self.note.rseed_split_note().into(),
             fvk: Some(self.fvk),
             witness: Some(self.merkle_path),
             alpha: Some(alpha),
-            split_flag: Some(self.split_flag),
             zip32_derivation: None,
             dummy_sk: self.dummy_sk,
             proprietary: BTreeMap::new(),
@@ -438,17 +436,17 @@ impl OutputInfo {
         (note, cmx, encrypted_note)
     }
 
-    fn into_pczt<P: OrchardPrimitives>(
+    fn into_pczt(
         self,
         cv_net: &ValueCommitment,
         nf_old: Nullifier,
         rng: impl RngCore,
     ) -> crate::pczt::Output {
-        let (note, cmx, encrypted_note) = self.build::<P>(cv_net, nf_old, rng);
+        let (note, cmx, encrypted_note) = self.build::<OrchardVanilla>(cv_net, nf_old, rng);
 
         crate::pczt::Output {
             cmx,
-            encrypted_note: encrypted_note.into(),
+            encrypted_note,
             recipient: Some(self.recipient),
             value: Some(self.value),
             rseed: Some(*note.rseed()),
@@ -533,7 +531,7 @@ impl ActionInfo {
         )
     }
 
-    fn build_for_pczt<P: OrchardPrimitives>(self, mut rng: impl RngCore) -> crate::pczt::Action {
+    fn build_for_pczt(self, mut rng: impl RngCore) -> crate::pczt::Action {
         assert_eq!(
             self.spend.note.asset(),
             self.output.asset,
@@ -543,9 +541,7 @@ impl ActionInfo {
         let cv_net = ValueCommitment::derive(v_net, self.rcv, self.spend.note.asset());
 
         let spend = self.spend.into_pczt(&mut rng);
-        let output = self
-            .output
-            .into_pczt::<P>(&cv_net, spend.nullifier, &mut rng);
+        let output = self.output.into_pczt(&cv_net, spend.nullifier, &mut rng);
 
         crate::pczt::Action {
             cv_net,
@@ -776,7 +772,7 @@ impl Builder {
 
     /// Builds a bundle containing the given spent notes and outputs along with their
     /// metadata, for inclusion in a PCZT.
-    pub fn build_for_pczt<P: OrchardPrimitives>(
+    pub fn build_for_pczt(
         self,
         rng: impl RngCore,
     ) -> Result<(crate::pczt::Bundle, BundleMetadata), BuildError> {
@@ -787,11 +783,11 @@ impl Builder {
             self.spends,
             self.outputs,
             self.burn,
-            |pre_actions, flags, value_sum, burn_vec, bundle_meta, mut rng| {
+            |pre_actions, flags, value_sum, _burn_vec, bundle_meta, mut rng| {
                 // Create the actions.
                 let actions = pre_actions
                     .into_iter()
-                    .map(|a| a.build_for_pczt::<P>(&mut rng))
+                    .map(|a| a.build_for_pczt(&mut rng))
                     .collect::<Vec<_>>();
 
                 Ok((
@@ -800,8 +796,6 @@ impl Builder {
                         flags,
                         value_sum,
                         anchor: self.anchor,
-                        burn: burn_vec,
-                        expiry_height: 0,
                         zkproof: None,
                         bsk: None,
                     },

--- a/src/pczt.rs
+++ b/src/pczt.rs
@@ -345,6 +345,7 @@ mod tests {
         constants::MERKLE_DEPTH_ORCHARD,
         keys::{FullViewingKey, Scope, SpendAuthorizingKey, SpendingKey},
         note::{AssetBase, ExtractedNoteCommitment, RandomSeed, Rho},
+        orchard_flavor::OrchardVanilla,
         pczt::Zip32Derivation,
         tree::{MerkleHashOrchard, EMPTY_ROOTS},
         value::NoteValue,
@@ -353,7 +354,7 @@ mod tests {
 
     #[test]
     fn shielding_bundle() {
-        let pk = ProvingKey::build();
+        let pk = ProvingKey::build::<OrchardVanilla>();
         let mut rng = OsRng;
 
         let sk = SpendingKey::random(&mut rng);
@@ -395,7 +396,7 @@ mod tests {
 
     #[test]
     fn shielded_bundle() {
-        let pk = ProvingKey::build();
+        let pk = ProvingKey::build::<OrchardVanilla>();
         let mut rng = OsRng;
 
         // Pretend we derived the spending key via ZIP 32.

--- a/src/pczt.rs
+++ b/src/pczt.rs
@@ -7,20 +7,15 @@ use core::fmt;
 
 use getset::Getters;
 use pasta_curves::pallas;
-use zcash_note_encryption::{note_bytes::NoteBytes, OutgoingCipherKey};
+use zcash_note_encryption::OutgoingCipherKey;
 use zip32::ChildIndex;
 
 use crate::{
     bundle::Flags,
     keys::{FullViewingKey, SpendingKey},
-    note::{
-        AssetBase, ExtractedNoteCommitment, Nullifier, RandomSeed, Rho, TransmittedNoteCiphertext,
-    },
-    orchard_sighash_versioning::VerSpendAuthSig,
-    primitives::{
-        redpallas::{self, Binding, SpendAuth},
-        OrchardPrimitives,
-    },
+    note::{ExtractedNoteCommitment, Nullifier, RandomSeed, Rho, TransmittedNoteCiphertext},
+    orchard_flavor::OrchardVanilla,
+    primitives::redpallas::{self, Binding, SpendAuth},
     tree::MerklePath,
     value::{NoteValue, ValueCommitTrapdoor, ValueCommitment, ValueSum},
     Address, Anchor, Proof,
@@ -77,23 +72,10 @@ pub struct Bundle {
     /// redacted from the PCZT after they are no longer necessary.
     pub(crate) value_sum: ValueSum,
 
-    /// Assets intended for burning
-    ///
-    /// Set by the Constructor.
-    pub(crate) burn: Vec<(AssetBase, NoteValue)>,
-
     /// The Orchard anchor for this transaction.
     ///
     /// Set by the Creator.
     pub(crate) anchor: Anchor,
-
-    /// Block height after which this Bundle's Actions are invalid by consensus.
-    ///
-    /// For the OrchardZSA protocol, `expiry_height` is set to 0, indicating no expiry.
-    /// This field is reserved for future use.
-    ///
-    /// Set by the Constructor.
-    pub(crate) expiry_height: u32,
 
     /// The Orchard bundle proof.
     ///
@@ -159,10 +141,10 @@ pub struct Spend {
     /// The randomized verification key for the note being spent.
     pub(crate) rk: redpallas::VerificationKey<SpendAuth>,
 
-    /// The versioned spend authorization signature.
+    /// The spend authorization signature.
     ///
     /// This is set by the Signer.
-    pub(crate) spend_auth_sig: Option<VerSpendAuthSig>,
+    pub(crate) spend_auth_sig: Option<redpallas::Signature<SpendAuth>>,
 
     /// The address that received the note being spent.
     ///
@@ -180,12 +162,6 @@ pub struct Spend {
     /// information, or after signatures have been applied, this can be redacted.
     pub(crate) value: Option<NoteValue>,
 
-    /// The asset of this Action.
-    ///
-    /// - This is set by the Constructor.
-    /// - This is required by the Prover.
-    pub(crate) asset: Option<AssetBase>,
-
     /// The rho value for the note being spent.
     ///
     /// - This is set by the Constructor.
@@ -200,12 +176,6 @@ pub struct Spend {
     /// - This is set by the Constructor.
     /// - This is required by the Prover.
     pub(crate) rseed: Option<RandomSeed>,
-
-    /// The seed randomness for split notes.
-    ///
-    /// - This is set by the Constructor.
-    /// - This is required by the Prover.
-    pub(crate) rseed_split_note: Option<RandomSeed>,
 
     /// The full viewing key that received the note being spent.
     ///
@@ -226,12 +196,6 @@ pub struct Spend {
     ///   validate `rk`.
     /// - After`zkproof` / `spend_auth_sig` has been set, this can be redacted.
     pub(crate) alpha: Option<pallas::Scalar>,
-
-    /// A flag to indicate whether the value of the SpendInfo will be counted in the `ValueSum` of the action.
-    ///
-    /// - This is chosen by the Constructor.
-    /// - This is required by the Prover.
-    pub(crate) split_flag: Option<bool>,
 
     /// The ZIP 32 derivation path at which the spending key can be found for the note
     /// being spent.
@@ -261,7 +225,7 @@ pub struct Output {
     /// - `ephemeral_key`
     /// - `enc_ciphertext`
     /// - `out_ciphertext`
-    pub(crate) encrypted_note: PcztTransmittedNoteCiphertext,
+    pub(crate) encrypted_note: TransmittedNoteCiphertext<OrchardVanilla>,
 
     /// The address that will receive the output.
     ///
@@ -367,75 +331,40 @@ impl Zip32Derivation {
     }
 }
 
-/// An encrypted note.
-#[derive(Clone, Debug)]
-pub struct PcztTransmittedNoteCiphertext {
-    /// The serialization of the ephemeral public key
-    pub epk_bytes: [u8; 32],
-    /// The encrypted note ciphertext
-    pub enc_ciphertext: Vec<u8>,
-    /// An encrypted value that allows the holder of the outgoing cipher
-    /// key for the note to recover the note plaintext.
-    pub out_ciphertext: [u8; 80],
-}
-
-impl<P: OrchardPrimitives> From<TransmittedNoteCiphertext<P>> for PcztTransmittedNoteCiphertext {
-    fn from(transmitted: TransmittedNoteCiphertext<P>) -> Self {
-        PcztTransmittedNoteCiphertext {
-            epk_bytes: transmitted.epk_bytes,
-            enc_ciphertext: transmitted.enc_ciphertext.as_ref().to_vec(),
-            out_ciphertext: transmitted.out_ciphertext,
-        }
-    }
-}
-
-impl<P: OrchardPrimitives> From<PcztTransmittedNoteCiphertext> for TransmittedNoteCiphertext<P> {
-    fn from(ciphertext: PcztTransmittedNoteCiphertext) -> Self {
-        TransmittedNoteCiphertext {
-            epk_bytes: ciphertext.epk_bytes,
-            enc_ciphertext: P::NoteCiphertextBytes::from_slice(&ciphertext.enc_ciphertext)
-                .expect("Failed to parse enc_ciphertext: data may be corrupt or incorrect size"),
-            out_ciphertext: ciphertext.out_ciphertext,
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use blake2b_simd::Hash as Blake2bHash;
     use ff::{Field, PrimeField};
     use incrementalmerkletree::{Marking, Retention};
-    use nonempty::NonEmpty;
     use pasta_curves::pallas;
-    use rand::{rngs::StdRng, SeedableRng};
+    use rand::rngs::OsRng;
     use shardtree::{store::memory::MemoryShardStore, ShardTree};
 
     use crate::{
         builder::{Builder, BundleType},
-        bundle::commitments::hash_bundle_txid_data,
         circuit::ProvingKey,
         constants::MERKLE_DEPTH_ORCHARD,
-        issuance::compute_asset_desc_hash,
-        issuance_auth::{IssueAuthKey, IssueValidatingKey, ZSASchnorr},
         keys::{FullViewingKey, Scope, SpendAuthorizingKey, SpendingKey},
         note::{AssetBase, ExtractedNoteCommitment, RandomSeed, Rho},
-        orchard_flavor::{OrchardFlavor, OrchardVanilla, OrchardZSA},
         pczt::Zip32Derivation,
         tree::{MerkleHashOrchard, EMPTY_ROOTS},
         value::NoteValue,
         Note,
     };
 
-    fn shielding_bundle<FL: OrchardFlavor>(bundle_type: BundleType) -> Blake2bHash {
-        let pk = ProvingKey::build::<FL>();
-        let mut rng = StdRng::seed_from_u64(1u64);
+    #[test]
+    fn shielding_bundle() {
+        let pk = ProvingKey::build();
+        let mut rng = OsRng;
 
         let sk = SpendingKey::random(&mut rng);
         let fvk = FullViewingKey::from(&sk);
         let recipient = fvk.address_at(0u32, Scope::External);
 
         // Run the Creator and Constructor roles.
-        let mut builder = Builder::new(bundle_type, EMPTY_ROOTS[MERKLE_DEPTH_ORCHARD].into());
+        let mut builder = Builder::new(
+            BundleType::DEFAULT_VANILLA,
+            EMPTY_ROOTS[MERKLE_DEPTH_ORCHARD].into(),
+        );
         builder
             .add_output(
                 None,
@@ -447,77 +376,27 @@ mod tests {
             .unwrap();
         let balance: i64 = builder.value_balance().unwrap();
         assert_eq!(balance, -5000);
-        let mut pczt_bundle = builder.build_for_pczt::<FL>(&mut rng).unwrap().0;
+        let mut pczt_bundle = builder.build_for_pczt(&mut rng).unwrap().0;
 
         // Run the IO Finalizer role.
         let sighash = [0; 32];
-        pczt_bundle.finalize_io(sighash, rng.clone()).unwrap();
+        pczt_bundle.finalize_io(sighash, rng).unwrap();
 
         // Run the Prover role.
-        pczt_bundle.create_proof::<FL, _>(&pk, rng.clone()).unwrap();
+        pczt_bundle.create_proof(&pk, rng).unwrap();
 
         // Run the Transaction Extractor role.
-        let bundle = pczt_bundle.extract::<i64, FL>().unwrap().unwrap();
-
-        let orchard_digest = hash_bundle_txid_data(&bundle);
+        let bundle = pczt_bundle.extract::<i64>().unwrap().unwrap();
 
         assert_eq!(bundle.value_balance(), &(-5000));
         // We can successfully bind the bundle.
         bundle.apply_binding_signature(sighash, rng).unwrap();
-
-        orchard_digest
     }
 
     #[test]
-    fn shielding_bundle_orchard_zsa() {
-        let orchard_digest = shielding_bundle::<OrchardZSA>(BundleType::DEFAULT_ZSA);
-        assert_eq!(
-            orchard_digest.as_bytes(),
-            // Locks the `orchard_digest` for OrchardZSA
-            &[
-                164, 99, 147, 6, 19, 86, 66, 138, 59, 232, 52, 111, 235, 197, 66, 151, 86, 53, 65,
-                250, 3, 129, 217, 11, 97, 160, 68, 75, 195, 188, 76, 161
-            ],
-        );
-        let orchard_digest = shielding_bundle::<OrchardZSA>(BundleType::DEFAULT_VANILLA);
-        assert_eq!(
-            orchard_digest.as_bytes(),
-            // Locks the `orchard_digest` for OrchardZSA
-            &[
-                208, 245, 141, 8, 182, 182, 91, 48, 64, 24, 222, 106, 63, 72, 11, 99, 216, 111,
-                114, 94, 36, 153, 68, 253, 137, 240, 20, 184, 160, 192, 10, 155
-            ],
-        );
-    }
-
-    #[test]
-    fn shielding_bundle_orchard_vanilla() {
-        let orchard_digest = shielding_bundle::<OrchardVanilla>(BundleType::DEFAULT_VANILLA);
-        assert_eq!(
-            orchard_digest.as_bytes(),
-            // `orchard_digest` taken from the `zcash/orchard` repository at commit `4ac248d0` (v0.11.0)
-            // This ensures backward compatibility.
-            &[
-                35, 70, 47, 40, 125, 172, 163, 93, 38, 0, 111, 90, 137, 81, 41, 181, 216, 25, 190,
-                222, 210, 45, 44, 127, 182, 44, 228, 229, 132, 64, 53, 7,
-            ],
-        );
-    }
-
-    fn shielded_bundle<FL: OrchardFlavor>(bundle_type: BundleType, zsa_asset: bool) -> Blake2bHash {
-        let pk = ProvingKey::build::<FL>();
-        let mut rng = StdRng::seed_from_u64(1u64);
-
-        let asset = if zsa_asset {
-            // Create a ZSA asset from its issue validating key.
-            let isk = IssueAuthKey::<ZSASchnorr>::random(&mut rng);
-            let ik = IssueValidatingKey::from(&isk);
-            let asset_desc_hash =
-                compute_asset_desc_hash(&NonEmpty::from_slice(b"asset1").unwrap());
-            AssetBase::derive(&ik, &asset_desc_hash)
-        } else {
-            AssetBase::native()
-        };
+    fn shielded_bundle() {
+        let pk = ProvingKey::build();
+        let mut rng = OsRng;
 
         // Pretend we derived the spending key via ZIP 32.
         let zip32_derivation = Zip32Derivation::parse([1; 32], vec![]).unwrap();
@@ -534,7 +413,7 @@ mod tests {
                 if let Some(note) = Note::from_parts(
                     recipient,
                     value,
-                    asset,
+                    AssetBase::native(),
                     rho,
                     RandomSeed::random(&mut rng, &rho),
                 )
@@ -570,7 +449,7 @@ mod tests {
         };
 
         // Run the Creator and Constructor roles.
-        let mut builder = Builder::new(bundle_type, anchor);
+        let mut builder = Builder::new(BundleType::DEFAULT_VANILLA, anchor);
         builder
             .add_spend(fvk.clone(), note, merkle_path.into())
             .unwrap();
@@ -579,7 +458,7 @@ mod tests {
                 None,
                 recipient,
                 NoteValue::from_raw(10_000),
-                asset,
+                AssetBase::native(),
                 [0u8; 512],
             )
             .unwrap();
@@ -588,17 +467,17 @@ mod tests {
                 Some(fvk.to_ovk(Scope::Internal)),
                 fvk.address_at(0u32, Scope::Internal),
                 NoteValue::from_raw(5_000),
-                asset,
+                AssetBase::native(),
                 [0u8; 512],
             )
             .unwrap();
         let balance: i64 = builder.value_balance().unwrap();
         assert_eq!(balance, 0);
-        let mut pczt_bundle = builder.build_for_pczt::<FL>(&mut rng).unwrap().0;
+        let mut pczt_bundle = builder.build_for_pczt(&mut rng).unwrap().0;
 
         // Run the IO Finalizer role.
         let sighash = [0; 32];
-        pczt_bundle.finalize_io(sighash, rng.clone()).unwrap();
+        pczt_bundle.finalize_io(sighash, rng).unwrap();
 
         // Run the Updater role.
         for action in pczt_bundle.actions_mut() {
@@ -611,7 +490,7 @@ mod tests {
         }
 
         // Run the Prover role.
-        pczt_bundle.create_proof::<FL, _>(&pk, rng.clone()).unwrap();
+        pczt_bundle.create_proof(&pk, rng).unwrap();
 
         // TODO: Verify that the PCZT contains sufficient information to decrypt and check
         // `enc_ciphertext`.
@@ -619,73 +498,15 @@ mod tests {
         // Run the Signer role.
         for action in pczt_bundle.actions_mut() {
             if action.spend.zip32_derivation.as_ref() == Some(&zip32_derivation) {
-                action.sign(sighash, &ask, rng.clone()).unwrap();
+                action.sign(sighash, &ask, rng).unwrap();
             }
         }
 
-        // Verify the PCZT bundle before extraction.
-        pczt_bundle
-            .actions
-            .iter()
-            .for_each(|action| action.verify_cv_net().unwrap());
-        pczt_bundle
-            .actions
-            .iter()
-            .for_each(|action| action.spend.verify_nullifier(Some(&fvk)).unwrap());
-        pczt_bundle
-            .actions
-            .iter()
-            .for_each(|action| action.spend.verify_rk(Some(&fvk)).unwrap());
-        pczt_bundle
-            .actions
-            .iter()
-            .for_each(|action| action.output.verify_note_commitment(&action.spend).unwrap());
-
         // Run the Transaction Extractor role.
-        let bundle = pczt_bundle.extract::<i64, FL>().unwrap().unwrap();
-
-        let orchard_digest = hash_bundle_txid_data(&bundle);
+        let bundle = pczt_bundle.extract::<i64>().unwrap().unwrap();
 
         assert_eq!(bundle.value_balance(), &0);
         // We can successfully bind the bundle.
         bundle.apply_binding_signature(sighash, rng).unwrap();
-
-        orchard_digest
-    }
-
-    #[test]
-    fn shielded_bundle_orchard_zsa() {
-        let orchard_digest = shielded_bundle::<OrchardZSA>(BundleType::DEFAULT_ZSA, true);
-        assert_eq!(
-            orchard_digest.as_bytes(),
-            // Locks the `orchard_digest` for OrchardZSA
-            &[
-                144, 163, 81, 183, 182, 35, 14, 118, 136, 151, 227, 118, 194, 19, 150, 182, 12, 69,
-                84, 141, 149, 253, 27, 56, 110, 185, 93, 33, 250, 222, 97, 91
-            ],
-        );
-        let orchard_digest = shielded_bundle::<OrchardZSA>(BundleType::DEFAULT_VANILLA, false);
-        assert_eq!(
-            orchard_digest.as_bytes(),
-            // Locks the `orchard_digest` for OrchardZSA
-            &[
-                34, 179, 215, 77, 244, 97, 43, 180, 112, 169, 87, 174, 23, 157, 98, 43, 72, 248,
-                198, 6, 24, 193, 245, 116, 123, 100, 230, 178, 196, 32, 5, 103
-            ],
-        );
-    }
-
-    #[test]
-    fn shielded_bundle_orchard_vanilla() {
-        let orchard_digest = shielded_bundle::<OrchardVanilla>(BundleType::DEFAULT_VANILLA, false);
-        assert_eq!(
-            orchard_digest.as_bytes(),
-            // `orchard_digest` taken from the `zcash/orchard` repository at commit `4ac248d0` (v0.11.0)
-            // This ensures backward compatibility.
-            &[
-                231, 253, 96, 110, 94, 252, 150, 231, 45, 160, 60, 178, 10, 219, 95, 29, 113, 154,
-                223, 96, 50, 247, 213, 119, 211, 232, 186, 59, 24, 93, 177, 225
-            ],
-        );
     }
 }

--- a/src/pczt/io_finalizer.rs
+++ b/src/pczt/io_finalizer.rs
@@ -3,8 +3,9 @@ use alloc::vec::Vec;
 use rand::{CryptoRng, RngCore};
 
 use crate::{
-    bundle::derive_bvk_raw, keys::SpendAuthorizingKey, primitives::redpallas,
-    value::ValueCommitTrapdoor,
+    keys::SpendAuthorizingKey,
+    primitives::redpallas,
+    value::{ValueCommitTrapdoor, ValueCommitment},
 };
 
 use super::SignerError;
@@ -29,15 +30,13 @@ impl super::Bundle {
         let bsk = rcvs.into_iter().sum::<ValueCommitTrapdoor>().into_bsk();
 
         // Verify that bsk and bvk are consistent.
-        let bvk = derive_bvk_raw(
-            &self
-                .actions
-                .iter()
-                .map(|a| a.cv_net().clone())
-                .collect::<Vec<_>>(),
-            self.value_sum,
-            &self.burn,
-        );
+        let bvk = (self
+            .actions
+            .iter()
+            .map(|a| a.cv_net())
+            .sum::<ValueCommitment>()
+            - ValueCommitment::derive(self.value_sum, ValueCommitTrapdoor::zero()))
+        .into_bvk();
         if redpallas::VerificationKey::from(&bsk) != bvk {
             return Err(IoFinalizerError::ValueCommitMismatch);
         }

--- a/src/pczt/io_finalizer.rs
+++ b/src/pczt/io_finalizer.rs
@@ -3,9 +3,8 @@ use alloc::vec::Vec;
 use rand::{CryptoRng, RngCore};
 
 use crate::{
-    keys::SpendAuthorizingKey,
-    primitives::redpallas,
-    value::{ValueCommitTrapdoor, ValueCommitment},
+    bundle::derive_bvk_raw, keys::SpendAuthorizingKey, primitives::redpallas,
+    value::ValueCommitTrapdoor,
 };
 
 use super::SignerError;
@@ -30,13 +29,15 @@ impl super::Bundle {
         let bsk = rcvs.into_iter().sum::<ValueCommitTrapdoor>().into_bsk();
 
         // Verify that bsk and bvk are consistent.
-        let bvk = (self
-            .actions
-            .iter()
-            .map(|a| a.cv_net())
-            .sum::<ValueCommitment>()
-            - ValueCommitment::derive(self.value_sum, ValueCommitTrapdoor::zero()))
-        .into_bvk();
+        let bvk = derive_bvk_raw(
+            &self
+                .actions
+                .iter()
+                .map(|a| a.cv_net().clone())
+                .collect::<Vec<_>>(),
+            self.value_sum,
+            &[],
+        );
         if redpallas::VerificationKey::from(&bsk) != bvk {
             return Err(IoFinalizerError::ValueCommitMismatch);
         }

--- a/src/pczt/parse.rs
+++ b/src/pczt/parse.rs
@@ -8,12 +8,11 @@ use pasta_curves::pallas;
 use zcash_note_encryption::OutgoingCipherKey;
 use zip32::ChildIndex;
 
-use super::{Action, Bundle, Output, PcztTransmittedNoteCiphertext, Spend, Zip32Derivation};
+use super::{Action, Bundle, Output, Spend, Zip32Derivation};
 use crate::{
     bundle::Flags,
     keys::{FullViewingKey, SpendingKey},
-    note::{AssetBase, ExtractedNoteCommitment, Nullifier, RandomSeed, Rho},
-    orchard_sighash_versioning::{OrchardSighashVersion, VerSpendAuthSig},
+    note::{ExtractedNoteCommitment, Nullifier, RandomSeed, Rho, TransmittedNoteCiphertext},
     primitives::redpallas::{self, SpendAuth},
     tree::{MerkleHashOrchard, MerklePath},
     value::{NoteValue, Sign, ValueCommitTrapdoor, ValueCommitment, ValueSum},
@@ -23,14 +22,11 @@ use crate::{
 impl Bundle {
     /// Parses a PCZT bundle from its component parts.
     /// `value_sum` is represented as `(magnitude, is_negative)`.
-    #[allow(clippy::too_many_arguments)]
     pub fn parse(
         actions: Vec<Action>,
         flags: u8,
         value_sum: (u64, bool),
         anchor: [u8; 32],
-        burn: Vec<([u8; 32], u64)>,
-        expiry_height: u32,
         zkproof: Option<Vec<u8>>,
         bsk: Option<[u8; 32]>,
     ) -> Result<Self, ParseError> {
@@ -52,17 +48,6 @@ impl Bundle {
             .into_option()
             .ok_or(ParseError::InvalidAnchor)?;
 
-        let burn = burn
-            .into_iter()
-            .map(|(burn_asset, burn_value)| {
-                let burn_asset = AssetBase::from_bytes(&burn_asset)
-                    .into_option()
-                    .ok_or(ParseError::InvalidBurn)?;
-                let burn_value = NoteValue::from_raw(burn_value);
-                Ok((burn_asset, burn_value))
-            })
-            .collect::<Result<Vec<_>, _>>()?;
-
         let zkproof = zkproof.map(Proof::new);
 
         let bsk = bsk
@@ -75,8 +60,6 @@ impl Bundle {
             flags,
             value_sum,
             anchor,
-            burn,
-            expiry_height,
             zkproof,
             bsk,
         })
@@ -112,32 +95,20 @@ impl Action {
     }
 }
 
-/// Converts an unsigned 8-bit integer into an `Option<OrchardSighashVersion>`.
-fn orchard_sighash_version_from_u8(n: u8) -> Option<OrchardSighashVersion> {
-    match n {
-        0 => Some(OrchardSighashVersion::V0),
-        u8::MAX => Some(OrchardSighashVersion::NoVersion),
-        _ => None,
-    }
-}
-
 impl Spend {
     /// Parses a PCZT spend from its component parts.
     #[allow(clippy::too_many_arguments)]
     pub fn parse(
         nullifier: [u8; 32],
         rk: [u8; 32],
-        spend_auth_sig: Option<(u8, [u8; 64])>,
+        spend_auth_sig: Option<[u8; 64]>,
         recipient: Option<[u8; 43]>,
         value: Option<u64>,
-        asset: Option<[u8; 32]>,
         rho: Option<[u8; 32]>,
         rseed: Option<[u8; 32]>,
-        rseed_split_note: Option<[u8; 32]>,
         fvk: Option<[u8; 96]>,
         witness: Option<(u32, [[u8; 32]; NOTE_COMMITMENT_TREE_DEPTH])>,
         alpha: Option<[u8; 32]>,
-        split_flag: Option<bool>,
         zip32_derivation: Option<Zip32Derivation>,
         dummy_sk: Option<[u8; 32]>,
         proprietary: BTreeMap<String, Vec<u8>>,
@@ -149,15 +120,7 @@ impl Spend {
         let rk = redpallas::VerificationKey::try_from(rk)
             .map_err(|_| ParseError::InvalidRandomizedKey)?;
 
-        let spend_auth_sig = spend_auth_sig
-            .as_ref()
-            .map(|(version, sig)| {
-                let version = orchard_sighash_version_from_u8(*version)
-                    .ok_or(ParseError::InvalidSighashVersion)?;
-                let sig = redpallas::Signature::<SpendAuth>::from(*sig);
-                Ok(VerSpendAuthSig::new(version, sig))
-            })
-            .transpose()?;
+        let spend_auth_sig = spend_auth_sig.map(redpallas::Signature::<SpendAuth>::from);
 
         let recipient = recipient
             .as_ref()
@@ -169,9 +132,6 @@ impl Spend {
             .transpose()?;
 
         let value = value.map(NoteValue::from_raw);
-
-        let asset: Option<AssetBase> =
-            asset.and_then(|bytes| AssetBase::from_bytes(&bytes).into_option());
 
         let rho = rho
             .map(|rho| {
@@ -185,15 +145,6 @@ impl Spend {
             .map(|rseed| {
                 let rho = rho.as_ref().ok_or(ParseError::MissingRho)?;
                 RandomSeed::from_bytes(rseed, rho)
-                    .into_option()
-                    .ok_or(ParseError::InvalidRandomSeed)
-            })
-            .transpose()?;
-
-        let rseed_split_note = rseed_split_note
-            .map(|rseed_split_note| {
-                let rho = rho.as_ref().ok_or(ParseError::MissingRho)?;
-                RandomSeed::from_bytes(rseed_split_note, rho)
                     .into_option()
                     .ok_or(ParseError::InvalidRandomSeed)
             })
@@ -240,14 +191,11 @@ impl Spend {
             spend_auth_sig,
             recipient,
             value,
-            asset,
             rho,
             rseed,
-            rseed_split_note,
             fvk,
             witness,
             alpha,
-            split_flag,
             zip32_derivation,
             dummy_sk,
             proprietary,
@@ -277,9 +225,12 @@ impl Output {
             .into_option()
             .ok_or(ParseError::InvalidExtractedNoteCommitment)?;
 
-        let encrypted_note = PcztTransmittedNoteCiphertext {
+        let encrypted_note = TransmittedNoteCiphertext {
             epk_bytes: ephemeral_key,
-            enc_ciphertext: enc_ciphertext.to_vec(),
+            enc_ciphertext: enc_ciphertext
+                .as_slice()
+                .try_into()
+                .map_err(|_| ParseError::InvalidEncCiphertext)?,
             out_ciphertext: out_ciphertext
                 .as_slice()
                 .try_into()
@@ -346,8 +297,6 @@ impl Zip32Derivation {
 pub enum ParseError {
     /// An invalid anchor was provided.
     InvalidAnchor,
-    /// An invalid `burn` was provided.
-    InvalidBurn,
     /// An invalid `bsk` was provided.
     InvalidBindingSignatureSigningKey,
     /// An invalid `dummy_sk` was provided.
@@ -370,8 +319,6 @@ pub enum ParseError {
     InvalidRecipient,
     /// An invalid `rho` was provided.
     InvalidRho,
-    /// An invalid `SighashVersion` was provided.
-    InvalidSighashVersion,
     /// An invalid `alpha` was provided.
     InvalidSpendAuthRandomizer,
     /// An invalid `cv_net` was provided.

--- a/src/pczt/parse.rs
+++ b/src/pczt/parse.rs
@@ -5,7 +5,7 @@ use alloc::vec::Vec;
 use ff::PrimeField;
 use incrementalmerkletree::Hashable;
 use pasta_curves::pallas;
-use zcash_note_encryption::OutgoingCipherKey;
+use zcash_note_encryption::{note_bytes::NoteBytes, OutgoingCipherKey};
 use zip32::ChildIndex;
 
 use super::{Action, Bundle, Output, Spend, Zip32Derivation};
@@ -13,7 +13,11 @@ use crate::{
     bundle::Flags,
     keys::{FullViewingKey, SpendingKey},
     note::{ExtractedNoteCommitment, Nullifier, RandomSeed, Rho, TransmittedNoteCiphertext},
-    primitives::redpallas::{self, SpendAuth},
+    orchard_flavor::OrchardVanilla,
+    primitives::{
+        redpallas::{self, SpendAuth},
+        OrchardPrimitives,
+    },
     tree::{MerkleHashOrchard, MerklePath},
     value::{NoteValue, Sign, ValueCommitTrapdoor, ValueCommitment, ValueSum},
     Address, Anchor, Proof, NOTE_COMMITMENT_TREE_DEPTH,
@@ -225,12 +229,12 @@ impl Output {
             .into_option()
             .ok_or(ParseError::InvalidExtractedNoteCommitment)?;
 
-        let encrypted_note = TransmittedNoteCiphertext {
+        let encrypted_note = TransmittedNoteCiphertext::<OrchardVanilla> {
             epk_bytes: ephemeral_key,
-            enc_ciphertext: enc_ciphertext
-                .as_slice()
-                .try_into()
-                .map_err(|_| ParseError::InvalidEncCiphertext)?,
+            enc_ciphertext: <OrchardVanilla as OrchardPrimitives>::NoteCiphertextBytes::from_slice(
+                enc_ciphertext.as_slice(),
+            )
+            .ok_or(ParseError::InvalidEncCiphertext)?,
             out_ciphertext: out_ciphertext
                 .as_slice()
                 .try_into()

--- a/src/pczt/prover.rs
+++ b/src/pczt/prover.rs
@@ -5,14 +5,14 @@ use rand::{CryptoRng, RngCore};
 
 use crate::{
     builder::SpendInfo,
-    circuit::{Circuit, Instance, OrchardCircuit, ProvingKey, Witnesses},
+    circuit::{Circuit, Instance, ProvingKey},
     note::Rho,
     Note, Proof,
 };
 
 impl super::Bundle {
     /// Adds a proof to this PCZT bundle.
-    pub fn create_proof<C: OrchardCircuit, R: RngCore + CryptoRng>(
+    pub fn create_proof<R: RngCore + CryptoRng>(
         &mut self,
         pk: &ProvingKey,
         rng: R,
@@ -34,24 +34,17 @@ impl super::Bundle {
                     .clone()
                     .ok_or(ProverError::MissingFullViewingKey)?;
 
-                let asset = action.spend.asset.ok_or(ProverError::MissingAsset)?;
-
-                let mut note = Note::from_parts(
+                let note = Note::from_parts(
                     action
                         .spend
                         .recipient
                         .ok_or(ProverError::MissingRecipient)?,
                     action.spend.value.ok_or(ProverError::MissingValue)?,
-                    asset,
                     action.spend.rho.ok_or(ProverError::MissingRho)?,
                     action.spend.rseed.ok_or(ProverError::MissingRandomSeed)?,
                 )
                 .into_option()
                 .ok_or(ProverError::InvalidSpendNote)?;
-
-                if let Some(rseed) = action.spend.rseed_split_note {
-                    note.set_rseed_split_note(rseed);
-                }
 
                 let merkle_path = action
                     .spend
@@ -59,16 +52,8 @@ impl super::Bundle {
                     .clone()
                     .ok_or(ProverError::MissingWitness)?;
 
-                let spend = SpendInfo::new(
-                    fvk,
-                    note,
-                    merkle_path,
-                    action
-                        .spend
-                        .split_flag
-                        .ok_or(ProverError::MissingSplitFlag)?,
-                )
-                .ok_or(ProverError::WrongFvkForNote)?;
+                let spend =
+                    SpendInfo::new(fvk, note, merkle_path).ok_or(ProverError::WrongFvkForNote)?;
 
                 let output_note = Note::from_parts(
                     action
@@ -76,7 +61,6 @@ impl super::Bundle {
                         .recipient
                         .ok_or(ProverError::MissingRecipient)?,
                     action.output.value.ok_or(ProverError::MissingValue)?,
-                    asset,
                     Rho::from_nf_old(action.spend.nullifier),
                     action.output.rseed.ok_or(ProverError::MissingRandomSeed)?,
                 )
@@ -87,14 +71,13 @@ impl super::Bundle {
                     .spend
                     .alpha
                     .ok_or(ProverError::MissingSpendAuthRandomizer)?;
-                let rcv = action.rcv.ok_or(ProverError::MissingValueCommitTrapdoor)?;
+                let rcv = action
+                    .rcv
+                    .clone()
+                    .ok_or(ProverError::MissingValueCommitTrapdoor)?;
 
-                Witnesses::from_action_context::<C>(spend, output_note, alpha, rcv)
+                Circuit::from_action_context(spend, output_note, alpha, rcv)
                     .ok_or(ProverError::RhoMismatch)
-                    .map(|witnesses| Circuit::<C> {
-                        witnesses,
-                        phantom: core::marker::PhantomData,
-                    })
             })
             .collect::<Result<Vec<_>, ProverError>>()?;
 
@@ -108,7 +91,8 @@ impl super::Bundle {
                     action.spend.nullifier,
                     action.spend.rk.clone(),
                     action.output.cmx,
-                    self.flags,
+                    self.flags.spends_enabled(),
+                    self.flags.outputs_enabled(),
                 )
             })
             .collect::<Vec<_>>();
@@ -141,14 +125,10 @@ pub enum ProverError {
     MissingSpendAuthRandomizer,
     /// The Prover role requires all `value` fields to be set.
     MissingValue,
-    /// The Prover role requires all `asset` fields to be set.
-    MissingAsset,
     /// The Prover role requires `rcv` to be set.
     MissingValueCommitTrapdoor,
     /// The Prover role requires `witness` to be set.
     MissingWitness,
-    /// The Prover role requires `split_flag` to be set.
-    MissingSplitFlag,
     /// An error occurred while creating the proof.
     ProofFailed(plonk::Error),
     /// The `rho` of the `output_note` is not equal to the nullifier of the spent note.

--- a/src/pczt/prover.rs
+++ b/src/pczt/prover.rs
@@ -5,8 +5,9 @@ use rand::{CryptoRng, RngCore};
 
 use crate::{
     builder::SpendInfo,
-    circuit::{Circuit, Instance, ProvingKey},
-    note::Rho,
+    circuit::{Circuit, Instance, ProvingKey, Witnesses},
+    note::{AssetBase, Rho},
+    orchard_flavor::OrchardVanilla,
     Note, Proof,
 };
 
@@ -40,6 +41,7 @@ impl super::Bundle {
                         .recipient
                         .ok_or(ProverError::MissingRecipient)?,
                     action.spend.value.ok_or(ProverError::MissingValue)?,
+                    AssetBase::native(),
                     action.spend.rho.ok_or(ProverError::MissingRho)?,
                     action.spend.rseed.ok_or(ProverError::MissingRandomSeed)?,
                 )
@@ -52,8 +54,8 @@ impl super::Bundle {
                     .clone()
                     .ok_or(ProverError::MissingWitness)?;
 
-                let spend =
-                    SpendInfo::new(fvk, note, merkle_path).ok_or(ProverError::WrongFvkForNote)?;
+                let spend = SpendInfo::new(fvk, note, merkle_path, false)
+                    .ok_or(ProverError::WrongFvkForNote)?;
 
                 let output_note = Note::from_parts(
                     action
@@ -61,6 +63,7 @@ impl super::Bundle {
                         .recipient
                         .ok_or(ProverError::MissingRecipient)?,
                     action.output.value.ok_or(ProverError::MissingValue)?,
+                    AssetBase::native(),
                     Rho::from_nf_old(action.spend.nullifier),
                     action.output.rseed.ok_or(ProverError::MissingRandomSeed)?,
                 )
@@ -76,8 +79,12 @@ impl super::Bundle {
                     .clone()
                     .ok_or(ProverError::MissingValueCommitTrapdoor)?;
 
-                Circuit::from_action_context(spend, output_note, alpha, rcv)
+                Witnesses::from_action_context::<OrchardVanilla>(spend, output_note, alpha, rcv)
                     .ok_or(ProverError::RhoMismatch)
+                    .map(|witnesses| Circuit::<OrchardVanilla> {
+                        witnesses,
+                        phantom: core::marker::PhantomData,
+                    })
             })
             .collect::<Result<Vec<_>, ProverError>>()?;
 
@@ -91,8 +98,7 @@ impl super::Bundle {
                     action.spend.nullifier,
                     action.spend.rk.clone(),
                     action.output.cmx,
-                    self.flags.spends_enabled(),
-                    self.flags.outputs_enabled(),
+                    self.flags,
                 )
             })
             .collect::<Vec<_>>();

--- a/src/pczt/prover.rs
+++ b/src/pczt/prover.rs
@@ -74,10 +74,7 @@ impl super::Bundle {
                     .spend
                     .alpha
                     .ok_or(ProverError::MissingSpendAuthRandomizer)?;
-                let rcv = action
-                    .rcv
-                    .clone()
-                    .ok_or(ProverError::MissingValueCommitTrapdoor)?;
+                let rcv = action.rcv.ok_or(ProverError::MissingValueCommitTrapdoor)?;
 
                 Witnesses::from_action_context::<OrchardVanilla>(spend, output_note, alpha, rcv)
                     .ok_or(ProverError::RhoMismatch)

--- a/src/pczt/signer.rs
+++ b/src/pczt/signer.rs
@@ -1,10 +1,6 @@
 use rand::{CryptoRng, RngCore};
 
-use crate::{
-    keys::SpendAuthorizingKey,
-    orchard_sighash_versioning::{OrchardSighashVersion, VerSpendAuthSig},
-    primitives::redpallas,
-};
+use crate::{keys::SpendAuthorizingKey, primitives::redpallas};
 
 impl super::Action {
     /// Signs the Orchard spend with the given spend authorizing key.
@@ -27,10 +23,7 @@ impl super::Action {
         let rk = redpallas::VerificationKey::from(&rsk);
 
         if self.spend.rk == rk {
-            self.spend.spend_auth_sig = Some(VerSpendAuthSig::new(
-                OrchardSighashVersion::V0,
-                rsk.sign(rng, &sighash),
-            ));
+            self.spend.spend_auth_sig = Some(rsk.sign(rng, &sighash));
             Ok(())
         } else {
             Err(SignerError::WrongSpendAuthorizingKey)

--- a/src/pczt/tx_extractor.rs
+++ b/src/pczt/tx_extractor.rs
@@ -4,6 +4,8 @@ use rand::{CryptoRng, RngCore};
 use super::Action;
 use crate::{
     bundle::{Authorization, Authorized, EffectsOnly},
+    orchard_flavor::OrchardVanilla,
+    orchard_sighash_versioning::{OrchardSighashVersion, VerBindingSig, VerSpendAuthSig},
     primitives::redpallas::{self, Binding, SpendAuth},
     Proof,
 };
@@ -16,7 +18,7 @@ impl super::Bundle {
     /// [regular `Bundle`]: crate::Bundle
     pub fn extract_effects<V: TryFrom<i64>>(
         &self,
-    ) -> Result<Option<crate::Bundle<EffectsOnly, V>>, TxExtractorError> {
+    ) -> Result<Option<crate::Bundle<EffectsOnly, V, OrchardVanilla>>, TxExtractorError> {
         self.to_tx_data(|_| Ok(()), |_| Ok(EffectsOnly))
     }
 
@@ -27,7 +29,7 @@ impl super::Bundle {
     /// [regular `Bundle`]: crate::Bundle
     pub fn extract<V: TryFrom<i64>>(
         self,
-    ) -> Result<Option<crate::Bundle<Unbound, V>>, TxExtractorError> {
+    ) -> Result<Option<crate::Bundle<Unbound, V, OrchardVanilla>>, TxExtractorError> {
         self.to_tx_data(
             |action| {
                 action
@@ -56,7 +58,7 @@ impl super::Bundle {
         &self,
         action_auth: F,
         bundle_auth: G,
-    ) -> Result<Option<crate::Bundle<A, V>>, E>
+    ) -> Result<Option<crate::Bundle<A, V, OrchardVanilla>>, E>
     where
         A: Authorization,
         E: From<TxExtractorError>,
@@ -93,6 +95,7 @@ impl super::Bundle {
                 actions,
                 self.flags,
                 value_balance,
+                vec![], //No burn in PCZT V1
                 self.anchor,
                 authorization,
             ))
@@ -126,7 +129,7 @@ impl Authorization for Unbound {
     type SpendAuth = redpallas::Signature<SpendAuth>;
 }
 
-impl<V> crate::Bundle<Unbound, V> {
+impl<V> crate::Bundle<Unbound, V, OrchardVanilla> {
     /// Verifies the given sighash with every `spend_auth_sig`, and then binds the bundle.
     ///
     /// Returns `None` if the given sighash does not validate against every `spend_auth_sig`.
@@ -134,7 +137,7 @@ impl<V> crate::Bundle<Unbound, V> {
         self,
         sighash: [u8; 32],
         rng: R,
-    ) -> Option<crate::Bundle<Authorized, V>> {
+    ) -> Option<crate::Bundle<Authorized, V, OrchardVanilla>> {
         if self
             .actions()
             .iter()
@@ -142,8 +145,13 @@ impl<V> crate::Bundle<Unbound, V> {
         {
             Some(self.map_authorization(
                 &mut (),
-                |_, _, a| a,
-                |_, Unbound { proof, bsk }| Authorized::from_parts(proof, bsk.sign(rng, &sighash)),
+                |_, _, a| VerSpendAuthSig::new(OrchardSighashVersion::V0, a),
+                |_, Unbound { proof, bsk }| {
+                    Authorized::from_parts(
+                        proof,
+                        VerBindingSig::new(OrchardSighashVersion::V0, bsk.sign(rng, &sighash)),
+                    )
+                },
             ))
         } else {
             None

--- a/src/pczt/tx_extractor.rs
+++ b/src/pczt/tx_extractor.rs
@@ -4,11 +4,7 @@ use rand::{CryptoRng, RngCore};
 use super::Action;
 use crate::{
     bundle::{Authorization, Authorized, EffectsOnly},
-    orchard_sighash_versioning::{OrchardSighashVersion, VerBindingSig, VerSpendAuthSig},
-    primitives::{
-        redpallas::{self, Binding},
-        OrchardPrimitives,
-    },
+    primitives::redpallas::{self, Binding, SpendAuth},
     Proof,
 };
 
@@ -18,9 +14,9 @@ impl super::Bundle {
     /// This is used by the Signer role to produce the transaction sighash.
     ///
     /// [regular `Bundle`]: crate::Bundle
-    pub fn extract_effects<V: TryFrom<i64>, P: OrchardPrimitives>(
+    pub fn extract_effects<V: TryFrom<i64>>(
         &self,
-    ) -> Result<Option<crate::Bundle<EffectsOnly, V, P>>, TxExtractorError> {
+    ) -> Result<Option<crate::Bundle<EffectsOnly, V>>, TxExtractorError> {
         self.to_tx_data(|_| Ok(()), |_| Ok(EffectsOnly))
     }
 
@@ -29,9 +25,9 @@ impl super::Bundle {
     /// This is used by the Transaction Extractor role to produce the final transaction.
     ///
     /// [regular `Bundle`]: crate::Bundle
-    pub fn extract<V: TryFrom<i64>, P: OrchardPrimitives>(
+    pub fn extract<V: TryFrom<i64>>(
         self,
-    ) -> Result<Option<crate::Bundle<Unbound, V, P>>, TxExtractorError> {
+    ) -> Result<Option<crate::Bundle<Unbound, V>>, TxExtractorError> {
         self.to_tx_data(
             |action| {
                 action
@@ -48,6 +44,7 @@ impl super::Bundle {
                         .ok_or(TxExtractorError::MissingProof)?,
                     bsk: bundle
                         .bsk
+                        .clone()
                         .ok_or(TxExtractorError::MissingBindingSignatureSigningKey)?,
                 })
             },
@@ -55,18 +52,17 @@ impl super::Bundle {
     }
 
     /// Converts this PCZT bundle into a regular bundle with the given authorizations.
-    fn to_tx_data<A, V, E, F, G, P>(
+    fn to_tx_data<A, V, E, F, G>(
         &self,
         action_auth: F,
         bundle_auth: G,
-    ) -> Result<Option<crate::Bundle<A, V, P>>, E>
+    ) -> Result<Option<crate::Bundle<A, V>>, E>
     where
         A: Authorization,
         E: From<TxExtractorError>,
         F: Fn(&Action) -> Result<<A as Authorization>::SpendAuth, E>,
         G: FnOnce(&Self) -> Result<A, E>,
         V: TryFrom<i64>,
-        P: OrchardPrimitives,
     {
         let actions = self
             .actions
@@ -78,7 +74,7 @@ impl super::Bundle {
                     action.spend.nullifier,
                     action.spend.rk.clone(),
                     action.output.cmx,
-                    action.output.encrypted_note.clone().into(),
+                    action.output.encrypted_note.clone(),
                     action.cv_net.clone(),
                     authorization,
                 ))
@@ -97,7 +93,6 @@ impl super::Bundle {
                 actions,
                 self.flags,
                 value_balance,
-                self.burn.clone(),
                 self.anchor,
                 authorization,
             ))
@@ -128,10 +123,10 @@ pub struct Unbound {
 }
 
 impl Authorization for Unbound {
-    type SpendAuth = VerSpendAuthSig;
+    type SpendAuth = redpallas::Signature<SpendAuth>;
 }
 
-impl<P: OrchardPrimitives, V> crate::Bundle<Unbound, V, P> {
+impl<V> crate::Bundle<Unbound, V> {
     /// Verifies the given sighash with every `spend_auth_sig`, and then binds the bundle.
     ///
     /// Returns `None` if the given sighash does not validate against every `spend_auth_sig`.
@@ -139,22 +134,16 @@ impl<P: OrchardPrimitives, V> crate::Bundle<Unbound, V, P> {
         self,
         sighash: [u8; 32],
         rng: R,
-    ) -> Option<crate::Bundle<Authorized, V, P>> {
-        if self.actions().iter().all(|action| {
-            action
-                .rk()
-                .verify(&sighash, action.authorization().sig())
-                .is_ok()
-        }) {
+    ) -> Option<crate::Bundle<Authorized, V>> {
+        if self
+            .actions()
+            .iter()
+            .all(|action| action.rk().verify(&sighash, action.authorization()).is_ok())
+        {
             Some(self.map_authorization(
                 &mut (),
                 |_, _, a| a,
-                |_, Unbound { proof, bsk }| {
-                    Authorized::from_parts(
-                        proof,
-                        VerBindingSig::new(OrchardSighashVersion::V0, bsk.sign(rng, &sighash)),
-                    )
-                },
+                |_, Unbound { proof, bsk }| Authorized::from_parts(proof, bsk.sign(rng, &sighash)),
             ))
         } else {
             None

--- a/src/pczt/tx_extractor.rs
+++ b/src/pczt/tx_extractor.rs
@@ -46,7 +46,6 @@ impl super::Bundle {
                         .ok_or(TxExtractorError::MissingProof)?,
                     bsk: bundle
                         .bsk
-                        .clone()
                         .ok_or(TxExtractorError::MissingBindingSignatureSigningKey)?,
                 })
             },

--- a/src/pczt/verify.rs
+++ b/src/pczt/verify.rs
@@ -1,6 +1,6 @@
 use crate::{
     keys::{FullViewingKey, SpendValidatingKey},
-    note::{ExtractedNoteCommitment, Rho},
+    note::{AssetBase, ExtractedNoteCommitment, Rho},
     value::ValueCommitment,
     Note,
 };
@@ -20,7 +20,7 @@ impl super::Action {
             .clone()
             .ok_or(VerifyError::MissingValueCommitTrapdoor)?;
 
-        let cv_net = ValueCommitment::derive(spend_value - output_value, rcv);
+        let cv_net = ValueCommitment::derive(spend_value - output_value, rcv, AssetBase::native());
         if cv_net.to_bytes() == self.cv_net.to_bytes() {
             Ok(())
         } else {
@@ -69,6 +69,7 @@ impl super::Spend {
         let note = Note::from_parts(
             self.recipient.ok_or(VerifyError::MissingRecipient)?,
             self.value.ok_or(VerifyError::MissingValue)?,
+            AssetBase::native(),
             self.rho.ok_or(VerifyError::MissingRho)?,
             self.rseed.ok_or(VerifyError::MissingRandomSeed)?,
         )
@@ -127,6 +128,7 @@ impl super::Output {
         let note = Note::from_parts(
             self.recipient.ok_or(VerifyError::MissingRecipient)?,
             self.value.ok_or(VerifyError::MissingValue)?,
+            AssetBase::native(),
             Rho::from_nf_old(spend.nullifier),
             self.rseed.ok_or(VerifyError::MissingRandomSeed)?,
         )

--- a/src/pczt/verify.rs
+++ b/src/pczt/verify.rs
@@ -15,10 +15,7 @@ impl super::Action {
     pub fn verify_cv_net(&self) -> Result<(), VerifyError> {
         let spend_value = self.spend().value.ok_or(VerifyError::MissingValue)?;
         let output_value = self.output().value.ok_or(VerifyError::MissingValue)?;
-        let rcv = self
-            .rcv
-            .clone()
-            .ok_or(VerifyError::MissingValueCommitTrapdoor)?;
+        let rcv = self.rcv.ok_or(VerifyError::MissingValueCommitTrapdoor)?;
 
         let cv_net = ValueCommitment::derive(spend_value - output_value, rcv, AssetBase::native());
         if cv_net.to_bytes() == self.cv_net.to_bytes() {

--- a/src/pczt/verify.rs
+++ b/src/pczt/verify.rs
@@ -1,7 +1,7 @@
 use crate::{
     keys::{FullViewingKey, SpendValidatingKey},
     note::{ExtractedNoteCommitment, Rho},
-    value::{NoteValue, ValueCommitment},
+    value::ValueCommitment,
     Note,
 };
 
@@ -13,24 +13,14 @@ impl super::Action {
     /// - `output.value`
     /// - `rcv`
     pub fn verify_cv_net(&self) -> Result<(), VerifyError> {
-        let spend_value = match self
-            .spend()
-            .split_flag
-            .ok_or(VerifyError::MissingSplitFlag)?
-        {
-            true => NoteValue::zero(),
-            false => self.spend().value.ok_or(VerifyError::MissingValue)?,
-        };
-
-        self.spend().value.ok_or(VerifyError::MissingValue)?;
+        let spend_value = self.spend().value.ok_or(VerifyError::MissingValue)?;
         let output_value = self.output().value.ok_or(VerifyError::MissingValue)?;
-        let rcv = self.rcv.ok_or(VerifyError::MissingValueCommitTrapdoor)?;
+        let rcv = self
+            .rcv
+            .clone()
+            .ok_or(VerifyError::MissingValueCommitTrapdoor)?;
 
-        let cv_net = ValueCommitment::derive(
-            spend_value - output_value,
-            rcv,
-            self.spend.asset.ok_or(VerifyError::MissingAsset)?,
-        );
+        let cv_net = ValueCommitment::derive(spend_value - output_value, rcv);
         if cv_net.to_bytes() == self.cv_net.to_bytes() {
             Ok(())
         } else {
@@ -76,19 +66,14 @@ impl super::Spend {
     ) -> Result<(), VerifyError> {
         let fvk = self.fvk_for_validation(expected_fvk)?;
 
-        let mut note = Note::from_parts(
+        let note = Note::from_parts(
             self.recipient.ok_or(VerifyError::MissingRecipient)?,
             self.value.ok_or(VerifyError::MissingValue)?,
-            self.asset.ok_or(VerifyError::MissingAsset)?,
             self.rho.ok_or(VerifyError::MissingRho)?,
             self.rseed.ok_or(VerifyError::MissingRandomSeed)?,
         )
         .into_option()
         .ok_or(VerifyError::InvalidSpendNote)?;
-
-        if let Some(rseed) = self.rseed_split_note {
-            note.set_rseed_split_note(rseed);
-        }
 
         // We need both the note and the FVK to verify the nullifier; we have everything
         // needed to also verify that the correct FVK was provided (the nullifier check
@@ -142,7 +127,6 @@ impl super::Output {
         let note = Note::from_parts(
             self.recipient.ok_or(VerifyError::MissingRecipient)?,
             self.value.ok_or(VerifyError::MissingValue)?,
-            spend.asset.ok_or(VerifyError::MissingAsset)?,
             Rho::from_nf_old(spend.nullifier),
             self.rseed.ok_or(VerifyError::MissingRandomSeed)?,
         )
@@ -186,10 +170,6 @@ pub enum VerifyError {
     MissingSpendAuthRandomizer,
     /// Verification requires all `value` fields to be set.
     MissingValue,
-    /// Verification requires `asset` to be set.
-    MissingAsset,
-    /// Verification requires `split_flag` to be set.
-    MissingSplitFlag,
     /// `cv_net` verification requires `rcv` to be set.
     MissingValueCommitTrapdoor,
     /// The provided `fvk` does not own the spent note.


### PR DESCRIPTION
The current version of PCZT corresponds to PCZT V2 which is not backward compatible with PCZT V1.
In this PR, we revert the implementation back to PCZT V1 to restore compatibility with the existing system.
The PCZT V2 implementation will be reintroduced later.