### PR TITLE
[to upstream] Evaluate fixed digests for backward compatible tests

### DIFF
--- a/src/bundle/commitments.rs
+++ b/src/bundle/commitments.rs
@@ -269,7 +269,7 @@ mod tests {
         builder.build::<i64>(rng).unwrap().unwrap().0
     }
 
-    /// Verify that the hash for an Orchard Vanilla bundle matches a fixed reference value
+    /// Verify that the hash for an Orchard V2 bundle matches a fixed reference value
     /// to ensure consistency.
     #[test]
     fn test_hash_bundle_txid_data_for_orchard_v2() {
@@ -278,6 +278,18 @@ mod tests {
         assert_eq!(
             sighash.to_hex().as_str(),
             "0ac1e319f6761a8561b7bd3fc0907a5c73ed5590a6c210c4d39ffae1d5741875"
+        );
+    }
+
+    /// Verify that the hash for an Ironwood V3 bundle matches a fixed reference value
+    /// to ensure consistency.
+    #[test]
+    fn test_hash_bundle_txid_data_for_ironwood_v3() {
+        let bundle = generate_bundle(BundleVersion::ironwood_v3());
+        let sighash = hash_bundle_txid_data(&bundle, TxVersion::V6).unwrap();
+        assert_eq!(
+            sighash.to_hex().as_str(),
+            "5f408a48dff8e499487169a9adb4f59ec41d7d393e8d4ee15e70e51c67b018a3"
         );
     }
 
@@ -294,7 +306,7 @@ mod tests {
         bundle.prepare(rng, sighash).finalize().unwrap()
     }
 
-    /// Verify that the authorizing data commitment for an Orchard Vanilla bundle matches a fixed
+    /// Verify that the authorizing data commitment for an Orchard V2 bundle matches a fixed
     /// reference value to ensure consistency.
     #[test]
     fn test_hash_bundle_auth_data_for_orchard_v2() {
@@ -303,6 +315,18 @@ mod tests {
         assert_eq!(
             orchard_auth_digest.to_hex().as_str(),
             "37d6c29faa98c2cb54420f3f7cac0477fdb105df1cdfde7adb7fbf68a24e3085"
+        );
+    }
+
+    /// Verify that the authorizing data commitment for an Ironwood V3 bundle matches a fixed
+    /// reference value to ensure consistency.
+    #[test]
+    fn test_hash_bundle_auth_data_for_ironwood_v3() {
+        let bundle = generate_auth_bundle(BundleVersion::ironwood_v3(), TxVersion::V6);
+        let orchard_auth_digest = hash_bundle_auth_data(&bundle, TxVersion::V6).unwrap();
+        assert_eq!(
+            orchard_auth_digest.to_hex().as_str(),
+            "404871b295dd65dfe4b44c5bfe92bdd194c0f70bc090a4f50b43a51244a37e5f"
         );
     }
 }

--- a/src/bundle/commitments.rs
+++ b/src/bundle/commitments.rs
@@ -236,7 +236,7 @@ mod tests {
         builder::{Builder, BundleType, UnauthorizedBundle},
         bundle::{
             commitments::{hash_bundle_auth_data, hash_bundle_txid_data},
-            Authorized, Bundle,
+            Authorized, Bundle, BundleVersion, TxVersion,
         },
         circuit::ProvingKey,
         keys::{FullViewingKey, Scope, SpendingKey},
@@ -245,13 +245,19 @@ mod tests {
     };
     use rand::{rngs::StdRng, SeedableRng};
 
-    fn generate_bundle(bundle_type: BundleType) -> UnauthorizedBundle<i64> {
+    fn generate_bundle(bundle_version: BundleVersion) -> UnauthorizedBundle<i64> {
         let rng = StdRng::seed_from_u64(5);
 
         let sk = SpendingKey::from_bytes([7; 32]).unwrap();
         let recipient = FullViewingKey::from(&sk).address_at(0u32, Scope::External);
 
-        let mut builder = Builder::new(bundle_type, Anchor::from_bytes([0; 32]).unwrap());
+        let mut builder = Builder::new(
+            BundleType::DEFAULT,
+            bundle_version,
+            bundle_version.default_flags(),
+            Anchor::from_bytes([0; 32]).unwrap(),
+        )
+        .unwrap();
         builder
             .add_output(None, recipient, NoteValue::from_raw(10), [0u8; 512])
             .unwrap();
@@ -266,31 +272,34 @@ mod tests {
     /// Verify that the hash for an Orchard Vanilla bundle matches a fixed reference value
     /// to ensure consistency.
     #[test]
-    fn test_hash_bundle_txid_data_for_orchard_vanilla() {
-        let bundle = generate_bundle(BundleType::DEFAULT);
-        let sighash = hash_bundle_txid_data(&bundle);
+    fn test_hash_bundle_txid_data_for_orchard_v2() {
+        let bundle = generate_bundle(BundleVersion::orchard_v2());
+        let sighash = hash_bundle_txid_data(&bundle, TxVersion::V5).unwrap();
         assert_eq!(
             sighash.to_hex().as_str(),
             "0ac1e319f6761a8561b7bd3fc0907a5c73ed5590a6c210c4d39ffae1d5741875"
         );
     }
 
-    fn generate_auth_bundle(bundle_type: BundleType) -> Bundle<Authorized, i64> {
+    fn generate_auth_bundle(
+        bundle_version: BundleVersion,
+        tx_version: TxVersion,
+    ) -> Bundle<Authorized, i64> {
         let mut rng = StdRng::seed_from_u64(6);
-        let pk = ProvingKey::build();
-        let bundle = generate_bundle(bundle_type)
+        let pk = ProvingKey::build(bundle_version.circuit_version());
+        let bundle = generate_bundle(bundle_version)
             .create_proof(&pk, &mut rng)
             .unwrap();
-        let sighash = bundle.commitment().into();
+        let sighash = bundle.commitment(tx_version).unwrap().into();
         bundle.prepare(rng, sighash).finalize().unwrap()
     }
 
     /// Verify that the authorizing data commitment for an Orchard Vanilla bundle matches a fixed
     /// reference value to ensure consistency.
     #[test]
-    fn test_hash_bundle_auth_data_for_orchard_vanilla() {
-        let bundle = generate_auth_bundle(BundleType::DEFAULT);
-        let orchard_auth_digest = hash_bundle_auth_data(&bundle);
+    fn test_hash_bundle_auth_data_for_orchard_v2() {
+        let bundle = generate_auth_bundle(BundleVersion::orchard_v2(), TxVersion::V5);
+        let orchard_auth_digest = hash_bundle_auth_data(&bundle, TxVersion::V5).unwrap();
         assert_eq!(
             orchard_auth_digest.to_hex().as_str(),
             "37d6c29faa98c2cb54420f3f7cac0477fdb105df1cdfde7adb7fbf68a24e3085"

--- a/src/bundle/commitments.rs
+++ b/src/bundle/commitments.rs
@@ -293,7 +293,7 @@ mod tests {
         let orchard_auth_digest = hash_bundle_auth_data(&bundle);
         assert_eq!(
             orchard_auth_digest.to_hex().as_str(),
-            "5f3bcf759cddf19170ec47a882a470b5767d66c95fc72ffc360f31324474a06b"
+            "37d6c29faa98c2cb54420f3f7cac0477fdb105df1cdfde7adb7fbf68a24e3085"
         );
     }
 }

--- a/src/bundle/commitments.rs
+++ b/src/bundle/commitments.rs
@@ -229,3 +229,71 @@ pub fn hash_bundle_auth_empty(
     )
     .finalize())
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::{
+        builder::{Builder, BundleType, UnauthorizedBundle},
+        bundle::{
+            commitments::{hash_bundle_auth_data, hash_bundle_txid_data},
+            Authorized, Bundle,
+        },
+        circuit::ProvingKey,
+        keys::{FullViewingKey, Scope, SpendingKey},
+        value::NoteValue,
+        Anchor,
+    };
+    use rand::{rngs::StdRng, SeedableRng};
+
+    fn generate_bundle(bundle_type: BundleType) -> UnauthorizedBundle<i64> {
+        let rng = StdRng::seed_from_u64(5);
+
+        let sk = SpendingKey::from_bytes([7; 32]).unwrap();
+        let recipient = FullViewingKey::from(&sk).address_at(0u32, Scope::External);
+
+        let mut builder = Builder::new(bundle_type, Anchor::from_bytes([0; 32]).unwrap());
+        builder
+            .add_output(None, recipient, NoteValue::from_raw(10), [0u8; 512])
+            .unwrap();
+
+        builder
+            .add_output(None, recipient, NoteValue::from_raw(20), [0u8; 512])
+            .unwrap();
+
+        builder.build::<i64>(rng).unwrap().unwrap().0
+    }
+
+    /// Verify that the hash for an Orchard Vanilla bundle matches a fixed reference value
+    /// to ensure consistency.
+    #[test]
+    fn test_hash_bundle_txid_data_for_orchard_vanilla() {
+        let bundle = generate_bundle(BundleType::DEFAULT);
+        let sighash = hash_bundle_txid_data(&bundle);
+        assert_eq!(
+            sighash.to_hex().as_str(),
+            "0ac1e319f6761a8561b7bd3fc0907a5c73ed5590a6c210c4d39ffae1d5741875"
+        );
+    }
+
+    fn generate_auth_bundle(bundle_type: BundleType) -> Bundle<Authorized, i64> {
+        let mut rng = StdRng::seed_from_u64(6);
+        let pk = ProvingKey::build();
+        let bundle = generate_bundle(bundle_type)
+            .create_proof(&pk, &mut rng)
+            .unwrap();
+        let sighash = bundle.commitment().into();
+        bundle.prepare(rng, sighash).finalize().unwrap()
+    }
+
+    /// Verify that the authorizing data commitment for an Orchard Vanilla bundle matches a fixed
+    /// reference value to ensure consistency.
+    #[test]
+    fn test_hash_bundle_auth_data_for_orchard_vanilla() {
+        let bundle = generate_auth_bundle(BundleType::DEFAULT);
+        let orchard_auth_digest = hash_bundle_auth_data(&bundle);
+        assert_eq!(
+            orchard_auth_digest.to_hex().as_str(),
+            "5f3bcf759cddf19170ec47a882a470b5767d66c95fc72ffc360f31324474a06b"
+        );
+    }
+}


### PR DESCRIPTION
The fixed digests obtained in this PR are used to check backward compatibility in  #239 