### PR TITLE
Pin blake2b_simd to version 1.0.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ rustdoc-args = ["--cfg", "docsrs", "--html-in-header", "katex-header.html"]
 [dependencies]
 aes = "0.8"
 bitvec = { version = "1", default-features = false }
-blake2b_simd = { version = "1", default-features = false }
+blake2b_simd = { version = "=1.0.1", default-features = false }
 ff = { version = "0.13", default-features = false }
 fpe = { version = "0.6", default-features = false, features = ["alloc"] }
 group = "0.13"


### PR DESCRIPTION
The current CI fails due to a new blake2b_simd release using edition = 2024, which breaks the MSRV toolchain