### PR TITLE
PR471 review: CI: disable LTO in release tests; add apt update to Ubuntu steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run tests
+        env:
+          # Disable LTO in CI to avoid very slow/hanging release test builds on macOS (rustc/LLVM).
+          CARGO_PROFILE_RELEASE_LTO: "off"
         run: cargo test --verbose --release
       - name: Verify working directory is clean
         run: git diff --exit-code
@@ -34,7 +37,7 @@ jobs:
         id: toolchain
       - run: rustup override set ${{steps.toolchain.outputs.name}}
       - if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get -y install libfontconfig1-dev
+        run: sudo apt-get update && sudo apt-get -y install libfontconfig1-dev
       - name: Remove lockfile to build with latest dependencies
         run: rm Cargo.lock
       - name: Build crate
@@ -128,7 +131,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: cargo fetch
       # Requires #![deny(rustdoc::broken_intra_doc_links)] in crates.
-      - run: sudo apt-get -y install libfontconfig1-dev
+      - run: sudo apt-get update && sudo apt-get -y install libfontconfig1-dev
       - name: Check intra-doc links
         run: cargo doc --all-features --document-private-items
 


### PR DESCRIPTION
1. Disable LTO for cargo test --release in CI to avoid very slow / stuck macOS builds (rustc/LLVM during release test compilation).

2. Run apt-get update before installing libfontconfig1-dev on Ubuntu to prevent intermittent 404s from stale package indexes.