### PR TITLE
PR471 review: Validate Orchard note plaintext lead byte

### DIFF
--- a/src/primitives/orchard_primitives.rs
+++ b/src/primitives/orchard_primitives.rs
@@ -68,4 +68,9 @@ pub trait OrchardPrimitives: fmt::Debug + Clone {
         bundle: &Bundle<Authorized, V, Self>,
         sighash_info_for_kind: impl Fn(&OrchardSighashKind) -> &'static [u8],
     ) -> Blake2bHash;
+
+    /// Returns true if the note plaintext leadByte is equal to
+    /// - 0x02 for V5 transactions (OrchardVanilla), or
+    /// - 0x03 for V6 transactions (OrchardZSA).
+    fn is_valid_note_plaintext_lead_byte(plaintext: &[u8]) -> bool;
 }

--- a/src/primitives/orchard_primitives_vanilla.rs
+++ b/src/primitives/orchard_primitives_vanilla.rs
@@ -108,6 +108,11 @@ impl OrchardPrimitives for OrchardVanilla {
         ));
         h.finalize()
     }
+
+    /// Returns true if the note plaintext leadByte is equal to 0x02.
+    fn is_valid_note_plaintext_lead_byte(plaintext: &[u8]) -> bool {
+        plaintext.first() == Some(&NOTE_VERSION_BYTE_V2)
+    }
 }
 
 #[cfg(test)]
@@ -137,9 +142,8 @@ mod tests {
             compact_action::CompactAction,
             orchard_domain::OrchardDomain,
             redpallas,
-            zcash_note_encryption_domain::{
-                parse_note_plaintext_without_memo, parse_note_version, prf_ock_orchard,
-            },
+            zcash_note_encryption_domain::{parse_note_plaintext_without_memo, prf_ock_orchard},
+            OrchardPrimitives,
         },
         value::{NoteValue, ValueCommitment},
     };
@@ -161,7 +165,7 @@ mod tests {
             let domain = OrchardDomainVanilla::for_rho(rho);
             let (compact, parsed_memo) = domain.split_plaintext_at_memo(&plaintext).unwrap();
 
-            assert!(parse_note_version(compact.as_ref()).is_some());
+            assert!(<OrchardVanilla as OrchardPrimitives>::is_valid_note_plaintext_lead_byte(compact.as_ref()));
 
             let (parsed_note, parsed_recipient) = parse_note_plaintext_without_memo::<OrchardVanilla, _>(rho, &compact,
                 |diversifier| {

--- a/src/primitives/orchard_primitives_zsa.rs
+++ b/src/primitives/orchard_primitives_zsa.rs
@@ -152,6 +152,11 @@ impl OrchardPrimitives for OrchardZSA {
         ));
         h.finalize()
     }
+
+    /// Returns true if the note plaintext leadByte is equal to 0x03.
+    fn is_valid_note_plaintext_lead_byte(plaintext: &[u8]) -> bool {
+        plaintext.first() == Some(&NOTE_VERSION_BYTE_V3)
+    }
 }
 
 #[cfg(test)]
@@ -181,9 +186,8 @@ mod tests {
             compact_action::CompactAction,
             orchard_domain::OrchardDomain,
             redpallas,
-            zcash_note_encryption_domain::{
-                parse_note_plaintext_without_memo, parse_note_version, prf_ock_orchard,
-            },
+            zcash_note_encryption_domain::{parse_note_plaintext_without_memo, prf_ock_orchard},
+            OrchardPrimitives,
         },
         value::{NoteValue, ValueCommitment},
     };
@@ -205,7 +209,7 @@ mod tests {
             let domain = OrchardDomainZSA::for_rho(rho);
             let (compact, parsed_memo) = domain.split_plaintext_at_memo(&plaintext).unwrap();
 
-            assert!(parse_note_version(compact.as_ref()).is_some());
+            assert!(<OrchardZSA as OrchardPrimitives>::is_valid_note_plaintext_lead_byte(compact.as_ref()));
 
             let (parsed_note, parsed_recipient) = parse_note_plaintext_without_memo::<OrchardZSA, _>(rho, &compact,
                 |diversifier| {

--- a/src/primitives/zcash_note_encryption_domain.rs
+++ b/src/primitives/zcash_note_encryption_domain.rs
@@ -80,15 +80,6 @@ pub(super) fn prf_ock_orchard(
     )
 }
 
-/// Retrieves the version of the note plaintext.
-/// Returns `Some(u8)` if the version is recognized, otherwise `None`.
-pub(super) fn parse_note_version(plaintext: &[u8]) -> Option<u8> {
-    plaintext.first().and_then(|version| match *version {
-        NOTE_VERSION_BYTE_V2 | NOTE_VERSION_BYTE_V3 => Some(*version),
-        _ => None,
-    })
-}
-
 /// Parses the note plaintext (excluding the memo) and extracts the note and address if valid.
 /// Domain-specific requirements:
 /// - If the note version is 3, the `plaintext` must contain a valid encoding of a ZSA asset type.
@@ -100,7 +91,9 @@ pub(super) fn parse_note_plaintext_without_memo<Pr: OrchardPrimitives, F>(
 where
     F: FnOnce(&Diversifier) -> Option<DiversifiedTransmissionKey>,
 {
-    parse_note_version(plaintext.as_ref())?;
+    if !Pr::is_valid_note_plaintext_lead_byte(plaintext.as_ref()) {
+        return None;
+    }
 
     // The unwraps below are guaranteed to succeed
     let diversifier = Diversifier::from_bytes(


### PR DESCRIPTION
Address the following review comments:
r2599737628

Ensures the note plaintext lead byte matches 0x02 for Orchard V5 transactions (OrchardVanilla) and 0x03 for Orchard V6 transactions (OrchardZSA).