### PR TITLE
PR471 review: pass asset as an argument into action proptest generators

### DIFF
--- a/src/action.rs
+++ b/src/action.rs
@@ -133,8 +133,8 @@ pub(crate) mod testing {
 
     use crate::{
         note::{
-            asset_base::testing::arb_asset_base, commitment::ExtractedNoteCommitment,
-            nullifier::testing::arb_nullifier, testing::arb_note, Note, TransmittedNoteCiphertext,
+            commitment::ExtractedNoteCommitment, nullifier::testing::arb_nullifier,
+            testing::arb_note, AssetBase, Note, TransmittedNoteCiphertext,
         },
         orchard_sighash_versioning::VerSpendAuthSig,
         primitives::redpallas::{
@@ -174,11 +174,14 @@ pub(crate) mod testing {
 
         prop_compose! {
             /// Generate an action without authorization data.
-            pub fn arb_unauthorized_action(spend_value: NoteValue, output_value: NoteValue)(
+            pub fn arb_unauthorized_action(
+                spend_value: NoteValue,
+                output_value: NoteValue,
+                asset: AssetBase)
+            (
                 nf in arb_nullifier(),
                 rk in arb_spendauth_verification_key(),
                 note in arb_note(output_value),
-                asset in arb_asset_base(),
                 rng_seed in prop::array::uniform32(prop::num::u8::ANY),
                 memo in prop::collection::vec(prop::num::u8::ANY, 512),
             ) -> Action<(), P> {
@@ -205,13 +208,16 @@ pub(crate) mod testing {
 
         prop_compose! {
             /// Generate an action with invalid (random) authorization data.
-            pub fn arb_action(spend_value: NoteValue, output_value: NoteValue)(
+            pub fn arb_action(
+                spend_value: NoteValue,
+                output_value: NoteValue,
+                asset: AssetBase,
+            )(
                 nf in arb_nullifier(),
                 sk in arb_spendauth_signing_key(),
                 note in arb_note(output_value),
                 rng_seed in prop::array::uniform32(prop::num::u8::ANY),
                 fake_sighash in prop::array::uniform32(prop::num::u8::ANY),
-                asset in arb_asset_base(),
                 memo in prop::collection::vec(prop::num::u8::ANY, 512),
             ) -> Action<VerSpendAuthSig, P> {
                 let cmx = ExtractedNoteCommitment::from(note.commitment());

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -631,7 +631,10 @@ pub mod testing {
     use proptest::prelude::*;
 
     use crate::{
-        note::{asset_base::testing::arb_zsa_asset_base, AssetBase},
+        note::{
+            asset_base::testing::{arb_asset_base, arb_zsa_asset_base},
+            AssetBase,
+        },
         orchard_sighash_versioning::{VerBindingSig, VerSpendAuthSig},
         primitives::{redpallas::testing::arb_binding_signing_key, OrchardPrimitives},
         value::{
@@ -675,8 +678,11 @@ pub mod testing {
                 };
 
                 output_value_gen.prop_flat_map(move |output_value| {
-                    ActionArb::arb_unauthorized_action(spend_value, output_value)
-                        .prop_map(move |a| (spend_value - output_value, a))
+                    arb_asset_base().prop_flat_map(move |asset| {
+                        let value_sum = spend_value - output_value;
+                        ActionArb::arb_unauthorized_action(spend_value, output_value, asset)
+                            .prop_map(move |a| (value_sum, a))
+                    })
                 })
             })
         }
@@ -700,8 +706,11 @@ pub mod testing {
                 };
 
                 output_value_gen.prop_flat_map(move |output_value| {
-                    ActionArb::arb_action(spend_value, output_value)
-                        .prop_map(move |a| (spend_value - output_value, a))
+                    arb_asset_base().prop_flat_map(move |asset| {
+                        let value_sum = spend_value - output_value;
+                        ActionArb::arb_action(spend_value, output_value, asset)
+                            .prop_map(move |a| (value_sum, a))
+                    })
                 })
             })
         }


### PR DESCRIPTION
Address review comments r2550138371 and r2550140892: make `asset: AssetBase` an explicit argument of `arb_unauthorized_action` and `arb_action` instead of generating it inside the `prop_compose!` bindings. Update bundle proptest helpers to generate an `AssetBase` at the call site (`bundle.rs`) and pass it through.