### PR TITLE
Remove dev-only numeric-extension patterns mistakenly committed to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,3 @@
 .vscode
 .idea
 action-circuit-layout.png
-*.[0-9]
-*.[0-9][0-9]


### PR DESCRIPTION
This PR deletes two lines from `.gitignore`:

```
*.[0-9]
*.[0-9][0-9]
```

These patterns were added locally for personal development to hide temporary file copies and were accidentally committed in a prior large PR (see QED-it/orchard#104). They ignore any files ending in `.0–.99`, which can mask real files and cause confusion.