### PR TITLE
PR471 review:  fix arb_asset_base generation

### DIFF
--- a/src/note/asset_base.rs
+++ b/src/note/asset_base.rs
@@ -170,13 +170,11 @@ pub mod testing {
 
     prop_compose! {
         /// Generate a uniformly distributed note type
-            pub fn arb_asset_base()
-                (is_native in prop::bool::ANY)
-                (asset in if is_native {
-                    Just(AssetBase::native()).boxed()
-                } else {
-                    arb_zsa_asset_base().boxed()
-            })
+        pub fn arb_asset_base()
+            (asset in prop_oneof![
+                Just(AssetBase::native()),
+                arb_zsa_asset_base(),
+            ])
             -> AssetBase
         {
             asset

--- a/src/note/asset_base.rs
+++ b/src/note/asset_base.rs
@@ -170,16 +170,16 @@ pub mod testing {
 
     prop_compose! {
         /// Generate a uniformly distributed note type
-        pub fn arb_asset_base()(
-            is_native in prop::bool::ANY,
-            isk in arb_issuance_authorizing_key(),
-            asset_desc_hash in any::<[u8; 32]>(),
-        ) -> AssetBase {
-            if is_native {
-                AssetBase::native()
-            } else {
-                AssetBase::derive(&IssueValidatingKey::from(&isk), &asset_desc_hash)
-            }
+            pub fn arb_asset_base()
+                (is_native in prop::bool::ANY)
+                (asset in if is_native {
+                    Just(AssetBase::native()).boxed()
+                } else {
+                    arb_zsa_asset_base().boxed()
+            })
+            -> AssetBase
+        {
+            asset
         }
     }
 

--- a/src/note/asset_base.rs
+++ b/src/note/asset_base.rs
@@ -169,7 +169,7 @@ pub mod testing {
     };
 
     prop_compose! {
-        /// Generate a uniformly distributed note type
+        /// Generate a uniformly distributed asset base
         pub fn arb_asset_base()
             (asset in prop_oneof![
                 Just(AssetBase::native()),


### PR DESCRIPTION
Address review comment r2550650833: only generate (`isk`, `asset_desc_hash`) for non-native assets.