### PR TITLE
Make OrchardCircuitVersion the single circuit selector

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -33,9 +33,7 @@ use {
     crate::{
         action::Action,
         bundle::derive_bvk,
-        circuit::{
-            Circuit, Instance, OrchardCircuit, OrchardCircuitVersion, ProvingKey, Witnesses,
-        },
+        circuit::{Circuit, Instance, OrchardCircuit, ProvingKey, Witnesses},
         flavor::OrchardFlavor,
     },
     nonempty::NonEmpty,
@@ -509,25 +507,11 @@ impl ActionInfo {
     ///
     /// Defined in [Zcash Protocol Spec § 4.7.3: Sending Notes (Orchard)][orchardsend].
     ///
-    /// The circuit version defaults to [`OrchardCircuitVersion::FixedPostNu6_2`],
-    /// which should be used for all new proofs.
-    ///
     /// [orchardsend]: https://zips.z.cash/protocol/nu5.pdf#orchardsend
     #[cfg(feature = "circuit")]
     fn build<FL: OrchardFlavor>(
         self,
-        rng: impl RngCore,
-    ) -> (Action<SigningMetadata, FL>, Witnesses) {
-        self.build_for_version(rng, OrchardCircuitVersion::FixedPostNu6_2)
-    }
-
-    /// Builds the action for a given circuit version. This must be consistent
-    /// between actions in a bundle.
-    #[cfg(feature = "circuit")]
-    fn build_for_version<FL: OrchardFlavor>(
-        self,
         mut rng: impl RngCore,
-        circuit_version: OrchardCircuitVersion,
     ) -> (Action<SigningMetadata, FL>, Witnesses) {
         let v_net = self.value_sum();
         let cv_net = ValueCommitment::derive(v_net, self.rcv.clone(), self.output.asset);
@@ -551,13 +535,7 @@ impl ActionInfo {
                 "rk is non-identity (α was generated randomly) and epk is a \
                  valid non-identity point by construction",
             ),
-            Witnesses::from_action_context_unchecked::<FL>(
-                self.spend,
-                note,
-                alpha,
-                self.rcv,
-                circuit_version,
-            ),
+            Witnesses::from_action_context_unchecked::<FL>(self.spend, note, alpha, self.rcv),
         )
     }
 
@@ -648,60 +626,17 @@ pub struct Builder {
     burn: BTreeMap<AssetBase, NoteValue>,
     bundle_type: BundleType,
     anchor: Anchor,
-    // Only proving (the `circuit` feature) consults the circuit version.
-    #[cfg(feature = "circuit")]
-    circuit_version: OrchardCircuitVersion,
 }
 
 impl Builder {
     /// Constructs a new empty builder for an Orchard bundle.
-    #[cfg_attr(
-        feature = "circuit",
-        doc = "",
-        doc = "When proving, the circuit version defaults to `FixedPostNu6_2`, which should be used",
-        doc = "for all new proofs; use [`Builder::new_for_version`] to choose another."
-    )]
     pub fn new(bundle_type: BundleType, anchor: Anchor) -> Self {
-        Self::new_internal(
-            bundle_type,
-            anchor,
-            #[cfg(feature = "circuit")]
-            OrchardCircuitVersion::FixedPostNu6_2,
-        )
-    }
-
-    /// Constructs a new empty builder for an Orchard bundle with a given
-    /// circuit version.
-    ///
-    /// Setting this to [`OrchardCircuitVersion::InsecurePreNu6_2`] produces a
-    /// bundle whose proof must be created with an insecure proving key (see
-    /// [`ProvingKey::build_for_version`]); this is intended only for
-    /// reproducing pre-NU6.2 proofs in tests, never for proving transactions
-    /// for the network.
-    ///
-    /// [`ProvingKey::build_for_version`]: crate::circuit::ProvingKey::build_for_version
-    #[cfg(feature = "circuit")]
-    pub fn new_for_version(
-        bundle_type: BundleType,
-        anchor: Anchor,
-        circuit_version: OrchardCircuitVersion,
-    ) -> Self {
-        Self::new_internal(bundle_type, anchor, circuit_version)
-    }
-
-    fn new_internal(
-        bundle_type: BundleType,
-        anchor: Anchor,
-        #[cfg(feature = "circuit")] circuit_version: OrchardCircuitVersion,
-    ) -> Self {
         Builder {
             spends: vec![],
             outputs: vec![],
             burn: BTreeMap::new(),
             bundle_type,
             anchor,
-            #[cfg(feature = "circuit")]
-            circuit_version,
         }
     }
 
