### PR TITLE
Fix tests for no-default-features

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1532,7 +1532,7 @@ pub mod testing {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "circuit"))]
 mod tests {
     use rand::rngs::OsRng;
 

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -652,7 +652,7 @@ pub mod testing {
     /// in property-based testing, addressing proptest crate limitations.
     #[derive(Debug)]
     pub struct BundleArb<Pr: OrchardPrimitives> {
-        phantom: std::marker::PhantomData<Pr>,
+        phantom: core::marker::PhantomData<Pr>,
     }
 
     impl<Pr: OrchardPrimitives + Default> BundleArb<Pr> {

--- a/src/bundle/commitments.rs
+++ b/src/bundle/commitments.rs
@@ -182,7 +182,7 @@ pub fn get_compact_size(size: usize) -> Vec<u8> {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "circuit"))]
 mod tests {
     use crate::{
         builder::{Builder, BundleType, UnauthorizedBundle},

--- a/src/constants/sinsemilla.rs
+++ b/src/constants/sinsemilla.rs
@@ -154,7 +154,7 @@ impl CommitDomains<pallas::Affine, OrchardFixedBases, OrchardHashDomains> for Or
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "circuit"))]
 mod tests {
     use super::*;
     use crate::constants::{

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -886,9 +886,6 @@ impl fmt::Display for Error {
 #[cfg(test)]
 mod tests {
     use crate::{
-        builder::{Builder, BundleType},
-        circuit::ProvingKey,
-        flavor::OrchardZSA,
         issuance::Error::{
             IncorrectRhoDerivation, InvalidIssueBundleSig, IssueActionNotFound,
             IssueActionPreviouslyFinalizedAssetBase, IssueBundleIkMismatchAssetBase,
@@ -900,23 +897,19 @@ mod tests {
             verify_issue_bundle, AssetRecord, IssuanceFlags, IssueAction, IssueBundle, IssueInfo,
             Signed,
         },
-        keys::{FullViewingKey, Scope, SpendAuthorizingKey, SpendingKey},
-        note::{rho_for_issuance_note, AssetBase, ExtractedNoteCommitment, Nullifier, Rho},
-        tree::{MerkleHashOrchard, MerklePath},
+        keys::{FullViewingKey, Scope, SpendingKey},
+        note::{rho_for_issuance_note, AssetBase, Nullifier, Rho},
         value::NoteValue,
-        Address, Anchor, Bundle, Note,
+        Address, Note,
     };
     use alloc::collections::BTreeMap;
     use alloc::string::{String, ToString};
     use alloc::vec::Vec;
     use group::{Group, GroupEncoding};
-    use incrementalmerkletree::{Marking, Retention};
     use nonempty::NonEmpty;
     use pasta_curves::pallas::{Point, Scalar};
     use rand::rngs::OsRng;
     use rand::RngCore;
-    use shardtree::store::memory::MemoryShardStore;
-    use shardtree::ShardTree;
 
     #[test]
     fn issuance_flags_roundtrip() {
@@ -1894,7 +1887,22 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "circuit")]
     fn verify_rho_computation_for_issuance_notes() {
+        use crate::{
+            builder::{Builder, BundleType},
+            circuit::ProvingKey,
+            flavor::OrchardZSA,
+            keys::SpendAuthorizingKey,
+            note::ExtractedNoteCommitment,
+            tree::{MerkleHashOrchard, MerklePath},
+            Anchor, Bundle,
+        };
+
+        use incrementalmerkletree::{Marking, Retention};
+        use shardtree::store::memory::MemoryShardStore;
+        use shardtree::ShardTree;
+
         // Setup keys
         let pk = ProvingKey::build::<OrchardZSA>();
         let sk = SpendingKey::from_bytes([1; 32]).unwrap();

--- a/src/pczt.rs
+++ b/src/pczt.rs
@@ -331,7 +331,7 @@ impl Zip32Derivation {
     }
 }
 
-#[cfg(test)]
+#[cfg(all(test, feature = "circuit"))]
 mod tests {
     use ff::{Field, PrimeField};
     use incrementalmerkletree::{Marking, Retention};

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -318,13 +318,14 @@ pub fn i2lebsp<const NUM_BITS: usize>(int: u64) -> [bool; NUM_BITS] {
 mod tests {
     use super::{i2lebsp, lebs2ip};
 
-    use group::Group;
-    use halo2_proofs::arithmetic::CurveExt;
-    use pasta_curves::pallas;
     use rand::{rngs::OsRng, RngCore};
 
     #[test]
+    #[cfg(feature = "circuit")]
     fn diversify_hash_substitution() {
+        use group::Group;
+        use halo2_proofs::arithmetic::CurveExt;
+        use pasta_curves::pallas;
         assert!(!bool::from(
             pallas::Point::hash_to_curve("z.cash:Orchard-gd")(&[]).is_identity()
         ));

--- a/tests/builder.rs
+++ b/tests/builder.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "circuit")]
+
 use incrementalmerkletree::{Hashable, Marking, Retention};
 use orchard::{
     builder::{Builder, BundleType},

--- a/tests/zsa.rs
+++ b/tests/zsa.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "circuit")]
+
 mod builder;
 
 use crate::builder::verify_bundle;


### PR DESCRIPTION
Several tests were failing when executing `cargo test --no-default-features` due to missing feature flags.
This PR adds the necessary feature flags to ensure tests are only compiled and run when their required features are enabled.

Most of the fixes are based on changes introduced in [commit](https://github.com/zcash/orchard/commit/92bd43a4595e6d5c21470e137166787e1b2f99cf)
