### PR TITLE
PR471: Make rho optional in Note

### DIFF
--- a/src/bundle/commitments/issuance.rs
+++ b/src/bundle/commitments/issuance.rs
@@ -159,7 +159,7 @@ mod tests {
         let issuance_digest = hash_issue_bundle_txid_data(&bundle);
         assert_eq!(
             issuance_digest.to_hex().as_str(),
-            "d99afbab7c0e8bd5d250e2df7d6df39d06891b264fff34090b55c5fac2d65ce5"
+            "ee70e3b61674fd0428ac0020cc4fc5819386e39c4eb3c63357c84c998195bcdb"
         );
     }
 
@@ -178,7 +178,7 @@ mod tests {
             hash_issue_bundle_auth_data(&signed_bundle, &sighash_version_map);
         assert_eq!(
             issuance_auth_digest.to_hex().as_str(),
-            "1e737ae27e378d3cd90c93efb7a5f8ef5a7b4db7aa9848ed7b57a7795253af86"
+            "6df77af7b5323d99376336b770e4c5b06ffc195de81ac7692d1b08b6eb19534d"
         );
     }
 }

--- a/src/bundle/commitments/issuance.rs
+++ b/src/bundle/commitments/issuance.rs
@@ -148,7 +148,7 @@ mod tests {
             .unwrap();
         assert_ne!(asset, third_asset);
 
-        (bundle.update_rho(&first_nullifier), isk)
+        (bundle.update_rho(&first_nullifier, rng), isk)
     }
 
     /// Verify that the `issuance_digest` of an IssueBundle matches a fixed reference value

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -1698,10 +1698,9 @@ mod tests {
             rng,
         );
 
-        let sighash: [u8; 32] = bundle.commitment().into();
         let signed = bundle
             .update_rho(&first_nullifier, rng)
-            .prepare(sighash)
+            .prepare([0_u8; 32])
             .sign(&isk)
             .unwrap();
 
