### PR TITLE
PR471 review: Add AssetId enum

### DIFF
--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -39,6 +39,7 @@ use Error::{
 pub mod auth;
 pub mod sighash_versioning;
 
+use crate::note::asset_base::AssetId;
 use auth::{IssueAuthKey, IssueValidatingKey, ZSASchnorr};
 use sighash_versioning::{IssueSighashVersion, VerBIP340IssueAuthSig};
 
@@ -226,7 +227,7 @@ impl IssueAction {
             return Err(IssueActionWithoutNoteNotFinalized);
         }
 
-        let issue_asset = AssetBase::derive(ik, &self.asset_desc_hash);
+        let issue_asset = AssetBase::derive(&AssetId::new_v0(ik.clone(), self.asset_desc_hash));
 
         // The new asset should not be the identity point of the Pallas curve.
         if bool::from(issue_asset.cv_base().is_identity()) {
@@ -367,7 +368,9 @@ impl<T: IssueAuth> IssueBundle<T> {
         let issue_actions: Vec<&IssueAction> = self
             .actions
             .iter()
-            .filter(|a| AssetBase::derive(&self.ik, &a.asset_desc_hash).eq(asset))
+            .filter(|a| {
+                AssetBase::derive(&AssetId::new_v0(self.ik.clone(), a.asset_desc_hash)).eq(asset)
+            })
             .collect();
         match issue_actions.len() {
             0 => None,
@@ -427,7 +430,7 @@ impl IssueBundle<AwaitingNullifier> {
         first_issuance: bool,
         mut rng: impl RngCore,
     ) -> (IssueBundle<AwaitingNullifier>, AssetBase) {
-        let asset = AssetBase::derive(&ik, &asset_desc_hash);
+        let asset = AssetBase::derive(&AssetId::new_v0(ik.clone(), asset_desc_hash));
 
         let mut notes = vec![];
         if first_issuance {
@@ -482,7 +485,7 @@ impl IssueBundle<AwaitingNullifier> {
         first_issuance: bool,
         mut rng: impl RngCore,
     ) -> Result<AssetBase, Error> {
-        let asset = AssetBase::derive(&self.ik, &asset_desc_hash);
+        let asset = AssetBase::derive(&AssetId::new_v0(self.ik.clone(), asset_desc_hash));
 
         let note = Note::new(recipient, value, asset, Rho::zero(), &mut rng);
 
@@ -898,7 +901,7 @@ mod tests {
             Signed,
         },
         keys::{FullViewingKey, Scope, SpendingKey},
-        note::{rho_for_issuance_note, AssetBase, Nullifier, Rho},
+        note::{asset_base::AssetId, rho_for_issuance_note, AssetBase, Nullifier, Rho},
         value::NoteValue,
         Address, Note,
     };
@@ -991,12 +994,12 @@ mod tests {
 
         let note1_asset_desc_hash =
             compute_asset_desc_hash(&NonEmpty::from_slice(note1_asset_desc).unwrap());
-        let asset = AssetBase::derive(&ik, &note1_asset_desc_hash);
+        let asset = AssetBase::derive(&AssetId::new_v0(ik.clone(), note1_asset_desc_hash));
         let note2_asset = note2_asset_desc.map_or(asset, |desc| {
-            AssetBase::derive(
-                &ik,
-                &compute_asset_desc_hash(&NonEmpty::from_slice(desc).unwrap()),
-            )
+            AssetBase::derive(&AssetId::new_v0(
+                ik.clone(),
+                compute_asset_desc_hash(&NonEmpty::from_slice(desc).unwrap()),
+            ))
         });
 
         let note1 = Note::new(
@@ -1156,7 +1159,10 @@ mod tests {
             .unwrap();
         assert_eq!(action2.notes.len(), 2);
         let reference_note = action2.notes.first().unwrap();
-        verify_reference_note(reference_note, AssetBase::derive(&ik, &asset_desc_hash_2));
+        verify_reference_note(
+            reference_note,
+            AssetBase::derive(&AssetId::new_v0(ik, asset_desc_hash_2)),
+        );
         let first_note = action2.notes().get(1).unwrap();
         assert_eq!(first_note.value().inner(), 15);
         assert_eq!(first_note.asset(), third_asset);
@@ -1322,10 +1328,10 @@ mod tests {
         let note = Note::new(
             recipient,
             NoteValue::from_raw(5),
-            AssetBase::derive(
-                bundle.ik(),
-                &compute_asset_desc_hash(&NonEmpty::from_slice(b"zsa_asset").unwrap()),
-            ),
+            AssetBase::derive(&AssetId::new_v0(
+                bundle.ik().clone(),
+                compute_asset_desc_hash(&NonEmpty::from_slice(b"zsa_asset").unwrap()),
+            )),
             Rho::zero(),
             &mut rng,
         );
@@ -1377,7 +1383,7 @@ mod tests {
         assert_eq!(
             issued_assets,
             BTreeMap::from([(
-                AssetBase::derive(&ik, &asset_desc_hash),
+                AssetBase::derive(&AssetId::new_v0(ik, asset_desc_hash)),
                 AssetRecord::new(NoteValue::from_raw(5), false, first_note)
             )])
         );
@@ -1423,7 +1429,7 @@ mod tests {
         assert_eq!(
             issued_assets,
             BTreeMap::from([(
-                AssetBase::derive(&ik, &asset_desc_hash),
+                AssetBase::derive(&AssetId::new_v0(ik, asset_desc_hash)),
                 AssetRecord::new(NoteValue::from_raw(7), true, first_note)
             )])
         );
@@ -1447,9 +1453,9 @@ mod tests {
         let asset3_desc_hash =
             compute_asset_desc_hash(&NonEmpty::from_slice(b"Verify with issued assets 3").unwrap());
 
-        let asset1_base = AssetBase::derive(&ik, &asset1_desc_hash);
-        let asset2_base = AssetBase::derive(&ik, &asset2_desc_hash);
-        let asset3_base = AssetBase::derive(&ik, &asset3_desc_hash);
+        let asset1_base = AssetBase::derive(&AssetId::new_v0(ik.clone(), asset1_desc_hash));
+        let asset2_base = AssetBase::derive(&AssetId::new_v0(ik.clone(), asset2_desc_hash));
+        let asset3_base = AssetBase::derive(&AssetId::new_v0(ik.clone(), asset3_desc_hash));
 
         let (mut bundle, _) = IssueBundle::new(
             ik,
@@ -1606,7 +1612,7 @@ mod tests {
             .sign(&isk)
             .unwrap();
 
-        let final_type = AssetBase::derive(&ik, &asset_desc_hash);
+        let final_type = AssetBase::derive(&AssetId::new_v0(ik, asset_desc_hash));
 
         let issued_assets = [(
             final_type,
@@ -1754,10 +1760,10 @@ mod tests {
         let note = Note::new(
             recipient,
             NoteValue::from_raw(5),
-            AssetBase::derive(
-                signed.ik(),
-                &compute_asset_desc_hash(&NonEmpty::from_slice(b"zsa_asset").unwrap()),
-            ),
+            AssetBase::derive(&AssetId::new_v0(
+                signed.ik().clone(),
+                compute_asset_desc_hash(&NonEmpty::from_slice(b"zsa_asset").unwrap()),
+            )),
             rho_for_issuance_note(&first_nullifier, 0, 2),
             &mut rng,
         );
@@ -1807,7 +1813,7 @@ mod tests {
         let note = Note::new(
             recipient,
             NoteValue::from_raw(55),
-            AssetBase::derive(&incorrect_ik, &asset_desc_hash),
+            AssetBase::derive(&AssetId::new_v0(incorrect_ik, asset_desc_hash)),
             rho_for_issuance_note(&first_nullifier, 0, 0),
             &mut rng,
         );
@@ -1913,10 +1919,10 @@ mod tests {
 
         // Setup note and merkle tree
         let mut rng = OsRng;
-        let asset1 = AssetBase::derive(
-            &ik,
-            &compute_asset_desc_hash(&NonEmpty::from_slice(b"zsa_asset1").unwrap()),
-        );
+        let asset1 = AssetBase::derive(&AssetId::new_v0(
+            ik.clone(),
+            compute_asset_desc_hash(&NonEmpty::from_slice(b"zsa_asset1").unwrap()),
+        ));
         let note1 = Note::new(
             recipient,
             NoteValue::from_raw(10),

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -227,7 +227,7 @@ impl IssueAction {
             return Err(IssueActionWithoutNoteNotFinalized);
         }
 
-        let issue_asset = AssetBase::custom(&AssetId::new_v0(ik.clone(), self.asset_desc_hash));
+        let issue_asset = AssetBase::custom(&AssetId::new_v0(ik, &self.asset_desc_hash));
 
         // The new asset should not be the identity point of the Pallas curve.
         if bool::from(issue_asset.cv_base().is_identity()) {
@@ -368,9 +368,7 @@ impl<T: IssueAuth> IssueBundle<T> {
         let issue_actions: Vec<&IssueAction> = self
             .actions
             .iter()
-            .filter(|a| {
-                AssetBase::custom(&AssetId::new_v0(self.ik.clone(), a.asset_desc_hash)).eq(asset)
-            })
+            .filter(|a| AssetBase::custom(&AssetId::new_v0(&self.ik, &a.asset_desc_hash)).eq(asset))
             .collect();
         match issue_actions.len() {
             0 => None,
@@ -430,7 +428,7 @@ impl IssueBundle<AwaitingNullifier> {
         first_issuance: bool,
         mut rng: impl RngCore,
     ) -> (IssueBundle<AwaitingNullifier>, AssetBase) {
-        let asset = AssetBase::custom(&AssetId::new_v0(ik.clone(), asset_desc_hash));
+        let asset = AssetBase::custom(&AssetId::new_v0(&ik, &asset_desc_hash));
 
         let mut notes = vec![];
         if first_issuance {
@@ -485,7 +483,7 @@ impl IssueBundle<AwaitingNullifier> {
         first_issuance: bool,
         mut rng: impl RngCore,
     ) -> Result<AssetBase, Error> {
-        let asset = AssetBase::custom(&AssetId::new_v0(self.ik.clone(), asset_desc_hash));
+        let asset = AssetBase::custom(&AssetId::new_v0(&self.ik, &asset_desc_hash));
 
         let note = Note::new(recipient, value, asset, Rho::zero(), &mut rng);
 
@@ -994,11 +992,11 @@ mod tests {
 
         let note1_asset_desc_hash =
             compute_asset_desc_hash(&NonEmpty::from_slice(note1_asset_desc).unwrap());
-        let asset = AssetBase::custom(&AssetId::new_v0(ik.clone(), note1_asset_desc_hash));
+        let asset = AssetBase::custom(&AssetId::new_v0(&ik, &note1_asset_desc_hash));
         let note2_asset = note2_asset_desc.map_or(asset, |desc| {
             AssetBase::custom(&AssetId::new_v0(
-                ik.clone(),
-                compute_asset_desc_hash(&NonEmpty::from_slice(desc).unwrap()),
+                &ik,
+                &compute_asset_desc_hash(&NonEmpty::from_slice(desc).unwrap()),
             ))
         });
 
@@ -1161,7 +1159,7 @@ mod tests {
         let reference_note = action2.notes.first().unwrap();
         verify_reference_note(
             reference_note,
-            AssetBase::custom(&AssetId::new_v0(ik, asset_desc_hash_2)),
+            AssetBase::custom(&AssetId::new_v0(&ik, &asset_desc_hash_2)),
         );
         let first_note = action2.notes().get(1).unwrap();
         assert_eq!(first_note.value().inner(), 15);
@@ -1329,8 +1327,8 @@ mod tests {
             recipient,
             NoteValue::from_raw(5),
             AssetBase::custom(&AssetId::new_v0(
-                bundle.ik().clone(),
-                compute_asset_desc_hash(&NonEmpty::from_slice(b"zsa_asset").unwrap()),
+                bundle.ik(),
+                &compute_asset_desc_hash(&NonEmpty::from_slice(b"zsa_asset").unwrap()),
             )),
             Rho::zero(),
             &mut rng,
@@ -1383,7 +1381,7 @@ mod tests {
         assert_eq!(
             issued_assets,
             BTreeMap::from([(
-                AssetBase::custom(&AssetId::new_v0(ik, asset_desc_hash)),
+                AssetBase::custom(&AssetId::new_v0(&ik, &asset_desc_hash)),
                 AssetRecord::new(NoteValue::from_raw(5), false, first_note)
             )])
         );
@@ -1429,7 +1427,7 @@ mod tests {
         assert_eq!(
             issued_assets,
             BTreeMap::from([(
-                AssetBase::custom(&AssetId::new_v0(ik, asset_desc_hash)),
+                AssetBase::custom(&AssetId::new_v0(&ik, &asset_desc_hash)),
                 AssetRecord::new(NoteValue::from_raw(7), true, first_note)
             )])
         );
@@ -1453,9 +1451,9 @@ mod tests {
         let asset3_desc_hash =
             compute_asset_desc_hash(&NonEmpty::from_slice(b"Verify with issued assets 3").unwrap());
 
-        let asset1_base = AssetBase::custom(&AssetId::new_v0(ik.clone(), asset1_desc_hash));
-        let asset2_base = AssetBase::custom(&AssetId::new_v0(ik.clone(), asset2_desc_hash));
-        let asset3_base = AssetBase::custom(&AssetId::new_v0(ik.clone(), asset3_desc_hash));
+        let asset1_base = AssetBase::custom(&AssetId::new_v0(&ik, &asset1_desc_hash));
+        let asset2_base = AssetBase::custom(&AssetId::new_v0(&ik, &asset2_desc_hash));
+        let asset3_base = AssetBase::custom(&AssetId::new_v0(&ik, &asset3_desc_hash));
 
         let (mut bundle, _) = IssueBundle::new(
             ik,
@@ -1612,7 +1610,7 @@ mod tests {
             .sign(&isk)
             .unwrap();
 
-        let final_type = AssetBase::custom(&AssetId::new_v0(ik, asset_desc_hash));
+        let final_type = AssetBase::custom(&AssetId::new_v0(&ik, &asset_desc_hash));
 
         let issued_assets = [(
             final_type,
@@ -1761,8 +1759,8 @@ mod tests {
             recipient,
             NoteValue::from_raw(5),
             AssetBase::custom(&AssetId::new_v0(
-                signed.ik().clone(),
-                compute_asset_desc_hash(&NonEmpty::from_slice(b"zsa_asset").unwrap()),
+                signed.ik(),
+                &compute_asset_desc_hash(&NonEmpty::from_slice(b"zsa_asset").unwrap()),
             )),
             rho_for_issuance_note(&first_nullifier, 0, 2),
             &mut rng,
@@ -1813,7 +1811,7 @@ mod tests {
         let note = Note::new(
             recipient,
             NoteValue::from_raw(55),
-            AssetBase::custom(&AssetId::new_v0(incorrect_ik, asset_desc_hash)),
+            AssetBase::custom(&AssetId::new_v0(&incorrect_ik, &asset_desc_hash)),
             rho_for_issuance_note(&first_nullifier, 0, 0),
             &mut rng,
         );
@@ -1920,8 +1918,8 @@ mod tests {
         // Setup note and merkle tree
         let mut rng = OsRng;
         let asset1 = AssetBase::custom(&AssetId::new_v0(
-            ik.clone(),
-            compute_asset_desc_hash(&NonEmpty::from_slice(b"zsa_asset1").unwrap()),
+            &ik,
+            &compute_asset_desc_hash(&NonEmpty::from_slice(b"zsa_asset1").unwrap()),
         ));
         let note1 = Note::new(
             recipient,

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -227,7 +227,7 @@ impl IssueAction {
             return Err(IssueActionWithoutNoteNotFinalized);
         }
 
-        let issue_asset = AssetBase::derive(&AssetId::new_v0(ik.clone(), self.asset_desc_hash));
+        let issue_asset = AssetBase::custom(&AssetId::new_v0(ik.clone(), self.asset_desc_hash));
 
         // The new asset should not be the identity point of the Pallas curve.
         if bool::from(issue_asset.cv_base().is_identity()) {
@@ -369,7 +369,7 @@ impl<T: IssueAuth> IssueBundle<T> {
             .actions
             .iter()
             .filter(|a| {
-                AssetBase::derive(&AssetId::new_v0(self.ik.clone(), a.asset_desc_hash)).eq(asset)
+                AssetBase::custom(&AssetId::new_v0(self.ik.clone(), a.asset_desc_hash)).eq(asset)
             })
             .collect();
         match issue_actions.len() {
@@ -430,7 +430,7 @@ impl IssueBundle<AwaitingNullifier> {
         first_issuance: bool,
         mut rng: impl RngCore,
     ) -> (IssueBundle<AwaitingNullifier>, AssetBase) {
-        let asset = AssetBase::derive(&AssetId::new_v0(ik.clone(), asset_desc_hash));
+        let asset = AssetBase::custom(&AssetId::new_v0(ik.clone(), asset_desc_hash));
 
         let mut notes = vec![];
         if first_issuance {
@@ -485,7 +485,7 @@ impl IssueBundle<AwaitingNullifier> {
         first_issuance: bool,
         mut rng: impl RngCore,
     ) -> Result<AssetBase, Error> {
-        let asset = AssetBase::derive(&AssetId::new_v0(self.ik.clone(), asset_desc_hash));
+        let asset = AssetBase::custom(&AssetId::new_v0(self.ik.clone(), asset_desc_hash));
 
         let note = Note::new(recipient, value, asset, Rho::zero(), &mut rng);
 
@@ -994,9 +994,9 @@ mod tests {
 
         let note1_asset_desc_hash =
             compute_asset_desc_hash(&NonEmpty::from_slice(note1_asset_desc).unwrap());
-        let asset = AssetBase::derive(&AssetId::new_v0(ik.clone(), note1_asset_desc_hash));
+        let asset = AssetBase::custom(&AssetId::new_v0(ik.clone(), note1_asset_desc_hash));
         let note2_asset = note2_asset_desc.map_or(asset, |desc| {
-            AssetBase::derive(&AssetId::new_v0(
+            AssetBase::custom(&AssetId::new_v0(
                 ik.clone(),
                 compute_asset_desc_hash(&NonEmpty::from_slice(desc).unwrap()),
             ))
@@ -1161,7 +1161,7 @@ mod tests {
         let reference_note = action2.notes.first().unwrap();
         verify_reference_note(
             reference_note,
-            AssetBase::derive(&AssetId::new_v0(ik, asset_desc_hash_2)),
+            AssetBase::custom(&AssetId::new_v0(ik, asset_desc_hash_2)),
         );
         let first_note = action2.notes().get(1).unwrap();
         assert_eq!(first_note.value().inner(), 15);
@@ -1328,7 +1328,7 @@ mod tests {
         let note = Note::new(
             recipient,
             NoteValue::from_raw(5),
-            AssetBase::derive(&AssetId::new_v0(
+            AssetBase::custom(&AssetId::new_v0(
                 bundle.ik().clone(),
                 compute_asset_desc_hash(&NonEmpty::from_slice(b"zsa_asset").unwrap()),
             )),
@@ -1383,7 +1383,7 @@ mod tests {
         assert_eq!(
             issued_assets,
             BTreeMap::from([(
-                AssetBase::derive(&AssetId::new_v0(ik, asset_desc_hash)),
+                AssetBase::custom(&AssetId::new_v0(ik, asset_desc_hash)),
                 AssetRecord::new(NoteValue::from_raw(5), false, first_note)
             )])
         );
@@ -1429,7 +1429,7 @@ mod tests {
         assert_eq!(
             issued_assets,
             BTreeMap::from([(
-                AssetBase::derive(&AssetId::new_v0(ik, asset_desc_hash)),
+                AssetBase::custom(&AssetId::new_v0(ik, asset_desc_hash)),
                 AssetRecord::new(NoteValue::from_raw(7), true, first_note)
             )])
         );
@@ -1453,9 +1453,9 @@ mod tests {
         let asset3_desc_hash =
             compute_asset_desc_hash(&NonEmpty::from_slice(b"Verify with issued assets 3").unwrap());
 
-        let asset1_base = AssetBase::derive(&AssetId::new_v0(ik.clone(), asset1_desc_hash));
-        let asset2_base = AssetBase::derive(&AssetId::new_v0(ik.clone(), asset2_desc_hash));
-        let asset3_base = AssetBase::derive(&AssetId::new_v0(ik.clone(), asset3_desc_hash));
+        let asset1_base = AssetBase::custom(&AssetId::new_v0(ik.clone(), asset1_desc_hash));
+        let asset2_base = AssetBase::custom(&AssetId::new_v0(ik.clone(), asset2_desc_hash));
+        let asset3_base = AssetBase::custom(&AssetId::new_v0(ik.clone(), asset3_desc_hash));
 
         let (mut bundle, _) = IssueBundle::new(
             ik,
@@ -1612,7 +1612,7 @@ mod tests {
             .sign(&isk)
             .unwrap();
 
-        let final_type = AssetBase::derive(&AssetId::new_v0(ik, asset_desc_hash));
+        let final_type = AssetBase::custom(&AssetId::new_v0(ik, asset_desc_hash));
 
         let issued_assets = [(
             final_type,
@@ -1760,7 +1760,7 @@ mod tests {
         let note = Note::new(
             recipient,
             NoteValue::from_raw(5),
-            AssetBase::derive(&AssetId::new_v0(
+            AssetBase::custom(&AssetId::new_v0(
                 signed.ik().clone(),
                 compute_asset_desc_hash(&NonEmpty::from_slice(b"zsa_asset").unwrap()),
             )),
@@ -1813,7 +1813,7 @@ mod tests {
         let note = Note::new(
             recipient,
             NoteValue::from_raw(55),
-            AssetBase::derive(&AssetId::new_v0(incorrect_ik, asset_desc_hash)),
+            AssetBase::custom(&AssetId::new_v0(incorrect_ik, asset_desc_hash)),
             rho_for_issuance_note(&first_nullifier, 0, 0),
             &mut rng,
         );
@@ -1919,7 +1919,7 @@ mod tests {
 
         // Setup note and merkle tree
         let mut rng = OsRng;
-        let asset1 = AssetBase::derive(&AssetId::new_v0(
+        let asset1 = AssetBase::custom(&AssetId::new_v0(
             ik.clone(),
             compute_asset_desc_hash(&NonEmpty::from_slice(b"zsa_asset1").unwrap()),
         ));

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -23,7 +23,7 @@ use rand::RngCore;
 use crate::{
     bundle::commitments::{hash_issue_bundle_auth_data, hash_issue_bundle_txid_data},
     constants::reference_keys::ReferenceKeys,
-    note::{rho_for_issuance_note, AssetBase, Nullifier, Rho},
+    note::{rho_for_issuance_note, AssetBase, AssetId, Nullifier, Rho},
     value::NoteValue,
     Address, Note,
 };
@@ -39,7 +39,6 @@ use Error::{
 pub mod auth;
 pub mod sighash_versioning;
 
-use crate::note::asset_base::AssetId;
 use auth::{IssueAuthKey, IssueValidatingKey, ZSASchnorr};
 use sighash_versioning::{IssueSighashVersion, VerBIP340IssueAuthSig};
 
@@ -899,7 +898,7 @@ mod tests {
             Signed,
         },
         keys::{FullViewingKey, Scope, SpendingKey},
-        note::{asset_base::AssetId, rho_for_issuance_note, AssetBase, Nullifier, Rho},
+        note::{rho_for_issuance_note, AssetBase, AssetId, Nullifier, Rho},
         value::NoteValue,
         Address, Note,
     };

--- a/src/note.rs
+++ b/src/note.rs
@@ -534,7 +534,7 @@ pub mod testing {
             Note {
                 recipient,
                 value,
-                asset: AssetBase::custom(&AssetId::new_v0(ik.clone(), asset_desc_hash)),
+                asset: AssetBase::custom(&AssetId::new_v0(&ik, &asset_desc_hash)),
                 rho,
                 rseed,
                 rseed_split_note: CtOption::new(rseed, 0u8.into()),

--- a/src/note.rs
+++ b/src/note.rs
@@ -530,7 +530,7 @@ pub mod testing {
             rho in arb_nullifier().prop_map(Rho::from_nf_old),
             rseed in arb_rseed(),
         ) -> Note {
-            use crate::note::asset_base::AssetId;
+            use crate::note::AssetId;
             Note {
                 recipient,
                 value,

--- a/src/note.rs
+++ b/src/note.rs
@@ -534,7 +534,7 @@ pub mod testing {
             Note {
                 recipient,
                 value,
-                asset: AssetBase::derive(&AssetId::new_v0(ik.clone(), asset_desc_hash)),
+                asset: AssetBase::custom(&AssetId::new_v0(ik.clone(), asset_desc_hash)),
                 rho,
                 rseed,
                 rseed_split_note: CtOption::new(rseed, 0u8.into()),

--- a/src/note.rs
+++ b/src/note.rs
@@ -20,6 +20,8 @@ use crate::{
 
 pub(crate) mod asset_base;
 pub use self::asset_base::AssetBase;
+#[cfg(feature = "zsa-issuance")]
+pub use self::asset_base::AssetId;
 
 pub(crate) mod commitment;
 pub use self::commitment::{ExtractedNoteCommitment, NoteCommitment};
@@ -528,10 +530,11 @@ pub mod testing {
             rho in arb_nullifier().prop_map(Rho::from_nf_old),
             rseed in arb_rseed(),
         ) -> Note {
+            use crate::note::asset_base::AssetId;
             Note {
                 recipient,
                 value,
-                asset: AssetBase::derive(&ik, &asset_desc_hash),
+                asset: AssetBase::derive(&AssetId::new_v0(ik.clone(), asset_desc_hash)),
                 rho,
                 rseed,
                 rseed_split_note: CtOption::new(rseed, 0u8.into()),

--- a/src/note/asset_base.rs
+++ b/src/note/asset_base.rs
@@ -37,41 +37,53 @@ impl Ord for AssetBase {
     }
 }
 
+#[cfg(feature = "zsa-issuance")]
+pub(crate) enum AssetId<'a> {
+    V0 {
+        ik: &'a IssueValidatingKey<ZSASchnorr>,
+        asset_desc_hash: &'a [u8; 32],
+    },
+}
+
+#[cfg(feature = "zsa-issuance")]
+impl<'a> AssetId<'a> {
+    /// Encoding the Asset Identifier, as defined in [ZIP 227][assetidentifier].
+    ///
+    /// [assetidentifier]: https://zips.z.cash/zip-0227.html#specification-asset-identifier-asset-digest-and-asset-base
+    fn encode_asset_id(&self) -> Vec<u8> {
+        match self {
+            AssetId::V0 {
+                ik,
+                asset_desc_hash,
+            } => {
+                let issuer = ik.encode();
+                let mut asset_id = Vec::with_capacity(1 + issuer.len() + asset_desc_hash.len());
+                asset_id.push(0u8); // version
+                asset_id.extend(issuer);
+                asset_id.extend_from_slice(&asset_desc_hash[..]);
+                asset_id
+            }
+        }
+    }
+
+    /// Derives the Asset Digest for the given ZSA asset.
+    ///
+    /// Defined in [ZIP-227: Issuance of Zcash Shielded Assets][assetdigest].
+    ///
+    /// [assetdigest]: https://zips.z.cash/zip-0227#asset-digests
+    fn asset_digest(&self) -> Blake2bHash {
+        Params::new()
+            .hash_length(64)
+            .personal(ZSA_ASSET_DIGEST_PERSONALIZATION)
+            .to_state()
+            .update(&self.encode_asset_id())
+            .finalize()
+    }
+}
+
 /// Personalization for the ZSA asset digest generator
 #[cfg(feature = "zsa-issuance")]
 pub const ZSA_ASSET_DIGEST_PERSONALIZATION: &[u8; 16] = b"ZSA-Asset-Digest";
-
-/// Derives the Asset Digest for the given ZSA asset.
-///
-/// Defined in [ZIP-227: Issuance of Zcash Shielded Assets][assetdigest].
-///
-/// [assetdigest]: https://zips.z.cash/zip-0227#asset-digests
-#[cfg(feature = "zsa-issuance")]
-pub fn asset_digest(encode_asset_id: &[u8]) -> Blake2bHash {
-    Params::new()
-        .hash_length(64)
-        .personal(ZSA_ASSET_DIGEST_PERSONALIZATION)
-        .to_state()
-        .update(encode_asset_id)
-        .finalize()
-}
-
-/// Encoding the Asset Identifier, as defined in [ZIP 227][assetidentifier].
-///
-/// [assetidentifier]: https://zips.z.cash/zip-0227.html#specification-asset-identifier-asset-digest-and-asset-base
-#[cfg(feature = "zsa-issuance")]
-pub fn encode_asset_id(
-    version: u8,
-    ik: &IssueValidatingKey<ZSASchnorr>,
-    asset_desc_hash: &[u8; 32],
-) -> Vec<u8> {
-    let issuer = ik.encode();
-    let mut asset_id = Vec::with_capacity(1 + issuer.len() + asset_desc_hash.len());
-    asset_id.push(version);
-    asset_id.extend(issuer);
-    asset_id.extend_from_slice(&asset_desc_hash[..]);
-    asset_id
-}
 
 impl AssetBase {
     /// Deserialize the AssetBase from a byte array.
@@ -96,11 +108,11 @@ impl AssetBase {
     #[cfg(feature = "zsa-issuance")]
     #[allow(non_snake_case)]
     pub fn derive(ik: &IssueValidatingKey<ZSASchnorr>, asset_desc_hash: &[u8; 32]) -> Self {
-        let version_byte: u8 = 0x00;
-
-        // EncodeAssetId(ik, asset_desc_hash) = version_byte || ik || asset_desc_hash
-        let asset_id = encode_asset_id(version_byte, ik, asset_desc_hash);
-        let asset_digest = asset_digest(&asset_id);
+        let asset_id = AssetId::V0 {
+            ik,
+            asset_desc_hash,
+        };
+        let asset_digest = asset_id.asset_digest();
 
         let asset_base =
             pallas::Point::hash_to_curve(ZSA_ASSET_BASE_PERSONALIZATION)(asset_digest.as_bytes());

--- a/src/note/asset_base.rs
+++ b/src/note/asset_base.rs
@@ -120,7 +120,7 @@ impl AssetBase {
     /// Panics if the derived AssetBase is the identity point.
     #[cfg(feature = "zsa-issuance")]
     #[allow(non_snake_case)]
-    pub fn derive(asset_id: &AssetId) -> Self {
+    pub fn custom(asset_id: &AssetId) -> Self {
         let asset_digest = asset_id.asset_digest();
 
         let asset_base =
@@ -251,7 +251,7 @@ mod tests {
             let asset_desc_hash = crate::issuance::compute_asset_desc_hash(
                 &nonempty::NonEmpty::from_slice(&tv.description).unwrap(),
             );
-            let calculated_asset_base = AssetBase::derive(&AssetId::new_v0(
+            let calculated_asset_base = AssetBase::custom(&AssetId::new_v0(
                 IssueValidatingKey::<ZSASchnorr>::decode(&tv.key).unwrap(),
                 asset_desc_hash,
             ));

--- a/src/note/asset_base.rs
+++ b/src/note/asset_base.rs
@@ -240,7 +240,7 @@ pub mod testing {
 mod tests {
     use crate::{
         issuance::auth::{IssueValidatingKey, ZSASchnorr},
-        note::{asset_base::AssetId, AssetBase},
+        note::{AssetBase, AssetId},
     };
 
     #[test]

--- a/src/note/asset_base.rs
+++ b/src/note/asset_base.rs
@@ -20,27 +20,15 @@ use {
     blake2b_simd::{Hash as Blake2bHash, Params},
 };
 
-/// Note type identifier.
-#[derive(Clone, Copy, Debug, Eq)]
-pub struct AssetBase(pallas::Point);
-
-// AssetBase must implement PartialOrd and Ord to be used as a key in BTreeMap.
-impl PartialOrd for AssetBase {
-    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for AssetBase {
-    fn cmp(&self, other: &Self) -> Ordering {
-        self.0.to_bytes().cmp(&other.0.to_bytes())
-    }
-}
-
+/// Asset Identifier
 #[cfg(feature = "zsa-issuance")]
+#[derive(Debug)]
 pub enum AssetId {
+    /// Version V0 of AssetId
     V0 {
+        /// Issue Validating Key
         ik: IssueValidatingKey<ZSASchnorr>,
+        /// Asset description hash
         asset_desc_hash: [u8; 32],
     },
 }
@@ -48,7 +36,7 @@ pub enum AssetId {
 #[cfg(feature = "zsa-issuance")]
 impl AssetId {
     /// Generates a new V0 AssetId.
-    fn new_v0(ik: IssueValidatingKey<ZSASchnorr>, asset_desc_hash: [u8; 32]) -> Self {
+    pub fn new_v0(ik: IssueValidatingKey<ZSASchnorr>, asset_desc_hash: [u8; 32]) -> Self {
         AssetId::V0 {
             ik,
             asset_desc_hash,
@@ -89,6 +77,23 @@ impl AssetId {
     }
 }
 
+/// Note type identifier.
+#[derive(Clone, Copy, Debug, Eq)]
+pub struct AssetBase(pallas::Point);
+
+// AssetBase must implement PartialOrd and Ord to be used as a key in BTreeMap.
+impl PartialOrd for AssetBase {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for AssetBase {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.0.to_bytes().cmp(&other.0.to_bytes())
+    }
+}
+
 /// Personalization for the ZSA asset digest generator
 #[cfg(feature = "zsa-issuance")]
 pub const ZSA_ASSET_DIGEST_PERSONALIZATION: &[u8; 16] = b"ZSA-Asset-Digest";
@@ -115,8 +120,7 @@ impl AssetBase {
     /// Panics if the derived AssetBase is the identity point.
     #[cfg(feature = "zsa-issuance")]
     #[allow(non_snake_case)]
-    pub fn derive(ik: &IssueValidatingKey<ZSASchnorr>, asset_desc_hash: &[u8; 32]) -> Self {
-        let asset_id = AssetId::new_v0(ik.clone(), *asset_desc_hash);
+    pub fn derive(asset_id: &AssetId) -> Self {
         let asset_digest = asset_id.asset_digest();
 
         let asset_base =
@@ -236,7 +240,7 @@ pub mod testing {
 mod tests {
     use crate::{
         issuance::auth::{IssueValidatingKey, ZSASchnorr},
-        note::AssetBase,
+        note::{asset_base::AssetId, AssetBase},
     };
 
     #[test]
@@ -247,10 +251,10 @@ mod tests {
             let asset_desc_hash = crate::issuance::compute_asset_desc_hash(
                 &nonempty::NonEmpty::from_slice(&tv.description).unwrap(),
             );
-            let calculated_asset_base = AssetBase::derive(
-                &IssueValidatingKey::<ZSASchnorr>::decode(&tv.key).unwrap(),
-                &asset_desc_hash,
-            );
+            let calculated_asset_base = AssetBase::derive(&AssetId::new_v0(
+                IssueValidatingKey::<ZSASchnorr>::decode(&tv.key).unwrap(),
+                asset_desc_hash,
+            ));
             let test_vector_asset_base = AssetBase::from_bytes(&tv.asset_base).unwrap();
 
             assert_eq!(calculated_asset_base, test_vector_asset_base);

--- a/src/note/asset_base.rs
+++ b/src/note/asset_base.rs
@@ -23,20 +23,20 @@ use {
 /// Asset Identifier
 #[cfg(feature = "zsa-issuance")]
 #[derive(Debug)]
-pub enum AssetId {
+pub enum AssetId<'a> {
     /// Version V0 of AssetId
     V0 {
-        /// Issue Validating Key
-        ik: IssueValidatingKey<ZSASchnorr>,
+        /// Issue validating Key
+        ik: &'a IssueValidatingKey<ZSASchnorr>,
         /// Asset description hash
-        asset_desc_hash: [u8; 32],
+        asset_desc_hash: &'a [u8; 32],
     },
 }
 
 #[cfg(feature = "zsa-issuance")]
-impl AssetId {
+impl<'a> AssetId<'a> {
     /// Generates a new V0 AssetId.
-    pub fn new_v0(ik: IssueValidatingKey<ZSASchnorr>, asset_desc_hash: [u8; 32]) -> Self {
+    pub fn new_v0(ik: &'a IssueValidatingKey<ZSASchnorr>, asset_desc_hash: &'a [u8; 32]) -> Self {
         AssetId::V0 {
             ik,
             asset_desc_hash,
@@ -120,7 +120,7 @@ impl AssetBase {
     /// Panics if the derived AssetBase is the identity point.
     #[cfg(feature = "zsa-issuance")]
     #[allow(non_snake_case)]
-    pub fn custom(asset_id: &AssetId) -> Self {
+    pub fn custom(asset_id: &AssetId<'_>) -> Self {
         let asset_digest = asset_id.asset_digest();
 
         let asset_base =
@@ -252,8 +252,8 @@ mod tests {
                 &nonempty::NonEmpty::from_slice(&tv.description).unwrap(),
             );
             let calculated_asset_base = AssetBase::custom(&AssetId::new_v0(
-                IssueValidatingKey::<ZSASchnorr>::decode(&tv.key).unwrap(),
-                asset_desc_hash,
+                &IssueValidatingKey::<ZSASchnorr>::decode(&tv.key).unwrap(),
+                &asset_desc_hash,
             ));
             let test_vector_asset_base = AssetBase::from_bytes(&tv.asset_base).unwrap();
 

--- a/src/note/asset_base.rs
+++ b/src/note/asset_base.rs
@@ -38,15 +38,23 @@ impl Ord for AssetBase {
 }
 
 #[cfg(feature = "zsa-issuance")]
-pub(crate) enum AssetId<'a> {
+pub enum AssetId {
     V0 {
-        ik: &'a IssueValidatingKey<ZSASchnorr>,
-        asset_desc_hash: &'a [u8; 32],
+        ik: IssueValidatingKey<ZSASchnorr>,
+        asset_desc_hash: [u8; 32],
     },
 }
 
 #[cfg(feature = "zsa-issuance")]
-impl<'a> AssetId<'a> {
+impl AssetId {
+    /// Generates a new V0 AssetId.
+    fn new_v0(ik: IssueValidatingKey<ZSASchnorr>, asset_desc_hash: [u8; 32]) -> Self {
+        AssetId::V0 {
+            ik,
+            asset_desc_hash,
+        }
+    }
+
     /// Encoding the Asset Identifier, as defined in [ZIP 227][assetidentifier].
     ///
     /// [assetidentifier]: https://zips.z.cash/zip-0227.html#specification-asset-identifier-asset-digest-and-asset-base
@@ -108,10 +116,7 @@ impl AssetBase {
     #[cfg(feature = "zsa-issuance")]
     #[allow(non_snake_case)]
     pub fn derive(ik: &IssueValidatingKey<ZSASchnorr>, asset_desc_hash: &[u8; 32]) -> Self {
-        let asset_id = AssetId::V0 {
-            ik,
-            asset_desc_hash,
-        };
+        let asset_id = AssetId::new_v0(ik.clone(), *asset_desc_hash);
         let asset_digest = asset_id.asset_digest();
 
         let asset_base =

--- a/tests/issuance_global_state.rs
+++ b/tests/issuance_global_state.rs
@@ -191,20 +191,20 @@ fn issue_bundle_verify_with_global_state() {
     let asset4_desc = b"Verify with issued assets 4".to_vec();
 
     let asset1_base = AssetBase::custom(&AssetId::new_v0(
-        ik.clone(),
-        compute_asset_desc_hash(&NonEmpty::from_slice(&asset1_desc).unwrap()),
+        &ik,
+        &compute_asset_desc_hash(&NonEmpty::from_slice(&asset1_desc).unwrap()),
     ));
     let asset2_base = AssetBase::custom(&AssetId::new_v0(
-        ik.clone(),
-        compute_asset_desc_hash(&NonEmpty::from_slice(&asset2_desc).unwrap()),
+        &ik,
+        &compute_asset_desc_hash(&NonEmpty::from_slice(&asset2_desc).unwrap()),
     ));
     let asset3_base = AssetBase::custom(&AssetId::new_v0(
-        ik.clone(),
-        compute_asset_desc_hash(&NonEmpty::from_slice(&asset3_desc).unwrap()),
+        &ik,
+        &compute_asset_desc_hash(&NonEmpty::from_slice(&asset3_desc).unwrap()),
     ));
     let asset4_base = AssetBase::custom(&AssetId::new_v0(
-        ik,
-        compute_asset_desc_hash(&NonEmpty::from_slice(&asset4_desc).unwrap()),
+        &ik,
+        &compute_asset_desc_hash(&NonEmpty::from_slice(&asset4_desc).unwrap()),
     ));
 
     let mut global_state = BTreeMap::new();

--- a/tests/issuance_global_state.rs
+++ b/tests/issuance_global_state.rs
@@ -190,19 +190,19 @@ fn issue_bundle_verify_with_global_state() {
     let asset3_desc = b"Verify with issued assets 3".to_vec();
     let asset4_desc = b"Verify with issued assets 4".to_vec();
 
-    let asset1_base = AssetBase::derive(&AssetId::new_v0(
+    let asset1_base = AssetBase::custom(&AssetId::new_v0(
         ik.clone(),
         compute_asset_desc_hash(&NonEmpty::from_slice(&asset1_desc).unwrap()),
     ));
-    let asset2_base = AssetBase::derive(&AssetId::new_v0(
+    let asset2_base = AssetBase::custom(&AssetId::new_v0(
         ik.clone(),
         compute_asset_desc_hash(&NonEmpty::from_slice(&asset2_desc).unwrap()),
     ));
-    let asset3_base = AssetBase::derive(&AssetId::new_v0(
+    let asset3_base = AssetBase::custom(&AssetId::new_v0(
         ik.clone(),
         compute_asset_desc_hash(&NonEmpty::from_slice(&asset3_desc).unwrap()),
     ));
-    let asset4_base = AssetBase::derive(&AssetId::new_v0(
+    let asset4_base = AssetBase::custom(&AssetId::new_v0(
         ik,
         compute_asset_desc_hash(&NonEmpty::from_slice(&asset4_desc).unwrap()),
     ));

--- a/tests/issuance_global_state.rs
+++ b/tests/issuance_global_state.rs
@@ -17,7 +17,7 @@ use orchard::{
         IssueBundle, IssueInfo, Signed,
     },
     keys::{FullViewingKey, Scope, SpendingKey},
-    note::{AssetBase, Nullifier},
+    note::{AssetBase, AssetId, Nullifier},
     value::NoteValue,
     Address, Note,
 };
@@ -190,22 +190,22 @@ fn issue_bundle_verify_with_global_state() {
     let asset3_desc = b"Verify with issued assets 3".to_vec();
     let asset4_desc = b"Verify with issued assets 4".to_vec();
 
-    let asset1_base = AssetBase::derive(
-        &ik,
-        &compute_asset_desc_hash(&NonEmpty::from_slice(&asset1_desc).unwrap()),
-    );
-    let asset2_base = AssetBase::derive(
-        &ik,
-        &compute_asset_desc_hash(&NonEmpty::from_slice(&asset2_desc).unwrap()),
-    );
-    let asset3_base = AssetBase::derive(
-        &ik,
-        &compute_asset_desc_hash(&NonEmpty::from_slice(&asset3_desc).unwrap()),
-    );
-    let asset4_base = AssetBase::derive(
-        &ik,
-        &compute_asset_desc_hash(&NonEmpty::from_slice(&asset4_desc).unwrap()),
-    );
+    let asset1_base = AssetBase::derive(&AssetId::new_v0(
+        ik.clone(),
+        compute_asset_desc_hash(&NonEmpty::from_slice(&asset1_desc).unwrap()),
+    ));
+    let asset2_base = AssetBase::derive(&AssetId::new_v0(
+        ik.clone(),
+        compute_asset_desc_hash(&NonEmpty::from_slice(&asset2_desc).unwrap()),
+    ));
+    let asset3_base = AssetBase::derive(&AssetId::new_v0(
+        ik.clone(),
+        compute_asset_desc_hash(&NonEmpty::from_slice(&asset3_desc).unwrap()),
+    ));
+    let asset4_base = AssetBase::derive(&AssetId::new_v0(
+        ik,
+        compute_asset_desc_hash(&NonEmpty::from_slice(&asset4_desc).unwrap()),
+    ));
 
     let mut global_state = BTreeMap::new();
 

--- a/tests/zsa.rs
+++ b/tests/zsa.rs
@@ -184,7 +184,7 @@ fn issue_zsa_notes(
 
     verify_reference_note(
         reference_note,
-        AssetBase::derive(&AssetId::new_v0(keys.ik().clone(), asset_desc_hash)),
+        AssetBase::custom(&AssetId::new_v0(keys.ik().clone(), asset_desc_hash)),
     );
 
     assert!(verify_issue_bundle(

--- a/tests/zsa.rs
+++ b/tests/zsa.rs
@@ -16,7 +16,7 @@ use orchard::{
         Signed,
     },
     keys::{FullViewingKey, PreparedIncomingViewingKey, Scope, SpendAuthorizingKey, SpendingKey},
-    note::{AssetBase, ExtractedNoteCommitment, Nullifier},
+    note::{AssetBase, AssetId, ExtractedNoteCommitment, Nullifier},
     primitives::OrchardDomain,
     tree::{MerkleHashOrchard, MerklePath},
     value::NoteValue,
@@ -184,7 +184,7 @@ fn issue_zsa_notes(
 
     verify_reference_note(
         reference_note,
-        AssetBase::derive(&keys.ik().clone(), &asset_desc_hash),
+        AssetBase::derive(&AssetId::new_v0(keys.ik().clone(), asset_desc_hash)),
     );
 
     assert!(verify_issue_bundle(

--- a/tests/zsa.rs
+++ b/tests/zsa.rs
@@ -184,7 +184,7 @@ fn issue_zsa_notes(
 
     verify_reference_note(
         reference_note,
-        AssetBase::custom(&AssetId::new_v0(keys.ik().clone(), asset_desc_hash)),
+        AssetBase::custom(&AssetId::new_v0(keys.ik(), &asset_desc_hash)),
     );
 
     assert!(verify_issue_bundle(


### PR DESCRIPTION
Address the following review comments:
r2550373804
r2550386724
r2550403709

Introduce the AssetId enum holding an ik and an asset_desc_hash, and use it as input for encode_asset_id, asset_digest, and AssetBase::custom (renamed from AssetBase::derive).
AssetId uses lifetimes to borrow ik and avoid cloning it.