### PR TITLE
Remove create_test_reference_note (Zebra now gets reference notes from IssueBundle in tests)

### DIFF
--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -575,12 +575,6 @@ fn create_reference_note(asset: AssetBase, mut rng: impl RngCore) -> Note {
     )
 }
 
-/// Test-only helper for creating Orchard reference notes (used by Zebra tests)
-#[cfg(all(feature = "temporary-zebra", feature = "test-dependencies"))]
-pub fn create_test_reference_note(asset: AssetBase, rng: impl RngCore) -> Note {
-    create_reference_note(asset, rng)
-}
-
 impl IssueBundle<Prepared> {
     /// Sign the `IssueBundle`.
     /// The call makes sure that the provided `isk` matches the `ik` and the derived `asset` for each note in the bundle.


### PR DESCRIPTION
Zebra no longer calls `create_test_reference_note`. Instead, it generates a reference note by constructing an `IssueBundle` and extracting the reference note from its actions.

This change is needed because `create_test_reference_note` produced reference notes with `rho = None`, which breaks `librustzcash` serialization and is undesirable in general.

Since the only purpose of `create_test_reference_note` in `orchard` was Zebra testing, it’s no longer needed and is removed in this PR.