@@ -1830,7 +1829,11 @@ mod tests {
     #[test]
     fn test_get_action_by_desc_hash() {
         let TestParams {
-            rng, ik, recipient, ..
+            rng,
+            ik,
+            recipient,
+            first_nullifier,
+            ..
         } = setup_params();
 
         // UTF heavy test string
@@ -1850,14 +1853,20 @@ mod tests {
             rng,
         );
 
+        // NOTE: Equality between two IssueActions can only be tested once `rho` is initialized.
+        // This call is required for the final `assert_eq!`.
+        let bundle_with_rho = bundle.update_rho(&first_nullifier, rng);
+
         // Checks for the case of UTF-8 encoded asset description.
-        let action = bundle.get_action_by_asset(&asset_base_1).unwrap();
+        let action = bundle_with_rho.get_action_by_asset(&asset_base_1).unwrap();
         assert_eq!(action.asset_desc_hash(), &asset_desc_hash_1);
         let reference_note = action.notes.first().unwrap();
         verify_reference_note(reference_note, asset_base_1);
         assert_eq!(action.notes.get(1).unwrap().value().inner(), 5);
         assert_eq!(
-            bundle.get_action_by_desc_hash(&asset_desc_hash_1).unwrap(),
+            bundle_with_rho
+                .get_action_by_desc_hash(&asset_desc_hash_1)
+                .unwrap(),
             action
         );
     }

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -23,7 +23,7 @@ use rand::RngCore;
 use crate::{
     bundle::commitments::{hash_issue_bundle_auth_data, hash_issue_bundle_txid_data},
     constants::reference_keys::ReferenceKeys,
-    note::{rho_for_issuance_note, AssetBase, AssetId, Nullifier, Rho},
+    note::{rho_for_issuance_note, AssetBase, AssetId, Nullifier},
     value::NoteValue,
     Address, Note,
 };
@@ -441,13 +441,8 @@ impl IssueBundle<AwaitingNullifier> {
                 flags: IssuanceFlags::from_parts(true),
             },
             Some(issue_info) => {
-                let note = Note::new(
-                    issue_info.recipient,
-                    issue_info.value,
-                    asset,
-                    Rho::zero(),
-                    &mut rng,
-                );
+                let note =
+                    Note::new_issue_note(issue_info.recipient, issue_info.value, asset, &mut rng);
 
                 notes.push(note);
 
@@ -484,7 +479,7 @@ impl IssueBundle<AwaitingNullifier> {
     ) -> Result<AssetBase, Error> {
         let asset = AssetBase::custom(&AssetId::new_v0(&self.ik, &asset_desc_hash));
 
-        let note = Note::new(recipient, value, asset, Rho::zero(), &mut rng);
+        let note = Note::new_issue_note(recipient, value, asset, &mut rng);
 
         let notes = if first_issuance {
             vec![create_reference_note(asset, &mut rng), note]
@@ -541,7 +536,11 @@ impl IssueBundle<AwaitingNullifier> {
     /// [ZIP-227: Issuance of Zcash Shielded Assets][zip227].
     ///
     /// [zip227]: https://zips.z.cash/zip-0227
-    pub fn update_rho(self, first_nullifier: &Nullifier) -> IssueBundle<AwaitingSighash> {
+    pub fn update_rho(
+        self,
+        first_nullifier: &Nullifier,
+        mut rng: impl RngCore,
+    ) -> IssueBundle<AwaitingSighash> {
         let mut bundle = self;
         bundle
             .actions
@@ -557,6 +556,7 @@ impl IssueBundle<AwaitingNullifier> {
                             first_nullifier,
                             index_action.try_into().unwrap(),
                             index_note.try_into().unwrap(),
+                            &mut rng,
                         );
                     });
             });
@@ -576,11 +576,10 @@ impl IssueBundle<AwaitingSighash> {
 }
 
 fn create_reference_note(asset: AssetBase, mut rng: impl RngCore) -> Note {
-    Note::new(
+    Note::new_issue_note(
         ReferenceKeys::recipient(),
         NoteValue::zero(),
         asset,
-        Rho::zero(),
         &mut rng,
     )
 }
@@ -999,19 +998,13 @@ mod tests {
             ))
         });
 
-        let note1 = Note::new(
-            recipient,
-            NoteValue::from_raw(note1_value),
-            asset,
-            Rho::zero(),
-            &mut rng,
-        );
+        let note1 =
+            Note::new_issue_note(recipient, NoteValue::from_raw(note1_value), asset, &mut rng);
 
-        let note2 = Note::new(
+        let note2 = Note::new_issue_note(
             recipient,
             NoteValue::from_raw(note2_value),
             note2_asset,
-            Rho::zero(),
             &mut rng,
         );
 
@@ -1124,14 +1117,14 @@ mod tests {
             action
                 .notes()
                 .iter()
-                .for_each(|note| assert_eq!(note.rho(), Rho::zero()))
+                .for_each(|note| assert!(!note.has_rho()))
         });
-        let awaiting_sighash_bundle = bundle.update_rho(&first_nullifier);
+        let awaiting_sighash_bundle = bundle.update_rho(&first_nullifier, rng);
         awaiting_sighash_bundle.actions().iter().for_each(|action| {
             action
                 .notes()
                 .iter()
-                .for_each(|note| assert_ne!(note.rho(), Rho::zero()))
+                .for_each(|note| assert!(note.has_rho()))
         });
 
         let actions = awaiting_sighash_bundle.actions();
@@ -1225,7 +1218,7 @@ mod tests {
             rng,
         );
 
-        let prepared = bundle.update_rho(&first_nullifier).prepare(sighash);
+        let prepared = bundle.update_rho(&first_nullifier, rng).prepare(sighash);
         assert_eq!(prepared.authorization().sighash, sighash);
     }
 
