### PR TITLE
PR471 review: export issuance empty-hash helpers

### DIFF
--- a/src/bundle/commitments.rs
+++ b/src/bundle/commitments.rs
@@ -15,6 +15,9 @@ mod issuance;
 #[cfg(feature = "zsa-issuance")]
 pub(crate) use issuance::{hash_issue_bundle_auth_data, hash_issue_bundle_txid_data};
 
+#[cfg(feature = "zsa-issuance")]
+pub use issuance::{hash_issue_bundle_auth_empty, hash_issue_bundle_txid_empty};
+
 pub(crate) const ZCASH_ORCHARD_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxIdOrchardHash";
 pub(crate) const ZCASH_ORCHARD_ACTION_GROUPS_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxIdOrcActGHash";
 pub(crate) const ZCASH_ORCHARD_ACTIONS_COMPACT_HASH_PERSONALIZATION: &[u8; 16] =


### PR DESCRIPTION
This change exports (i.e. makes pub) `hash_issue_bundle_txid_empty` and `hash_issue_bundle_auth_empty` from `src/bundle/commitments.rs under` `#[cfg(feature = "zsa-issuance")]`. These helpers are used by `librustzcash/zcash_primitives` crate, see the following module in `librustzcash` repository for details:

`zcash_primitives/src/transaction/txid.rs`

Those functions were accessible as pub before redesigning the commitment module in Orchard PR #214.