### PR TITLE
Drop unnecessary Hasher::finish() in AssetBase::hash

### DIFF
--- a/src/note/asset_base.rs
+++ b/src/note/asset_base.rs
@@ -177,7 +177,6 @@ impl AssetBase {
 impl Hash for AssetBase {
     fn hash<H: Hasher>(&self, h: &mut H) {
         h.write(&self.to_bytes());
-        h.finish();
     }
 }
 


### PR DESCRIPTION
This PR removes the `h.finish();` line in `src/note/asset_base.rs` (`AssetBase::hash`) because it does nothing useful there and it generates the `unused_must_use` compilation warning when compiling Orchard as a `librustzcash` dependency:

```
Checking orchard v0.11.0 (/home/dima/devel/qedit/zsa/orchard)
warning: unused return value of `finish` that must be used
   --> /home/dima/devel/qedit/zsa/orchard/src/note/asset_base.rs:149:9
    |
149 |         h.finish();
    |         ^^^^^^^^^^
    |
    = note: `#[warn(unused_must_use)]` on by default
help: use `let _ = ...` to ignore the resulting value
    |
149 |         let _ = h.finish();
    |         +++++++

warning: `orchard` (lib) generated 1 warning
```