### PR TITLE
PR471 review: add IssuanceFlags to handle ZIP 230 issuance flags byte

### DIFF
--- a/src/bundle/commitments.rs
+++ b/src/bundle/commitments.rs
@@ -119,7 +119,7 @@ pub(crate) fn hash_issue_bundle_txid_data<A: IssueAuth>(bundle: &IssueBundle<A>)
             ind.update(note.rseed().as_bytes());
         }
         ia.update(ind.finalize().as_bytes());
-        ia.update(&[u8::from(action.is_finalized())]);
+        ia.update(&[action.flags().to_byte()]);
     }
     h.update(ia.finalize().as_bytes());
     h.finalize()

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -117,7 +117,7 @@ pub struct IssueAction {
     asset_desc_hash: [u8; 32],
     /// The newly issued notes.
     notes: Vec<Note>,
-    /// Issuance action flags (`flagsIssuance` in ZIP 230).
+    /// Issuance-specific flags for this `IssueAction`.
     flags: IssuanceFlags,
 }
 

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -58,7 +58,11 @@ pub struct IssueBundle<T: IssueAuth> {
     authorization: T,
 }
 
-/// Flags for an issuance action (`flagsIssuance` in ZIP 230).
+/// Flags for an issuance action.
+///
+/// flagsIssuance is defined in [ZIP-230: Version 6 Transaction Format][issueaction].
+///
+/// [issueaction]: https://zips.z.cash/zip-0230#issuance-action-description-issueaction
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct IssuanceFlags {
     /// Flag denoting whether issuance of this asset type is finalized.

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -81,7 +81,9 @@ impl IssuanceFlags {
         self.finalize
     }
 
-    /// Serialize to `flagsIssuance` byte (ZIP 230).
+    /// Serialize IssuanceFlags to a byte as defined in [ZIP-230: Version 6 Transaction Format][issueaction].
+    ///
+    /// [issueaction]: https://zips.z.cash/zip-0230#issuance-action-description-issueaction
     pub fn to_byte(&self) -> u8 {
         let mut value = 0u8;
         if self.finalize {

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -92,9 +92,11 @@ impl IssuanceFlags {
         value
     }
 
-    /// Parse from `flagsIssuance` byte (ZIP 230).
+    /// Parse issuance flags from a single byte as defined in [ZIP-230: Version 6 Transaction Format][issueaction].
     ///
-    /// Returns `None` if any reserved bits are set.
+    /// Returns `None` if unexpected bits are set in the flag byte.
+    ///
+    /// [issueaction]: https://zips.z.cash/zip-0230#issuance-action-description-issueaction
     pub fn from_byte(value: u8) -> Option<Self> {
         if value & ISSUANCE_FLAGS_EXPECTED_UNSET == 0 {
             Some(Self {

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -58,6 +58,49 @@ pub struct IssueBundle<T: IssueAuth> {
     authorization: T,
 }
 
+/// Flags for an issuance action (`flagsIssuance` in ZIP 230).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct IssuanceFlags {
+    finalize: bool,
+}
+
+const ISSUANCE_FLAG_FINALIZE: u8 = 0b0000_0001;
+const ISSUANCE_FLAGS_EXPECTED_UNSET: u8 = !ISSUANCE_FLAG_FINALIZE;
+
+impl IssuanceFlags {
+    /// Construct a set of flags from its constituent parts
+    pub const fn from_parts(finalize: bool) -> Self {
+        Self { finalize }
+    }
+
+    /// Returns whether the issuance action is marked as `finalize`.
+    pub const fn finalize(&self) -> bool {
+        self.finalize
+    }
+
+    /// Serialize to `flagsIssuance` byte (ZIP 230).
+    pub fn to_byte(&self) -> u8 {
+        let mut value = 0u8;
+        if self.finalize {
+            value |= ISSUANCE_FLAG_FINALIZE;
+        }
+        value
+    }
+
+    /// Parse from `flagsIssuance` byte (ZIP 230).
+    ///
+    /// Returns `None` if any reserved bits are set.
+    pub fn from_byte(value: u8) -> Option<Self> {
+        if value & ISSUANCE_FLAGS_EXPECTED_UNSET == 0 {
+            Some(Self {
+                finalize: (value & ISSUANCE_FLAG_FINALIZE) != 0,
+            })
+        } else {
+            None
+        }
+    }
+}
+
 /// An issue action applied to the global ledger.
 ///
 /// Externally, this creates new zsa notes (adding a commitment to the global ledger).
@@ -67,8 +110,8 @@ pub struct IssueAction {
     asset_desc_hash: [u8; 32],
     /// The newly issued notes.
     notes: Vec<Note>,
-    /// `finalize` will prevent further issuance of the same asset type.
-    finalize: bool,
+    /// Issuance action flags (`flagsIssuance` in ZIP 230).
+    flags: IssuanceFlags,
 }
 
 /// The parameters required to add a Note into an IssueAction.
@@ -104,15 +147,11 @@ pub fn compute_asset_desc_hash(asset_desc: &NonEmpty<u8>) -> [u8; 32] {
 impl IssueAction {
     /// Constructs a new `IssueAction`.
     pub fn new_with_flags(asset_desc_hash: [u8; 32], notes: Vec<Note>, flags: u8) -> Option<Self> {
-        let finalize = match flags {
-            0b0000_0000 => false,
-            0b0000_0001 => true,
-            _ => return None,
-        };
+        let flags = IssuanceFlags::from_byte(flags)?;
         Some(IssueAction {
             asset_desc_hash,
             notes,
-            finalize,
+            flags,
         })
     }
 
@@ -121,7 +160,7 @@ impl IssueAction {
         IssueAction {
             asset_desc_hash,
             notes,
-            finalize,
+            flags: IssuanceFlags::from_parts(finalize),
         }
     }
 
@@ -137,7 +176,7 @@ impl IssueAction {
 
     /// Returns whether the asset type was finalized in this action.
     pub fn is_finalized(&self) -> bool {
-        self.finalize
+        self.flags.finalize()
     }
 
     /// Verifies and computes the new asset supply for an `IssueAction`.
@@ -195,14 +234,9 @@ impl IssueAction {
         Ok((issue_asset, value_sum))
     }
 
-    /// Serialize `finalize` flag to a byte
-    #[allow(clippy::bool_to_int_with_if)]
-    pub fn flags(&self) -> u8 {
-        if self.finalize {
-            0b0000_0001
-        } else {
-            0b0000_0000
-        }
+    /// Returns the flags for this action.
+    pub fn flags(&self) -> &IssuanceFlags {
+        &self.flags
     }
 
     /// Returns the reference note if the first note matches the reference note criteria.
@@ -387,7 +421,7 @@ impl IssueBundle<AwaitingNullifier> {
             None => IssueAction {
                 asset_desc_hash,
                 notes,
-                finalize: true,
+                flags: IssuanceFlags::from_parts(true),
             },
             Some(issue_info) => {
                 let note = Note::new(
@@ -403,7 +437,7 @@ impl IssueBundle<AwaitingNullifier> {
                 IssueAction {
                     asset_desc_hash,
                     notes,
-                    finalize: false,
+                    flags: IssuanceFlags::from_parts(false),
                 }
             }
         };
@@ -460,7 +494,7 @@ impl IssueBundle<AwaitingNullifier> {
                 self.actions.push(IssueAction {
                     asset_desc_hash,
                     notes,
-                    finalize: false,
+                    flags: IssuanceFlags::from_parts(false),
                 });
             }
         };
@@ -476,7 +510,7 @@ impl IssueBundle<AwaitingNullifier> {
             .find(|issue_action| issue_action.asset_desc_hash.eq(asset_desc_hash))
         {
             Some(issue_action) => {
-                issue_action.finalize = true;
+                issue_action.flags = IssuanceFlags::from_parts(true);
             }
             None => {
                 return Err(IssueActionNotFound);
@@ -843,7 +877,7 @@ mod tests {
         },
         issuance::{
             compute_asset_desc_hash, is_reference_note, verify_issue_bundle, AssetRecord,
-            IssueAction, IssueBundle, IssueInfo, Signed,
+            IssuanceFlags, IssueAction, IssueBundle, IssueInfo, Signed,
         },
         issuance_auth::{IssueAuthKey, IssueValidatingKey, ZSASchnorr},
         issuance_sighash_versioning::{IssueSighashVersion, VerBIP340IssueAuthSig},
@@ -865,6 +899,21 @@ mod tests {
     use rand::RngCore;
     use shardtree::store::memory::MemoryShardStore;
     use shardtree::ShardTree;
+
+    #[test]
+    fn issuance_flags_roundtrip() {
+        for &b in &[0u8, 1u8] {
+            let f = IssuanceFlags::from_byte(b).unwrap();
+            assert_eq!(f.to_byte(), b);
+        }
+    }
+
+    #[test]
+    fn issuance_flags_rejects_reserved_bits() {
+        for b in 2u8..=255 {
+            assert!(IssuanceFlags::from_byte(b).is_none());
+        }
+    }
 
     /// Validation for reference note
     ///
@@ -1769,10 +1818,10 @@ mod tests {
             compute_asset_desc_hash(&NonEmpty::from_slice(b"Asset description").unwrap());
 
         let action = IssueAction::new_with_flags(asset_desc_hash, vec![note], 0u8).unwrap();
-        assert_eq!(action.flags(), 0b0000_0000);
+        assert_eq!(action.flags().to_byte(), 0b0000_0000);
 
         let action = IssueAction::new_with_flags(asset_desc_hash, vec![note], 1u8).unwrap();
-        assert_eq!(action.flags(), 0b0000_0001);
+        assert_eq!(action.flags().to_byte(), 0b0000_0001);
 
         let action = IssueAction::new_with_flags(asset_desc_hash, vec![note], 2u8);
         assert!(action.is_none());
@@ -1976,7 +2025,8 @@ mod tests {
 pub mod testing {
     use crate::{
         issuance::{
-            AwaitingNullifier, IssueAction, IssueBundle, Prepared, Signed, VerBIP340IssueAuthSig,
+            AwaitingNullifier, IssuanceFlags, IssueAction, IssueBundle, Prepared, Signed,
+            VerBIP340IssueAuthSig,
         },
         issuance_auth::{
             testing::arb_issuance_validating_key, IssueAuthSig, IssueAuthSigScheme,
@@ -2015,7 +2065,7 @@ pub mod testing {
             IssueAction{
                 asset_desc_hash,
                 notes: vec![note],
-                finalize: false,
+                flags: IssuanceFlags::from_parts(false)
             }
         }
     }

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -61,6 +61,9 @@ pub struct IssueBundle<T: IssueAuth> {
 /// Flags for an issuance action (`flagsIssuance` in ZIP 230).
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub struct IssuanceFlags {
+    /// Flag denoting whether issuance of this asset type is finalized.
+    ///
+    /// If `true`, further issuance of the same asset type is prevented.
     finalize: bool,
 }
 

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -72,7 +72,7 @@ const ISSUANCE_FLAGS_EXPECTED_UNSET: u8 = !ISSUANCE_FLAG_FINALIZE;
 
 impl IssuanceFlags {
     /// Construct a set of flags from its constituent parts
-    pub const fn from_parts(finalize: bool) -> Self {
+    pub(crate) const fn from_parts(finalize: bool) -> Self {
         Self { finalize }
     }
 

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -60,7 +60,7 @@ pub struct IssueBundle<T: IssueAuth> {
 
 /// Flags for an issuance action.
 ///
-/// flagsIssuance is defined in [ZIP-230: Version 6 Transaction Format][issueaction].
+/// `flagsIssuance` is defined in [ZIP-230: Version 6 Transaction Format][issueaction].
 ///
 /// [issueaction]: https://zips.z.cash/zip-0230#issuance-action-description-issueaction
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -85,7 +85,8 @@ impl IssuanceFlags {
         self.finalize
     }
 
-    /// Serialize IssuanceFlags to a byte as defined in [ZIP-230: Version 6 Transaction Format][issueaction].
+    /// Serialize `IssuanceFlags` to a byte as defined in
+    /// [ZIP-230: Version 6 Transaction Format][issueaction].
     ///
     /// [issueaction]: https://zips.z.cash/zip-0230#issuance-action-description-issueaction
     pub fn to_byte(&self) -> u8 {
@@ -96,7 +97,8 @@ impl IssuanceFlags {
         value
     }
 
-    /// Parse issuance flags from a single byte as defined in [ZIP-230: Version 6 Transaction Format][issueaction].
+    /// Parse issuance flags from a single byte as defined in
+    /// [ZIP-230: Version 6 Transaction Format][issueaction].
     ///
     /// Returns `None` if unexpected bits are set in the flag byte.
     ///


### PR DESCRIPTION
Address review comment r2602307494: introduce `IssuanceFlags` (similar to `bundle::Flags`) to centralize issuance flags parsing/encoding per ZIP 230 and reject reserved bits.