@@ -835,14 +770,13 @@ impl Builder {
         self,
         rng: impl RngCore,
     ) -> Result<Option<UnauthorizedBundleWithMetadata<V, FL>>, BuildError> {
-        bundle_for_version(
+        bundle(
             rng,
             self.anchor,
             self.bundle_type,
             self.spends,
             self.outputs,
             self.burn,
-            self.circuit_version,
         )
     }
 
@@ -956,36 +890,6 @@ pub fn bundle<V: TryFrom<i64>, FL: OrchardFlavor>(
     outputs: Vec<OutputInfo>,
     burn: BTreeMap<AssetBase, NoteValue>,
 ) -> Result<Option<UnauthorizedBundleWithMetadata<V, FL>>, BuildError> {
-    bundle_for_version(
-        rng,
-        anchor,
-        bundle_type,
-        spends,
-        outputs,
-        burn,
-        OrchardCircuitVersion::FixedPostNu6_2,
-    )
-}
-
-/// Builds a bundle containing the given spent notes and outputs, with the Action circuits
-/// built for the given `circuit_version`.
-///
-/// Only [`OrchardCircuitVersion::FixedPostNu6_2`] should be used to prove transactions for the
-/// network; [`OrchardCircuitVersion::InsecurePreNu6_2`] exists only to reproduce pre-NU6.2
-/// proofs in tests, and requires an insecure proving key (see
-/// [`ProvingKey::build_for_version`]) to create the proof.
-///
-/// [`ProvingKey::build_for_version`]: crate::circuit::ProvingKey::build_for_version
-#[cfg(feature = "circuit")]
-pub fn bundle_for_version<V: TryFrom<i64>, FL: OrchardFlavor>(
-    rng: impl RngCore,
-    anchor: Anchor,
-    bundle_type: BundleType,
-    spends: Vec<SpendInfo>,
-    outputs: Vec<OutputInfo>,
-    burn: BTreeMap<AssetBase, NoteValue>,
-    circuit_version: OrchardCircuitVersion,
-) -> Result<Option<UnauthorizedBundleWithMetadata<V, FL>>, BuildError> {
     build_bundle(
         rng,
         anchor,
@@ -1008,10 +912,8 @@ pub fn bundle_for_version<V: TryFrom<i64>, FL: OrchardFlavor>(
                 .into_bsk();
 
             // Create the actions.
-            let (actions, witnesses): (Vec<_>, Vec<_>) = pre_actions
-                .into_iter()
-                .map(|a| a.build_for_version(&mut rng, circuit_version))
-                .unzip();
+            let (actions, witnesses): (Vec<_>, Vec<_>) =
+                pre_actions.into_iter().map(|a| a.build(&mut rng)).unzip();
 
             // Verify that bsk and bvk are consistent.
             let bvk = derive_bvk(&actions, zatoshi_value_balance, &burn_vec);
@@ -1026,10 +928,7 @@ pub fn bundle_for_version<V: TryFrom<i64>, FL: OrchardFlavor>(
                         burn_vec,
                         anchor,
                         InProgress {
-                            proof: Unproven {
-                                witnesses,
-                                circuit_version,
-                            },
+                            proof: Unproven { witnesses },
                             sigs: Unauthorized { bsk },
                         },
                     ),
@@ -1229,7 +1128,6 @@ impl<P: fmt::Debug, S: InProgressSignatures> Authorization for InProgress<P, S> 
 #[derive(Clone, Debug)]
 pub struct Unproven {
     witnesses: Vec<Witnesses>,
-    circuit_version: OrchardCircuitVersion,
 }
 
 #[cfg(feature = "circuit")]
@@ -1259,12 +1157,6 @@ impl<S: InProgressSignatures> InProgress<Unproven, S> {
 
 #[cfg(feature = "circuit")]
 impl<S: InProgressSignatures, V, FL: OrchardFlavor> Bundle<InProgress<Unproven, S>, V, FL> {
-    /// The circuit version this bundle's actions were built for, and that its proof must
-    /// therefore be created against (with a matching [`ProvingKey`]).
-    pub fn circuit_version(&self) -> OrchardCircuitVersion {
-        self.authorization().proof.circuit_version
-    }
-
     /// Creates the proof for this bundle.
     pub fn create_proof(
         self,

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -26,6 +26,7 @@ use crate::{
     constants::{
         OrchardCommitDomains, OrchardFixedBases, OrchardHashDomains, MERKLE_DEPTH_ORCHARD,
     },
+    flavor::{OrchardVanilla, OrchardZSA},
     keys::{
         CommitIvkRandomness, DiversifiedTransmissionKey, NullifierDerivingKey, SpendValidatingKey,
     },
@@ -148,48 +149,66 @@ impl<C: OrchardCircuit> plonk::Circuit<pallas::Base> for Circuit<C> {
     }
 }
 
-/// Selects which version of the Orchard Action circuit to build.
+/// Selects which Orchard Action circuit to build.
 ///
-/// The two versions produce different verifying keys: the fixed circuit anchors the
-/// variable-base scalar-multiplication base (see `halo2_gadgets`), the pre-NU6.2 one does
-/// not. [`FixedPostNu6_2`] is used for all proving and current verification;
-/// [`InsecurePreNu6_2`] reconstructs the historical (NU5..NU6.2) verifying key solely to
-/// verify proofs produced before NU6.2.
+/// This is the single runtime selector for the circuit: it picks both the protocol flavor
+/// (Vanilla vs. ZSA) and, for Vanilla, the variable-base scalar-multiplication base. It is
+/// consumed at the key-building boundary ([`ProvingKey::build_for_kind`],
+/// [`VerifyingKey::build_for_kind`]), which dispatches to the corresponding compile-time
+/// flavor type ([`OrchardVanilla`]/[`OrchardZSA`]); everything downstream stays typed.
 ///
-/// This is a runtime value rather than a type parameter: it is carried in [`Circuit`] and
-/// chosen when building a [`ProvingKey`] or [`VerifyingKey`], so the circuit version can be
-/// threaded dynamically (e.g. across an FFI boundary).
+/// [`InsecurePreNu6_2`] reconstructs the historical (NU5..NU6.2) Vanilla verifying key solely
+/// to verify proofs produced before NU6.2; it is never used for proving (proving is always
+/// anchored). The illegal "ZSA on the unanchored base" combination is simply not a variant of
+/// this enum.
 ///
-/// [`FixedPostNu6_2`]: OrchardCircuitVersion::FixedPostNu6_2
+/// [`OrchardVanilla`]: crate::flavor::OrchardVanilla
+/// [`OrchardZSA`]: crate::flavor::OrchardZSA
 /// [`InsecurePreNu6_2`]: OrchardCircuitVersion::InsecurePreNu6_2
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
 pub enum OrchardCircuitVersion {
-    /// The insecure pre-NU6.2 circuit, in which the variable-base scalar-multiplication base
-    /// is not anchored to the real base. For reconstructing the historical (NU5..NU6.2)
+    /// The insecure pre-NU6.2 Vanilla circuit, in which the variable-base scalar-multiplication
+    /// base is not anchored to the real base. For reconstructing the historical (NU5..NU6.2)
     /// verifying key only — never for proving or current verification.
     InsecurePreNu6_2,
-    /// The fixed circuit, active from NU6.2 onward. Used for all proving and current
-    /// verification.
+    /// The fixed Vanilla circuit, active from NU6.2 onward. Used for all Vanilla proving and
+    /// current verification.
     #[default]
     FixedPostNu6_2,
+    /// The OrchardZSA circuit (always anchored).
+    Zsa,
 }
 
-impl OrchardCircuitVersion {
+/// Which variable-base scalar-multiplication base the Action circuit is synthesized against.
+///
+/// All proving and current verification use [`EccBase::Anchored`]. [`EccBase::Unanchored`]
+/// reconstructs the historical (NU5..NU6.2) Vanilla circuit and is set only by
+/// [`VerifyingKey::build_legacy_vanilla`]; it never reaches a proving path.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+pub(crate) enum EccBase {
+    /// The fixed (NU6.2-onward) base, anchored to the real base.
+    #[default]
+    Anchored,
+    /// The historical pre-NU6.2 base, not anchored to the real base. Verify-only.
+    Unanchored,
+}
+
+impl EccBase {
     /// The corresponding `halo2_gadgets` variable-base scalar-mul circuit version.
     fn halo2_version(self) -> CircuitVersion {
         match self {
-            OrchardCircuitVersion::InsecurePreNu6_2 => CircuitVersion::InsecureUnanchoredBase,
-            OrchardCircuitVersion::FixedPostNu6_2 => CircuitVersion::AnchoredBase,
+            EccBase::Unanchored => CircuitVersion::InsecureUnanchoredBase,
+            EccBase::Anchored => CircuitVersion::AnchoredBase,
         }
     }
 }
 
 /// The Orchard Action circuit.
 ///
-/// The `circuit_version` field selects which circuit to build; it defaults to
-/// [`OrchardCircuitVersion::FixedPostNu6_2`], so a default `Circuit` is the current (fixed)
-/// circuit. [`OrchardCircuitVersion::InsecurePreNu6_2`] exists only to rebuild the historical
-/// verifying key.
+/// The protocol flavor is the compile-time type parameter `C`. The witnesses carry an
+/// [`EccBase`] selecting the variable-base scalar-multiplication base; it defaults to
+/// [`EccBase::Anchored`] (the current circuit), and is only set to [`EccBase::Unanchored`] by
+/// [`VerifyingKey::build_legacy_vanilla`] to rebuild the historical verifying key.
 #[derive(Clone, Debug, Default)]
 pub struct Circuit<C: OrchardCircuit> {
     pub(crate) witnesses: Witnesses,
@@ -240,7 +259,7 @@ pub struct Witnesses {
     // The ZSA-specific witnesses.
     // For OrchardVanilla circuits, this field should be initialized to `Value::unknown()`.
     pub(crate) additional_zsa_witnesses: Value<AdditionalZsaWitnesses>,
-    pub(crate) circuit_version: OrchardCircuitVersion,
+    pub(crate) ecc_base: EccBase,
 }
 
 impl Witnesses {
@@ -266,35 +285,8 @@ impl Witnesses {
         alpha: pallas::Scalar,
         rcv: ValueCommitTrapdoor,
     ) -> Option<Self> {
-        Self::from_action_context_for_version::<C>(
-            spend,
-            output_note,
-            alpha,
-            rcv,
-            OrchardCircuitVersion::FixedPostNu6_2,
-        )
-    }
-
-    /// Like [`Witnesses::from_action_context`], but builds the circuit for the given
-    /// `circuit_version`. Only [`OrchardCircuitVersion::FixedPostNu6_2`] should be used for
-    /// proving; [`OrchardCircuitVersion::InsecurePreNu6_2`] exists to reconstruct historical
-    /// proofs (e.g. for testing that pre-NU6.2 proofs still verify).
-    pub fn from_action_context_for_version<C: OrchardCircuit>(
-        spend: SpendInfo,
-        output_note: Note,
-        alpha: pallas::Scalar,
-        rcv: ValueCommitTrapdoor,
-        circuit_version: OrchardCircuitVersion,
-    ) -> Option<Self> {
-        (Rho::from_nf_old(spend.note.nullifier(&spend.fvk)) == output_note.rho()).then(|| {
-            Self::from_action_context_unchecked::<C>(
-                spend,
-                output_note,
-                alpha,
-                rcv,
-                circuit_version,
-            )
-        })
+        (Rho::from_nf_old(spend.note.nullifier(&spend.fvk)) == output_note.rho())
+            .then(|| Self::from_action_context_unchecked::<C>(spend, output_note, alpha, rcv))
     }
 
     pub(crate) fn from_action_context_unchecked<C: OrchardCircuit>(
@@ -302,7 +294,6 @@ impl Witnesses {
         output_note: Note,
         alpha: pallas::Scalar,
         rcv: ValueCommitTrapdoor,
-        circuit_version: OrchardCircuitVersion,
     ) -> Self {
         let sender_address = spend.note.recipient();
         let rho_old = spend.note.rho();
@@ -340,16 +331,17 @@ impl Witnesses {
             rcv: Value::known(rcv),
 
             additional_zsa_witnesses,
-            circuit_version,
+            ecc_base: EccBase::Anchored,
         }
     }
 }
 
 /// The verifying key for the Orchard Action circuit.
 ///
-/// Build with [`VerifyingKey::build`] for the current (fixed) circuit, or
-/// [`VerifyingKey::build_for_version`] to reconstruct the historical verifying key. The key
-/// verifies only proofs created for the same circuit version.
+/// Build with [`VerifyingKey::build`] for the current (fixed) circuit of a given flavor, with
+/// [`VerifyingKey::build_for_kind`] to select the circuit at runtime, or with
+/// [`VerifyingKey::build_legacy_vanilla`] to reconstruct the historical (pre-NU6.2) Vanilla
+/// verifying key. Each key verifies only proofs created for the same circuit.
 ///
 /// In the current type system, this could be a verifying key for either
 /// the original Orchard Action circuit, or the OrchardZSA circuit.
@@ -360,17 +352,33 @@ pub struct VerifyingKey {
 }
 
 impl VerifyingKey {
-    /// Builds the verifying key for the current (fixed, NU6.2-onward) circuit.
+    /// Builds the verifying key for the current (fixed, NU6.2-onward) circuit of flavor `C`.
     pub fn build<C: OrchardCircuit>() -> Self {
-        Self::build_for_version::<C>(OrchardCircuitVersion::FixedPostNu6_2)
+        Self::build_inner::<C>(EccBase::Anchored)
     }
 
-    /// Builds the verifying key for the given circuit version.
-    pub fn build_for_version<C: OrchardCircuit>(circuit_version: OrchardCircuitVersion) -> Self {
+    /// Builds the verifying key for the circuit selected by `kind` (runtime dispatch over the
+    /// flavor and base).
+    pub fn build_for_kind(kind: OrchardCircuitVersion) -> Self {
+        match kind {
+            OrchardCircuitVersion::Zsa => Self::build::<OrchardZSA>(),
+            OrchardCircuitVersion::FixedPostNu6_2 => Self::build::<OrchardVanilla>(),
+            OrchardCircuitVersion::InsecurePreNu6_2 => Self::build_legacy_vanilla(),
+        }
+    }
+
+    /// Reconstructs the historical (NU5..NU6.2) Vanilla verifying key, built against the
+    /// unanchored base. Verify-only: it exists solely to verify proofs produced before NU6.2,
+    /// and must never be used for proving.
+    pub fn build_legacy_vanilla() -> Self {
+        Self::build_inner::<OrchardVanilla>(EccBase::Unanchored)
+    }
+
+    fn build_inner<C: OrchardCircuit>(ecc_base: EccBase) -> Self {
         let params = halo2_proofs::poly::commitment::Params::new(K);
         let circuit = Circuit::<C> {
             witnesses: Witnesses {
-                circuit_version,
+                ecc_base,
                 ..Default::default()
             },
             phantom: PhantomData,
@@ -384,8 +392,10 @@ impl VerifyingKey {
 
 /// The proving key for the Orchard Action circuit.
 ///
-/// Build with [`ProvingKey::build`] for the current (fixed) circuit. The resulting proofs
-/// verify only under a [`VerifyingKey`] for the same circuit version.
+/// Build with [`ProvingKey::build`] for a given flavor, or [`ProvingKey::build_for_kind`] to
+/// select the flavor at runtime. Proving is always anchored (NU6.2-onward); there is no
+/// insecure proving key. The resulting proofs verify only under a [`VerifyingKey`] for the
+/// same circuit.
 ///
 /// In the current type system, this could be a proving key for either
 /// the original Orchard Action circuit, or the OrchardZSA circuit.
@@ -393,43 +403,34 @@ impl VerifyingKey {
 pub struct ProvingKey {
     params: halo2_proofs::poly::commitment::Params<vesta::Affine>,
     pk: plonk::ProvingKey<vesta::Affine>,
-    circuit_version: OrchardCircuitVersion,
 }
 
 impl ProvingKey {
-    /// Builds the proving key for the current (fixed, NU6.2-onward) circuit.
+    /// Builds the proving key for the (fixed, NU6.2-onward) circuit of flavor `C`.
     pub fn build<C: OrchardCircuit>() -> Self {
-        Self::build_for_version::<C>(OrchardCircuitVersion::FixedPostNu6_2)
-    }
-
-    /// Builds the proving key for the given circuit version.
-    ///
-    /// Only [`OrchardCircuitVersion::FixedPostNu6_2`] should be used to prove transactions for
-    /// the network; [`OrchardCircuitVersion::InsecurePreNu6_2`] exists only to reproduce
-    /// historical proofs (e.g. for testing that pre-NU6.2 proofs still verify).
-    pub fn build_for_version<C: OrchardCircuit>(circuit_version: OrchardCircuitVersion) -> Self {
         let params = halo2_proofs::poly::commitment::Params::new(K);
         let circuit = Circuit::<C> {
-            witnesses: Witnesses {
-                circuit_version,
-                ..Default::default()
-            },
+            witnesses: Witnesses::default(),
             phantom: PhantomData,
         };
 
         let vk = plonk::keygen_vk(&params, &circuit).unwrap();
         let pk = plonk::keygen_pk(&params, vk, &circuit).unwrap();
 
-        ProvingKey {
-            params,
-            pk,
-            circuit_version,
-        }
+        ProvingKey { params, pk }
     }
 
-    /// The circuit version this proving key produces proofs for.
-    pub fn circuit_version(&self) -> OrchardCircuitVersion {
-        self.circuit_version
+    /// Builds the proving key for the flavor selected by `kind` (runtime dispatch).
+    ///
+    /// Proving is always anchored, so the anchored/unanchored distinction in `kind` is
+    /// irrelevant here: both Vanilla variants build the (fixed) Vanilla proving key.
+    pub fn build_for_kind(kind: OrchardCircuitVersion) -> Self {
+        match kind {
+            OrchardCircuitVersion::Zsa => Self::build::<OrchardZSA>(),
+            OrchardCircuitVersion::FixedPostNu6_2 | OrchardCircuitVersion::InsecurePreNu6_2 => {
+                Self::build::<OrchardVanilla>()
+            }
+        }
     }
 }
 
@@ -575,13 +576,6 @@ impl Proof {
         instances: &[Instance],
         mut rng: impl RngCore,
     ) -> Result<Self, plonk::Error> {
-        if circuits
-            .iter()
-            .any(|c| c.witnesses.circuit_version != pk.circuit_version)
-        {
-            return Err(plonk::Error::Synthesis);
-        }
-
         let instances: Vec<_> = instances.iter().map(|i| i.to_halo2_instance()).collect();
         let instances: Vec<Vec<_>> = instances
             .iter()

--- a/src/circuit/circuit_vanilla.rs
+++ b/src/circuit/circuit_vanilla.rs
@@ -240,7 +240,7 @@ impl OrchardCircuit for OrchardVanilla {
         SinsemillaChip::load(config.sinsemilla_config_1.clone(), &mut layouter)?;
 
         // Construct the ECC chip.
-        let ecc_chip = config.ecc_chip(circuit.circuit_version.halo2_version());
+        let ecc_chip = config.ecc_chip(circuit.ecc_base.halo2_version());
 
         // Witness private inputs that are used across multiple checks.
         let (psi_old, rho_old, cm_old, g_d_old, ak_P, nk, v_old, v_new) = {
@@ -478,7 +478,7 @@ impl OrchardCircuit for OrchardVanilla {
                     "g★_d || pk★_d || i2lebsp_{64}(v) || i2lebsp_{255}(rho) || i2lebsp_{255}(psi)"
                 }),
                 config.sinsemilla_chip_1(),
-                config.ecc_chip(circuit.circuit_version.halo2_version()),
+                config.ecc_chip(circuit.ecc_base.halo2_version()),
                 config.note_commit_chip_old(),
                 g_d_old.inner(),
                 pk_d_old.inner(),
@@ -539,7 +539,7 @@ impl OrchardCircuit for OrchardVanilla {
                     "g★_d || pk★_d || i2lebsp_{64}(v) || i2lebsp_{255}(rho) || i2lebsp_{255}(psi)"
                 }),
                 config.sinsemilla_chip_2(),
-                config.ecc_chip(circuit.circuit_version.halo2_version()),
+                config.ecc_chip(circuit.ecc_base.halo2_version()),
                 config.note_commit_chip_new(),
                 g_d_new.inner(),
                 pk_d_new.inner(),
@@ -638,9 +638,7 @@ mod tests {
 
     use crate::{
         bundle::Flags,
-        circuit::{
-            Circuit, Instance, OrchardCircuitVersion, Proof, ProvingKey, VerifyingKey, Witnesses, K,
-        },
+        circuit::{Circuit, Instance, Proof, ProvingKey, VerifyingKey, Witnesses, K},
         flavor::OrchardVanilla,
         keys::SpendValidatingKey,
         note::{AssetBase, Note, Rho},
@@ -648,10 +646,7 @@ mod tests {
         value::{ValueCommitTrapdoor, ValueCommitment},
     };
 
-    fn generate_circuit_instance<R: RngCore>(
-        mut rng: R,
-        circuit_version: OrchardCircuitVersion,
-    ) -> (Circuit<OrchardVanilla>, Instance) {
+    fn generate_circuit_instance<R: RngCore>(mut rng: R) -> (Circuit<OrchardVanilla>, Instance) {
         let (_, fvk, spent_note) = Note::dummy(&mut rng, None);
 
         let sender_address = spent_note.recipient();
@@ -676,7 +671,6 @@ mod tests {
         (
             Circuit {
                 witnesses: Witnesses {
-                    circuit_version,
                     path: Value::known(path.auth_path()),
                     pos: Value::known(path.position()),
                     g_d_old: Value::known(sender_address.g_d()),
@@ -769,7 +763,7 @@ mod tests {
         let mut rng = OsRng;
 
         let (circuits, instances): (Vec<_>, Vec<_>) = iter::once(())
-            .map(|()| generate_circuit_instance(&mut rng, OrchardCircuitVersion::FixedPostNu6_2))
+            .map(|()| generate_circuit_instance(&mut rng))
             .unzip();
 
         let vk = VerifyingKey::build::<OrchardVanilla>();
@@ -835,56 +829,24 @@ mod tests {
         assert_eq!(proof.0.len(), expected_proof_size);
     }
 
-    // Proves with the proving key for `proving_version` and checks that the proof verifies
-    // under the verifying key for the same version, but not under the verifying key for
-    // `other_version`. The two circuit versions have different verifying keys, so a proof is
-    // bound to the version it was created with.
-    fn proof_is_bound_to_circuit_version(
-        proving_version: OrchardCircuitVersion,
-        other_version: OrchardCircuitVersion,
-    ) {
+    // The fixed (anchored) and legacy (unanchored) Vanilla circuits have different verifying
+    // keys, so a proof is bound to the circuit it was created with. Proving is always anchored,
+    // so this proves with the fixed proving key and checks the proof verifies under the fixed
+    // verifying key but not under the legacy one. (The reverse direction — a genuine pre-NU6.2
+    // proof rejected by the fixed key — is covered by `insecure_against_stored_circuit`.)
+    #[test]
+    fn proof_is_bound_to_fixed_verifying_key() {
         let mut rng = OsRng;
-        let (circuit, instance) = generate_circuit_instance(&mut rng, proving_version);
+        let (circuit, instance) = generate_circuit_instance(&mut rng);
         let instances = core::slice::from_ref(&instance);
-        let pk = ProvingKey::build_for_version::<OrchardVanilla>(proving_version);
+        let pk = ProvingKey::build::<OrchardVanilla>();
         let proof = Proof::create(&pk, &[circuit], instances, &mut rng).unwrap();
-        // Verifies under the matching version's verifying key.
-        let vk_matching = VerifyingKey::build_for_version::<OrchardVanilla>(proving_version);
-        assert!(proof.verify(&vk_matching, instances).is_ok());
-        // Does not verify under the other version's verifying key.
-        let vk_other = VerifyingKey::build_for_version::<OrchardVanilla>(other_version);
-        assert!(proof.verify(&vk_other, instances).is_err());
-    }
-
-    #[test]
-    fn proof_verifies_against_matching_circuit_version() {
-        // Each prover's proof verifies under its own verifying key, and is rejected by the
-        // other version's verifying key.
-        proof_is_bound_to_circuit_version(
-            OrchardCircuitVersion::FixedPostNu6_2,
-            OrchardCircuitVersion::InsecurePreNu6_2,
-        );
-        proof_is_bound_to_circuit_version(
-            OrchardCircuitVersion::InsecurePreNu6_2,
-            OrchardCircuitVersion::FixedPostNu6_2,
-        );
-    }
-    // Proving a circuit with a proving key for a different circuit version is a misuse: the
-    // proving key and circuits must agree (see `Proof::create`). Confirm `create` rejects it
-    // with `plonk::Error::Synthesis` rather than emitting an unverifiable proof.
-    #[test]
-    fn create_rejects_mismatched_proving_key_version() {
-        let mut rng = OsRng;
-        // Circuits for the insecure version, but proved with the fixed proving key.
-        let (circuit, instance) =
-            generate_circuit_instance(&mut rng, OrchardCircuitVersion::InsecurePreNu6_2);
-        let instances = core::slice::from_ref(&instance);
-        let mismatched_pk =
-            ProvingKey::build_for_version::<OrchardVanilla>(OrchardCircuitVersion::FixedPostNu6_2);
-        assert!(matches!(
-            Proof::create(&mismatched_pk, &[circuit], instances, &mut rng),
-            Err(super::plonk::Error::Synthesis),
-        ));
+        // Verifies under the fixed verifying key.
+        let vk_fixed = VerifyingKey::build::<OrchardVanilla>();
+        assert!(proof.verify(&vk_fixed, instances).is_ok());
+        // Does not verify under the legacy (unanchored) verifying key.
+        let vk_legacy = VerifyingKey::build_legacy_vanilla();
+        assert!(proof.verify(&vk_legacy, instances).is_err());
     }
 
     #[test]
@@ -895,8 +857,7 @@ mod tests {
             let create_proof = || -> std::io::Result<()> {
                 let mut rng = OsRng;
 
-                let (circuit, instance) =
-                    generate_circuit_instance(OsRng, OrchardCircuitVersion::FixedPostNu6_2);
+                let (circuit, instance) = generate_circuit_instance(OsRng);
                 let instances = core::slice::from_ref(&instance);
 
                 let pk = ProvingKey::build::<OrchardVanilla>();
@@ -925,16 +886,16 @@ mod tests {
         assert!(proof.verify(&vk, &[instance]).is_ok());
     }
 
-    // The deployed (NU5..NU6.2) verifying key and a pre-fix proof. `InsecurePreNu6_2`
+    // The deployed (NU5..NU6.2) verifying key and a pre-fix proof. `build_legacy_vanilla`
     // reconstructs the historical circuit, so this checks that the deployed verifying key is
     // reproduced exactly and that the old proof still verifies under it — the guarantee that
-    // lets a node sync from before the fix. These fixtures are frozen as the canonical
-    // pre-NU6.2 verifying key and a sample proof, so they are never regenerated.
+    // lets a node sync from before the fix. It also confirms the historical proof is rejected
+    // by the fixed verifying key, the reverse direction of the version binding. These fixtures
+    // are frozen as the canonical pre-NU6.2 verifying key and a sample proof, so they are never
+    // regenerated.
     #[test]
     fn insecure_against_stored_circuit() {
-        let vk = VerifyingKey::build_for_version::<OrchardVanilla>(
-            OrchardCircuitVersion::InsecurePreNu6_2,
-        );
+        let vk = VerifyingKey::build_legacy_vanilla();
         assert_eq!(
             format!("{:#?}\n", vk.vk.pinned()),
             include_str!("../circuit_data/circuit_description_insecure_vanilla")
@@ -947,7 +908,12 @@ mod tests {
             read_test_case(&test_case_bytes[..]).expect("proof must be valid")
         };
         assert_eq!(proof.0.len(), 4992);
-        assert!(proof.verify(&vk, &[instance]).is_ok());
+        let instances = core::slice::from_ref(&instance);
+        // Verifies under the legacy (unanchored) verifying key it was created with.
+        assert!(proof.verify(&vk, instances).is_ok());
+        // Is rejected by the fixed (anchored) verifying key.
+        let vk_fixed = VerifyingKey::build::<OrchardVanilla>();
+        assert!(proof.verify(&vk_fixed, instances).is_err());
     }
 
     #[cfg(feature = "dev-graph")]
@@ -962,10 +928,7 @@ mod tests {
             .unwrap();
 
         let circuit = Circuit::<OrchardVanilla> {
-            witnesses: Witnesses {
-                circuit_version: OrchardCircuitVersion::FixedPostNu6_2,
-                ..Default::default()
-            },
+            witnesses: Witnesses::default(),
             phantom: core::marker::PhantomData,
         };
         halo2_proofs::dev::CircuitLayout::default()

--- a/src/circuit/circuit_zsa.rs
+++ b/src/circuit/circuit_zsa.rs
@@ -9,9 +9,7 @@ use group::Curve;
 use pasta_curves::{arithmetic::CurveAffine, pallas};
 
 use halo2_gadgets::{
-    ecc::{
-        chip::EccChip, CircuitVersion, FixedPoint, NonIdentityPoint, Point, ScalarFixed, ScalarVar,
-    },
+    ecc::{chip::EccChip, FixedPoint, NonIdentityPoint, Point, ScalarFixed, ScalarVar},
     poseidon::{primitives as poseidon, Pow5Chip as PoseidonChip},
     sinsemilla::{
         chip::SinsemillaChip,
@@ -331,10 +329,6 @@ impl OrchardCircuit for OrchardZSA {
         config: Self::Config,
         mut layouter: impl Layouter<pallas::Base>,
     ) -> Result<(), plonk::Error> {
-        if circuit.circuit_version.halo2_version() == CircuitVersion::InsecureUnanchoredBase {
-            return Err(plonk::Error::Synthesis);
-        }
-
         // Load the Sinsemilla generator lookup table used by the whole circuit.
         SinsemillaChip::load(config.sinsemilla_config_1.clone(), &mut layouter)?;
 
@@ -343,7 +337,7 @@ impl OrchardCircuit for OrchardZSA {
             unpack(circuit.additional_zsa_witnesses.clone());
 
         // Construct the ECC chip.
-        let ecc_chip = config.ecc_chip(circuit.circuit_version.halo2_version());
+        let ecc_chip = config.ecc_chip(circuit.ecc_base.halo2_version());
 
         // Witness private inputs that are used across multiple checks.
         let (psi_nf, psi_old, rho_old, cm_old, g_d_old, ak_P, nk, v_old, v_new, asset) = {
@@ -638,7 +632,7 @@ impl OrchardCircuit for OrchardZSA {
                     "g★_d || pk★_d || i2lebsp_{64}(v) || i2lebsp_{255}(rho) || i2lebsp_{255}(psi)"
                 }),
                 config.sinsemilla_chip_1(),
-                config.ecc_chip(circuit.circuit_version.halo2_version()),
+                config.ecc_chip(circuit.ecc_base.halo2_version()),
                 config.note_commit_chip_old(),
                 g_d_old.inner(),
                 pk_d_old.inner(),
@@ -706,7 +700,7 @@ impl OrchardCircuit for OrchardZSA {
                     "g★_d || pk★_d || i2lebsp_{64}(v) || i2lebsp_{255}(rho) || i2lebsp_{255}(psi)"
                 }),
                 config.sinsemilla_chip_2(),
-                config.ecc_chip(circuit.circuit_version.halo2_version()),
+                config.ecc_chip(circuit.ecc_base.halo2_version()),
                 config.note_commit_chip_new(),
                 g_d_new.inner(),
                 pk_d_new.inner(),
@@ -886,8 +880,8 @@ mod tests {
         builder::SpendInfo,
         bundle::Flags,
         circuit::{
-            AdditionalZsaWitnesses, Circuit, Instance, OrchardCircuitVersion, Proof, ProvingKey,
-            VerifyingKey, Witnesses, K,
+            AdditionalZsaWitnesses, Circuit, EccBase, Instance, Proof, ProvingKey, VerifyingKey,
+            Witnesses, K,
         },
         flavor::OrchardZSA,
         keys::{FullViewingKey, Scope, SpendValidatingKey, SpendingKey},
@@ -924,7 +918,7 @@ mod tests {
         (
             Circuit {
                 witnesses: Witnesses {
-                    circuit_version: OrchardCircuitVersion::FixedPostNu6_2,
+                    ecc_base: EccBase::Anchored,
                     path: Value::known(path.auth_path()),
                     pos: Value::known(path.position()),
                     g_d_old: Value::known(sender_address.g_d()),
@@ -1096,7 +1090,7 @@ mod tests {
                 let mut rng = OsRng;
 
                 let (circuit, instance) = generate_dummy_circuit_instance(OsRng);
-                let instances = &[instance.clone()];
+                let instances = core::slice::from_ref(&instance);
 
                 let pk = ProvingKey::build::<OrchardZSA>();
                 let proof = Proof::create(&pk, &[circuit], instances, &mut rng).unwrap();
@@ -1134,10 +1128,7 @@ mod tests {
             .unwrap();
 
         let circuit = Circuit::<OrchardZSA> {
-            witnesses: Witnesses {
-                circuit_version: OrchardCircuitVersion::FixedPostNu6_2,
-                ..Default::default()
-            },
+            witnesses: Witnesses::default(),
             phantom: core::marker::PhantomData,
         };
         halo2_proofs::dev::CircuitLayout::default()
@@ -1173,7 +1164,6 @@ mod tests {
     fn generate_circuit_instance<R: CryptoRngCore>(
         is_zatoshi_asset: bool,
         split_flag: bool,
-        orchard_circuit_version: OrchardCircuitVersion,
         mut rng: R,
     ) -> (Circuit<OrchardZSA>, Instance) {
         // We cannot create a split note with a zatoshi asset.
@@ -1264,7 +1254,6 @@ mod tests {
                     output_note,
                     alpha,
                     rcv,
-                    orchard_circuit_version,
                 ),
                 phantom: core::marker::PhantomData,
             },
@@ -1299,12 +1288,8 @@ mod tests {
         let mut rng = OsRng;
 
         for (is_zatoshi_asset, split_flag) in [(true, false), (false, true), (false, false)] {
-            let (circuit, instance) = generate_circuit_instance(
-                is_zatoshi_asset,
-                split_flag,
-                OrchardCircuitVersion::FixedPostNu6_2,
-                &mut rng,
-            );
+            let (circuit, instance) =
+                generate_circuit_instance(is_zatoshi_asset, split_flag, &mut rng);
 
             let should_pass = !(matches!((is_zatoshi_asset, split_flag), (true, true)));
 
@@ -1342,7 +1327,7 @@ mod tests {
             // The proof should fail
             let circuit_wrong_cm_old = Circuit {
                 witnesses: Witnesses {
-                    circuit_version: circuit.witnesses.circuit_version,
+                    ecc_base: circuit.witnesses.ecc_base,
                     path: circuit.witnesses.path,
                     pos: circuit.witnesses.pos,
                     g_d_old: circuit.witnesses.g_d_old,
@@ -1402,7 +1387,7 @@ mod tests {
             if !split_flag {
                 let circuit_wrong_psi_nf = Circuit {
                     witnesses: Witnesses {
-                        circuit_version: circuit.witnesses.circuit_version,
+                        ecc_base: circuit.witnesses.ecc_base,
                         path: circuit.witnesses.path,
                         pos: circuit.witnesses.pos,
                         g_d_old: circuit.witnesses.g_d_old,
@@ -1453,18 +1438,5 @@ mod tests {
                 check_proof_of_orchard_circuit(&circuit, &instance_wrong_enable_zsa, false);
             }
         }
-    }
-
-    #[test]
-    fn cannot_create_insecure_zsa_proof() {
-        let mut rng = OsRng;
-        let (circuit, instance) = generate_circuit_instance(
-            true,
-            false,
-            OrchardCircuitVersion::InsecurePreNu6_2,
-            &mut rng,
-        );
-        let pk = ProvingKey::build::<OrchardZSA>();
-        assert!(Proof::create(&pk, &[circuit], &[instance], &mut rng).is_err());
     }
 }

--- a/tests/builder.rs
+++ b/tests/builder.rs
@@ -4,7 +4,7 @@ use incrementalmerkletree::{Hashable, Marking, Retention};
 use orchard::{
     builder::{Builder, BundleType},
     bundle::{Authorized, Flags},
-    circuit::{OrchardCircuitVersion, ProvingKey, VerifyingKey},
+    circuit::{ProvingKey, VerifyingKey},
     flavor::{OrchardFlavor, OrchardVanilla, OrchardZSA},
     keys::{FullViewingKey, PreparedIncomingViewingKey, Scope, SpendAuthorizingKey, SpendingKey},
     note::{AssetBase, ExtractedNoteCommitment},
@@ -14,7 +14,6 @@ use orchard::{
     value::NoteValue,
     Anchor, Bundle, Note,
 };
-use rand::rngs::OsRng;
 use rand::rngs::StdRng;
 use rand::SeedableRng;
 use shardtree::{store::memory::MemoryShardStore, ShardTree};
@@ -247,52 +246,4 @@ fn bundle_chain_zsa() {
             123, 94, 240, 183, 227, 9, 245, 74, 51, 16, 12, 157, 60
         ]
     );
-}
-
-// A bundle built with the circuit version set to `InsecurePreNu6_2` produces a proof against
-// the historical (insecure) circuit, which verifies under the insecure verifying key but not
-// the fixed one. This is the path that lets tests reproduce pre-NU6.2 proofs.
-#[test]
-fn builder_builds_for_insecure_circuit_version() {
-    let mut rng = OsRng;
-    let insecure_pk =
-        ProvingKey::build_for_version::<OrchardVanilla>(OrchardCircuitVersion::InsecurePreNu6_2);
-    let insecure_vk =
-        VerifyingKey::build_for_version::<OrchardVanilla>(OrchardCircuitVersion::InsecurePreNu6_2);
-    let fixed_vk = VerifyingKey::build::<OrchardVanilla>();
-
-    let sk = SpendingKey::from_bytes([0; 32]).unwrap();
-    let fvk = FullViewingKey::from(&sk);
-    let recipient = fvk.address_at(0u32, Scope::External);
-
-    let anchor = MerkleHashOrchard::empty_root(32.into()).into();
-    let mut builder = Builder::new_for_version(
-        BundleType::Transactional {
-            flags: Flags::SPENDS_DISABLED,
-            bundle_required: false,
-        },
-        anchor,
-        OrchardCircuitVersion::InsecurePreNu6_2,
-    );
-    assert_eq!(
-        builder.add_output(
-            None,
-            recipient,
-            NoteValue::from_raw(5000),
-            AssetBase::zatoshi(),
-            [0u8; 512]
-        ),
-        Ok(())
-    );
-
-    let (unauthorized, _) = builder
-        .build::<i64, OrchardVanilla>(&mut rng)
-        .unwrap()
-        .unwrap();
-    let sighash: [u8; 32] = unauthorized.commitment().into();
-    let proven = unauthorized.create_proof(&insecure_pk, &mut rng).unwrap();
-    let bundle = proven.apply_signatures(rng, sighash, &[]).unwrap();
-
-    assert!(matches!(bundle.verify_proof(&insecure_vk), Ok(())));
-    assert!(bundle.verify_proof(&fixed_vk).is_err());
 }


### PR DESCRIPTION
Fold ZSA into OrchardCircuitVersion (add `Zsa`) so one runtime enum selects the circuit, dispatched to the compile-time flavor type at the key-building boundary (`build_for_kind`); the flavor type still carries downstream. Replace the `circuit_version` axis on `Witnesses` with a 2-value `EccBase`, settable to `Unanchored` only via `VerifyingKey::build_legacy_vanilla()`, so proving is always anchored and "ZSA on the unanchored base" is unrepresentable (drops the runtime guard). Remove the now-redundant `*_for_version` entry points, the `Proof::create` version check, and the stored-version accessors.