@@ -1254,7 +1247,7 @@ mod tests {
         );
 
         let signed = bundle
-            .update_rho(&first_nullifier)
+            .update_rho(&first_nullifier, rng)
             .prepare(sighash)
             .sign(&isk)
             .unwrap();
@@ -1290,7 +1283,7 @@ mod tests {
         let wrong_isk = IssueAuthKey::<ZSASchnorr>::random(&mut rng);
 
         let err = bundle
-            .update_rho(&first_nullifier)
+            .update_rho(&first_nullifier, rng)
             .prepare([0; 32])
             .sign(&wrong_isk)
             .expect_err("should not be able to sign");
@@ -1322,20 +1315,19 @@ mod tests {
         );
 
         // Add "bad" note
-        let note = Note::new(
+        let note = Note::new_issue_note(
             recipient,
             NoteValue::from_raw(5),
             AssetBase::custom(&AssetId::new_v0(
                 bundle.ik(),
                 &compute_asset_desc_hash(&NonEmpty::from_slice(b"zsa_asset").unwrap()),
             )),
-            Rho::zero(),
             &mut rng,
         );
         bundle.actions.first_mut().notes.push(note);
 
         let err = bundle
-            .update_rho(&first_nullifier)
+            .update_rho(&first_nullifier, rng)
             .prepare([0; 32])
             .sign(&isk)
             .expect_err("should not be able to sign");
@@ -1368,7 +1360,7 @@ mod tests {
         );
 
         let signed = bundle
-            .update_rho(&first_nullifier)
+            .update_rho(&first_nullifier, rng)
             .prepare(sighash)
             .sign(&isk)
             .unwrap();
@@ -1414,7 +1406,7 @@ mod tests {
         bundle.finalize_action(&asset_desc_hash).unwrap();
 
         let signed = bundle
-            .update_rho(&first_nullifier)
+            .update_rho(&first_nullifier, rng)
             .prepare(sighash)
             .sign(&isk)
             .unwrap();
@@ -1500,7 +1492,7 @@ mod tests {
             .unwrap();
 
         let signed = bundle
-            .update_rho(&first_nullifier)
+            .update_rho(&first_nullifier, rng)
             .prepare(sighash)
             .sign(&isk)
             .unwrap();
@@ -1566,7 +1558,7 @@ mod tests {
         );
 
         let signed = bundle
-            .update_rho(&first_nullifier)
+            .update_rho(&first_nullifier, rng)
             .prepare(sighash)
             .sign(&isk)
             .unwrap();
@@ -1604,7 +1596,7 @@ mod tests {
         );
 
         let signed = bundle
-            .update_rho(&first_nullifier)
+            .update_rho(&first_nullifier, rng)
             .prepare(sighash)
             .sign(&isk)
             .unwrap();
@@ -1616,13 +1608,7 @@ mod tests {
             AssetRecord::new(
                 NoteValue::from_raw(20),
                 true,
-                Note::new(
-                    recipient,
-                    NoteValue::from_raw(10),
-                    final_type,
-                    Rho::zero(),
-                    &mut rng,
-                ),
+                Note::new_issue_note(recipient, NoteValue::from_raw(10), final_type, &mut rng),
             ),
         )]
         .into_iter()
@@ -1672,7 +1658,7 @@ mod tests {
         let wrong_isk = IssueAuthKey::<ZSASchnorr>::random(&mut rng);
 
         let mut signed = bundle
-            .update_rho(&first_nullifier)
+            .update_rho(&first_nullifier, rng)
             .prepare(sighash)
             .sign(&isk)
             .unwrap();
@@ -1714,7 +1700,7 @@ mod tests {
 
         let sighash: [u8; 32] = bundle.commitment().into();
         let signed = bundle
-            .update_rho(&first_nullifier)
+            .update_rho(&first_nullifier, rng)
             .prepare(sighash)
             .sign(&isk)
             .unwrap();
@@ -1748,7 +1734,7 @@ mod tests {
         );
 
         let mut signed = bundle
-            .update_rho(&first_nullifier)
+            .update_rho(&first_nullifier, rng)
             .prepare(sighash)
             .sign(&isk)
             .unwrap();
@@ -1798,7 +1784,7 @@ mod tests {
         );
 
         let mut signed = bundle
-            .update_rho(&first_nullifier)
+            .update_rho(&first_nullifier, rng)
             .prepare(sighash)
             .sign(&isk)
             .unwrap();
@@ -2009,10 +1995,11 @@ mod tests {
             action
                 .notes()
                 .iter()
-                .for_each(|note| assert_eq!(note.rho(), Rho::zero()))
+                .for_each(|note| assert!(!note.has_rho()))
         });
 
-        let awaiting_sighash_bundle = bundle.update_rho(authorized.actions().first().nullifier());
+        let awaiting_sighash_bundle =
+            bundle.update_rho(authorized.actions().first().nullifier(), rng);
 
         assert_eq!(awaiting_sighash_bundle.actions().len(), 2);
         assert_eq!(

--- a/src/note.rs
+++ b/src/note.rs
@@ -152,10 +152,17 @@ pub struct Note {
     asset: AssetBase,
     /// A unique creation ID for this note.
     ///
-    /// This is produced from the nullifier of the note that will be spent in the [`Action`] that
-    /// creates this note.
+    /// For notes created by spending an existing note, `rho` is derived from the
+    /// nullifier of the spent note.
     ///
-    /// [`Action`]: crate::action::Action
+    /// For issuance notes ([ZIP-227]), `rho` is initially unset and later
+    /// deterministically derived from the issuance context when
+    /// `update_rho_for_issuance_note` is called.
+    ///
+    /// The `rho` value is used as domain-separated randomness in the note
+    /// commitment and must be initialized before commitment or equality checks.
+    ///
+    /// [ZIP-227]: https://zips.z.cash/zip-0227
     rho: Option<Rho>,
     /// The seed randomness for various note components.
     rseed: RandomSeed,
@@ -265,8 +272,16 @@ impl Note {
         }
     }
 
-    // TODO add comment
-    // We have to check note.commitment_inner().is_some() after setting rho
+    /// Generates a new issuance note with an uninitialized `rho`.
+    ///
+    /// For issuance notes ([ZIP-227]), the `rho` value is not known at creation
+    /// time and is therefore left unset. It is later deterministically derived
+    /// from the issuance context and assigned via `update_rho_for_issuance_note`.
+    ///
+    /// A temporary `rseed` is sampled at construction time and later updated
+    /// by `update_rho_for_issuance_note` to ensure a valid note commitment.
+    ///
+    /// [ZIP-227]: https://zips.z.cash/zip-0227
     pub(crate) fn new_issue_note(
         recipient: Address,
         value: NoteValue,
@@ -336,13 +351,7 @@ impl Note {
 
     /// Derives the ephemeral secret key for this note.
     pub(crate) fn esk(&self) -> EphemeralSecretKey {
-        EphemeralSecretKey(
-            self.rseed.esk(
-                &self
-                    .rho
-                    .expect("must call Note::update_rho_for_issuance_note first"),
-            ),
-        )
+        EphemeralSecretKey(self.rseed.esk(&self.rho()))
     }
 
     /// Returns rho of this note.
@@ -377,28 +386,26 @@ impl Note {
     /// [notes]: https://zips.z.cash/protocol/nu5.pdf#notes
     fn commitment_inner(&self) -> CtOption<NoteCommitment> {
         let g_d = self.recipient.g_d();
-        let rho = self.rho();
 
         NoteCommitment::derive(
             g_d.to_bytes(),
             self.recipient.pk_d().to_bytes(),
             self.value,
             self.asset,
-            rho.0,
-            self.rseed.psi(&rho),
-            self.rseed.rcm(&rho),
+            self.rho().0,
+            self.rseed.psi(&self.rho()),
+            self.rseed.rcm(&self.rho()),
         )
     }
 
     /// Derives the nullifier for this note.
     pub fn nullifier(&self, fvk: &FullViewingKey) -> Nullifier {
         let selected_rseed = self.rseed_split_note.unwrap_or(self.rseed);
-        let rho = self.rho();
 
         Nullifier::derive(
             fvk.nk(),
-            rho.0,
-            selected_rseed.psi(&rho),
+            self.rho().0,
+            selected_rseed.psi(&self.rho()),
             self.commitment(),
             self.rseed_split_note.is_some(),
         )
@@ -420,12 +427,19 @@ impl Note {
         }
     }
 
-    /// Update the rho value of the issuance note (see
-    /// [ZIP-227: Issuance of Zcash Shielded Assets][zip227]).
+    /// Updates the `rho` value of an issuance note as specified in
+    /// [ZIP-227: Issuance of Zcash Shielded Assets][zip227].
     ///
-    /// TODO
+    /// The `rho` value is deterministically derived from the note context and used
+    /// in the Sinsemilla-based note commitment. As required by
+    /// [Section 5.4.8.4] of the Zcash Protocol Specification, the commitment must not
+    /// evaluate to ⊥.
+    ///
+    /// Although the probability of observing ⊥ is negligible, this method enforces
+    /// this invariant by resampling a random `rseed` until a valid commitment is produced.
     ///
     /// [zip227]: https://zips.z.cash/zip-0227
+    /// [Section 5.4.8.4]: https://zips.z.cash/protocol/protocol.pdf#concretesinsemillacommit
     pub(crate) fn update_rho_for_issuance_note(
         &mut self,
         nullifier: &Nullifier,
@@ -433,9 +447,9 @@ impl Note {
         index_note: u32,
         mut rng: impl RngCore,
     ) {
+        let rho = rho_for_issuance_note(nullifier, index_action, index_note);
+        self.rho = Some(rho);
         loop {
-            let rho = rho_for_issuance_note(nullifier, index_action, index_note);
-            self.rho = Some(rho);
             self.rseed = RandomSeed::random(&mut rng, &rho);
             if self.commitment_inner().is_some().into() {
                 break;

--- a/src/note.rs
+++ b/src/note.rs
@@ -64,12 +64,6 @@ impl Rho {
     pub(crate) fn into_inner(self) -> pallas::Base {
         self.0
     }
-
-    /// When creating an issuance note, the rho value is initialized with the Pallas base element zero.
-    /// This value will be updated later by calling `update_rho` method on the `IssueBundle`.
-    pub(crate) fn zero() -> Self {
-        Rho(pallas::Base::zero())
-    }
 }
 
 /// The ZIP 212 seed randomness for a note.
@@ -162,7 +156,7 @@ pub struct Note {
     /// creates this note.
     ///
     /// [`Action`]: crate::action::Action
-    rho: Rho,
+    rho: Option<Rho>,
     /// The seed randomness for various note components.
     rseed: RandomSeed,
     /// The seed randomness for split notes.
@@ -238,7 +232,7 @@ impl Note {
             recipient,
             value,
             asset,
-            rho,
+            rho: Some(rho),
             rseed,
             rseed_split_note,
         };
@@ -268,6 +262,25 @@ impl Note {
             if note.is_some().into() {
                 break note.unwrap();
             }
+        }
+    }
+
+    // TODO add comment
+    // We have to check note.commitment_inner().is_some() after setting rho
+    pub(crate) fn new_issue_note(
+        recipient: Address,
+        value: NoteValue,
+        asset: AssetBase,
+        mut rng: impl RngCore,
+    ) -> Self {
+        let rseed = RandomSeed::random(&mut rng, &Rho(pallas::Base::zero()));
+        Note {
+            recipient,
+            value,
+            asset,
+            rho: None,
+            rseed,
+            rseed_split_note: CtOption::new(rseed, 0u8.into()),
         }
     }
 
@@ -323,12 +336,24 @@ impl Note {
 
     /// Derives the ephemeral secret key for this note.
     pub(crate) fn esk(&self) -> EphemeralSecretKey {
-        EphemeralSecretKey(self.rseed.esk(&self.rho))
+        EphemeralSecretKey(
+            self.rseed.esk(
+                &self
+                    .rho
+                    .expect("must call Note::update_rho_for_issuance_note first"),
+            ),
+        )
     }
 
     /// Returns rho of this note.
     pub fn rho(&self) -> Rho {
         self.rho
+            .expect("must call Note::update_rho_for_issuance_note first")
+    }
+
+    #[cfg(test)]
+    pub fn has_rho(&self) -> bool {
+        self.rho.is_some()
     }
 
     /// Derives the commitment to this note.
@@ -352,26 +377,28 @@ impl Note {
     /// [notes]: https://zips.z.cash/protocol/nu5.pdf#notes
     fn commitment_inner(&self) -> CtOption<NoteCommitment> {
         let g_d = self.recipient.g_d();
+        let rho = self.rho();
 
         NoteCommitment::derive(
             g_d.to_bytes(),
             self.recipient.pk_d().to_bytes(),
             self.value,
             self.asset,
-            self.rho.0,
-            self.rseed.psi(&self.rho),
-            self.rseed.rcm(&self.rho),
+            rho.0,
+            self.rseed.psi(&rho),
+            self.rseed.rcm(&rho),
         )
     }
 
     /// Derives the nullifier for this note.
     pub fn nullifier(&self, fvk: &FullViewingKey) -> Nullifier {
         let selected_rseed = self.rseed_split_note.unwrap_or(self.rseed);
+        let rho = self.rho();
 
         Nullifier::derive(
             fvk.nk(),
-            self.rho.0,
-            selected_rseed.psi(&self.rho),
+            rho.0,
+            selected_rseed.psi(&rho),
             self.commitment(),
             self.rseed_split_note.is_some(),
         )
@@ -388,7 +415,7 @@ impl Note {
     pub fn create_split_note(self, rng: &mut impl RngCore) -> Self {
         assert!(bool::from(!self.asset().is_native()));
         Note {
-            rseed_split_note: CtOption::new(RandomSeed::random(rng, &self.rho), 1u8.into()),
+            rseed_split_note: CtOption::new(RandomSeed::random(rng, &self.rho()), 1u8.into()),
             ..self
         }
     }
@@ -396,14 +423,24 @@ impl Note {
     /// Update the rho value of the issuance note (see
     /// [ZIP-227: Issuance of Zcash Shielded Assets][zip227]).
     ///
+    /// TODO
+    ///
     /// [zip227]: https://zips.z.cash/zip-0227
     pub(crate) fn update_rho_for_issuance_note(
         &mut self,
         nullifier: &Nullifier,
         index_action: u32,
         index_note: u32,
+        mut rng: impl RngCore,
     ) {
-        self.rho = rho_for_issuance_note(nullifier, index_action, index_note);
+        loop {
+            let rho = rho_for_issuance_note(nullifier, index_action, index_note);
+            self.rho = Some(rho);
+            self.rseed = RandomSeed::random(&mut rng, &rho);
+            if self.commitment_inner().is_some().into() {
+                break;
+            }
+        }
     }
 }
 
@@ -483,7 +520,7 @@ pub mod testing {
                 recipient,
                 value,
                 asset,
-                rho,
+                rho: Some(rho),
                 rseed,
                 rseed_split_note: CtOption::new(rseed, 0u8.into()),
             }
@@ -502,7 +539,7 @@ pub mod testing {
                 recipient,
                 value,
                 asset: AssetBase::native(),
-                rho,
+                rho: Some(rho),
                 rseed,
                 rseed_split_note: CtOption::new(rseed, 0u8.into())
             }
@@ -523,7 +560,7 @@ pub mod testing {
                 recipient,
                 value,
                 asset: AssetBase::custom(&AssetId::new_v0(&ik, &asset_desc_hash)),
-                rho,
+                rho: Some(rho),
                 rseed,
                 rseed_split_note: CtOption::new(rseed, 0u8.into()),
             }

--- a/tests/issuance_global_state.rs
+++ b/tests/issuance_global_state.rs
@@ -171,7 +171,7 @@ fn build_issue_bundle(params: &TestParams, data: &[IssueTestNote]) -> IssueBundl
     }
 
     bundle
-        .update_rho(first_nullifier)
+        .update_rho(first_nullifier, rng)
         .prepare(sighash)
         .sign(isk)
         .unwrap()

--- a/tests/zsa.rs
+++ b/tests/zsa.rs
@@ -23,6 +23,7 @@ use orchard::{
     Address, Anchor, Bundle, Note,
 };
 use rand::rngs::OsRng;
+use rand_core::RngCore;
 use shardtree::{store::memory::MemoryShardStore, ShardTree};
 use std::collections::HashSet;
 use zcash_note_encryption::try_note_decryption;
@@ -78,8 +79,9 @@ fn sign_issue_bundle(
     awaiting_nullifier_bundle: IssueBundle<AwaitingNullifier>,
     isk: &IssueAuthKey<ZSASchnorr>,
     first_nullifier: &Nullifier,
+    rng: impl RngCore,
 ) -> IssueBundle<Signed> {
-    let awaiting_sighash_bundle = awaiting_nullifier_bundle.update_rho(first_nullifier);
+    let awaiting_sighash_bundle = awaiting_nullifier_bundle.update_rho(first_nullifier, rng);
     let sighash = awaiting_sighash_bundle.commitment().into();
     let prepared_bundle = awaiting_sighash_bundle.prepare(sighash);
     prepared_bundle.sign(isk).unwrap()
@@ -174,7 +176,8 @@ fn issue_zsa_notes(
         )
         .is_ok());
 
-    let issue_bundle = sign_issue_bundle(awaiting_nullifier_bundle, keys.isk(), first_nullifier);
+    let issue_bundle =
+        sign_issue_bundle(awaiting_nullifier_bundle, keys.isk(), first_nullifier, rng);
 
     // Take notes from first action
     let notes = issue_bundle.get_all_notes();

--- a/tests/zsa.rs
+++ b/tests/zsa.rs
@@ -23,7 +23,6 @@ use orchard::{
     Address, Anchor, Bundle, Note,
 };
 use rand::rngs::OsRng;
-use rand_core::RngCore;
 use shardtree::{store::memory::MemoryShardStore, ShardTree};
 use std::collections::HashSet;
 use zcash_note_encryption::try_note_decryption;
@@ -79,7 +78,7 @@ fn sign_issue_bundle(
     awaiting_nullifier_bundle: IssueBundle<AwaitingNullifier>,
     isk: &IssueAuthKey<ZSASchnorr>,
     first_nullifier: &Nullifier,
-    rng: impl RngCore,
+    rng: OsRng,
 ) -> IssueBundle<Signed> {
     let awaiting_sighash_bundle = awaiting_nullifier_bundle.update_rho(first_nullifier, rng);
     let sighash = awaiting_sighash_bundle.commitment().into();


### PR DESCRIPTION
Address the following review comments:
r2543612212
r2543614980

When creating an issuance note, the rho value is now initialized to None (instead of being set to 0 previously).
The rho value is later deterministically derived and assigned when calling the `update_rho` method on the `IssueBundle`.

In addition, this PR fixes an issue where issuance notes could be invalid. Previously, rseed was sampled before the final rho value was known, which could result in an invalid note. With this change, rseed is updated after rho is set, ensuring that the resulting note is always valid.