### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run tests
+        env:
+          # Disable LTO in CI to avoid very slow/hanging release test builds on macOS (rustc/LLVM).
+          CARGO_PROFILE_RELEASE_LTO: "off"
         run: cargo test --verbose --release
       - name: Verify working directory is clean
         run: git diff --exit-code
@@ -34,7 +37,7 @@ jobs:
         id: toolchain
       - run: rustup override set ${{steps.toolchain.outputs.name}}
       - if: matrix.os == 'ubuntu-latest'
-        run: sudo apt-get -y install libfontconfig1-dev
+        run: sudo apt-get update && sudo apt-get -y install libfontconfig1-dev
       - name: Remove lockfile to build with latest dependencies
         run: rm Cargo.lock
       - name: Build crate
@@ -128,7 +131,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: cargo fetch
       # Requires #![deny(rustdoc::broken_intra_doc_links)] in crates.
-      - run: sudo apt-get -y install libfontconfig1-dev
+      - run: sudo apt-get update && sudo apt-get -y install libfontconfig1-dev
       - name: Check intra-doc links
         run: cargo doc --all-features --document-private-items
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ rustdoc-args = ["--cfg", "docsrs", "--html-in-header", "katex-header.html"]
 [dependencies]
 aes = "0.8"
 bitvec = { version = "1", default-features = false }
-blake2b_simd = { version = "1", default-features = false }
+blake2b_simd = { version = "=1.0.1", default-features = false }
 ff = { version = "0.13", default-features = false }
 fpe = { version = "0.6", default-features = false, features = ["alloc"] }
 group = "0.13"


### PR DESCRIPTION
- Pin blake2b_simd to version 1.0.1
- Disable LTO for cargo test --release in CI
- Run apt-get update before installing libfontconfig1-dev on Ubuntu to prevent intermittent 404s from stale package indexes