### PR TITLE
Add IssueBundle::note_commitments to expose extracted note commitments

### DIFF
--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -921,10 +921,11 @@ mod tests {
         value::NoteValue,
         Address, Note,
     };
-    use alloc::collections::BTreeMap;
+    use alloc::collections::{BTreeMap, BTreeSet};
     use alloc::string::{String, ToString};
     use alloc::vec::Vec;
     use nonempty::NonEmpty;
+    use pasta_curves::pallas;
     use rand::rngs::OsRng;
     use rand::RngCore;
 
@@ -1470,6 +1471,14 @@ mod tests {
                 reference_note3
             ))
         );
+
+        // Verify note_commitments() returns non-zero, unique pallas::Base values
+        let mut unique_commitments = BTreeSet::new();
+        for commitment in signed.note_commitments() {
+            assert_ne!(commitment, pallas::Base::zero());
+            assert!(unique_commitments.insert(commitment));
+        }
+        assert_eq!(unique_commitments.len(), 7);
     }
 
     #[test]

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -637,9 +637,8 @@ impl IssueBundle<Signed> {
 
     /// Returns the note commitments for all notes in this bundle, in action order.
     ///
-    /// This allows downstream code to consume note commitments directly as
-    /// `use pasta_curves::pallas::Base` values, avoiding byte round-trips when
-    /// recomputing issuance-related commitments.
+    /// This exposes the commitments directly as `pasta_curves::pallas::Base`
+    /// values for external crates, avoiding extra byte conversions.
     pub fn note_commitments(&self) -> impl Iterator<Item = pallas::Base> + '_ {
         self.actions().iter().flat_map(|action| {
             action

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -18,11 +18,12 @@ use core::fmt;
 use core::fmt::Debug;
 use group::Group;
 use nonempty::NonEmpty;
+use pasta_curves::pallas;
 use rand::RngCore;
 
 use crate::{
     bundle::commitments::{hash_issue_bundle_auth_data, hash_issue_bundle_txid_data},
-    note::{rho_for_issuance_note, AssetBase, AssetId, Nullifier},
+    note::{rho_for_issuance_note, AssetBase, AssetId, ExtractedNoteCommitment, Nullifier},
     value::NoteValue,
     Address, Note,
 };
@@ -637,8 +638,8 @@ impl IssueBundle<Signed> {
     /// Returns the note commitments for all notes in this bundle, in action order.
     ///
     /// This allows downstream code to consume note commitments directly as
-    /// `pallas::Base` values, avoiding byte round-trips when recomputing
-    /// issuance-related commitments.
+    /// `use pasta_curves::pallas::Base` values, avoiding byte round-trips when
+    /// recomputing issuance-related commitments.
     pub fn note_commitments(&self) -> impl Iterator<Item = pallas::Base> + '_ {
         self.actions().iter().flat_map(|action| {
             action

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -1472,7 +1472,8 @@ mod tests {
             ))
         );
 
-        // Verify note_commitments() returns non-zero, unique pallas::Base values
+        // Verify note_commitments() returns a correct number of non-zero,
+        // unique pallas::Base values
         let mut unique_commitments = BTreeSet::new();
         for commitment in signed.note_commitments() {
             assert_ne!(commitment, pallas::Base::zero());

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -633,6 +633,20 @@ impl IssueBundle<Signed> {
     ) -> IssueBundleAuthorizingCommitment {
         IssueBundleAuthorizingCommitment(hash_issue_bundle_auth_data(self, sighash_info_for_kind))
     }
+
+    /// Returns the note commitments for all notes in this bundle, in action order.
+    ///
+    /// This allows downstream code to consume note commitments directly as
+    /// `pallas::Base` values, avoiding byte round-trips when recomputing
+    /// issuance-related commitments.
+    pub fn note_commitments(&self) -> impl Iterator<Item = pallas::Base> + '_ {
+        self.actions().iter().flat_map(|action| {
+            action
+                .notes()
+                .iter()
+                .map(|note| ExtractedNoteCommitment::from(note.commitment()).inner())
+        })
+    }
 }
 
 /// Checks an [`IssueBundle`] without signature verification.

--- a/src/issuance.rs
+++ b/src/issuance.rs
@@ -2017,6 +2017,20 @@ mod tests {
             }
         }
     }
+
+    #[test]
+    fn issue_bundle_note_commitments_empty_bundle() {
+        let params = setup_params();
+        let (bundle, _) = IssueBundle::new(
+            params.ik.clone(),
+            asset_desc_hash(b"asset1"),
+            None, // no notes, finalize-only
+            false,
+            params.rng,
+        );
+        let signed = sign_bundle(bundle, &params);
+        assert_eq!(signed.note_commitments().count(), 0);
+    }
 }
 
 /// Generators for property testing.

--- a/src/note/commitment.rs
+++ b/src/note/commitment.rs
@@ -120,7 +120,7 @@ impl From<NoteCommitment> for ExtractedNoteCommitment {
 }
 
 impl ExtractedNoteCommitment {
-    pub(crate) fn inner(&self) -> pallas::Base {
+    pub fn inner(&self) -> pallas::Base {
         self.0
     }
 }

--- a/src/note/commitment.rs
+++ b/src/note/commitment.rs
@@ -120,8 +120,7 @@ impl From<NoteCommitment> for ExtractedNoteCommitment {
 }
 
 impl ExtractedNoteCommitment {
-    /// Returns the extracted note commitment as a `pallas::Base` value.
-    pub fn inner(&self) -> pallas::Base {
+    pub(crate) fn inner(&self) -> pallas::Base {
         self.0
     }
 }

--- a/src/note/commitment.rs
+++ b/src/note/commitment.rs
@@ -120,6 +120,7 @@ impl From<NoteCommitment> for ExtractedNoteCommitment {
 }
 
 impl ExtractedNoteCommitment {
+    /// Returns the extracted note commitment as a `pallas::Base` value.
     pub fn inner(&self) -> pallas::Base {
         self.0
     }


### PR DESCRIPTION
This adds `IssueBundle::note_commitments()` to expose extracted note commitments directly as `pallas::Base` values.

This is useful in Zebra to recompute issuance-related commitments without the current `to_bytes`/`from_bytes` workaround:

https://github.com/QED-it/zebra/blob/2634fd662a4eaca6df901c82b1bc05d2982636d7/zebra-chain/src/orchard_zsa/issuance.rs#L43

See also the related Zebra PR review comment:

https://github.com/QED-it/zebra/pull/111#discussion_r2889611006