### PR TITLE
Some renamings in circuit files

### DIFF
--- a/src/bundle/commitments.rs
+++ b/src/bundle/commitments.rs
@@ -279,7 +279,7 @@ fn hash_bundle_txid_data_zsa<A: Authorization, V: Copy + Into<i64>>(
     agh.update(nh.finalize().as_bytes());
 
     agh.update(&[bundle.flag_byte()]);
-    // For the OrchardZSA protocol, `expiry_height` is set to 0, indicating no expiry.
+    // For the ZSA protocol, `expiry_height` is set to 0, indicating no expiry.
     agh.update(&0u32.to_le_bytes());
 
     let mut burn_hasher = hasher(zsa_personalizations.ironwood_burn);
@@ -546,7 +546,7 @@ mod tests {
 
     // TODO Constance: add test for (Orchard, V3) and (Ironwood, V3)
 
-    /// Verifies that the hash for an OrchardZSA bundle matches a fixed reference value.
+    /// Verifies that the hash for a ZSA bundle matches a fixed reference value.
     ///
     /// This is a regression test: inputs are fully deterministic (seeded RNG and fixed
     /// bundle contents), so the resulting digest must remain stable. The reference value
@@ -597,7 +597,7 @@ mod tests {
 
     // TODO Constance: add test for (Orchard, V3) and (Ironwood, V3)
 
-    /// Verifies that the authorizing data commitment for an OrchardZSA bundle matches a fixed
+    /// Verifies that the authorizing data commitment for an ZSA bundle matches a fixed
     /// reference value.
     ///
     /// This is a regression test: inputs are fully deterministic (seeded RNG and fixed
@@ -605,7 +605,7 @@ mod tests {
     /// was (re)generated after intentional changes that affect the digest, and
     /// is now treated as the expected output for this implementation.
     #[test]
-    fn test_hash_bundle_auth_data_for_orchard_zsa() {
+    fn test_hash_bundle_auth_data_for_zsa() {
         let bundle = generate_auth_bundle(BundleVersion::zsa(), TxVersion::ZSA);
         let orchard_auth_digest =
             hash_bundle_auth_data(&bundle, TxVersion::ZSA, test_sighash_info_for_kind).unwrap();

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -40,7 +40,7 @@ use halo2_gadgets::{
 mod circuit_vanilla;
 mod circuit_zsa;
 
-use circuit_vanilla::CircuitVanilla;
+use circuit_vanilla::CircuitNative;
 use circuit_zsa::CircuitZsa;
 
 #[cfg(not(feature = "unstable-voting-circuits"))]
@@ -171,7 +171,7 @@ impl OrchardCircuitVersion {
 pub enum Circuit {
     /// The Vanilla Orchard Action circuit.
     /// It is used with all [`OrchardCircuitVersion`] except [`OrchardCircuitVersion::ZSA`].
-    OrchardVanilla(CircuitVanilla),
+    OrchardVanilla(CircuitNative),
     /// The ZSA Orchard Action circuit.
     /// It is used only with [`OrchardCircuitVersion::ZSA`].
     OrchardZSA(CircuitZsa),
@@ -215,7 +215,7 @@ impl Circuit {
             OrchardCircuitVersion::InsecurePreNu6_2
             | OrchardCircuitVersion::FixedPostNu6_2
             | OrchardCircuitVersion::PostNu6_3 => {
-                Circuit::OrchardVanilla(CircuitVanilla::empty(circuit_version))
+                Circuit::OrchardVanilla(CircuitNative::empty(circuit_version))
             }
         }
     }
@@ -267,7 +267,7 @@ impl Circuit {
             OrchardCircuitVersion::InsecurePreNu6_2
             | OrchardCircuitVersion::FixedPostNu6_2
             | OrchardCircuitVersion::PostNu6_3 => {
-                Circuit::OrchardVanilla(CircuitVanilla::from_action_context_unchecked(
+                Circuit::OrchardVanilla(CircuitNative::from_action_context_unchecked(
                     spend,
                     output_note,
                     alpha,
@@ -278,8 +278,8 @@ impl Circuit {
         }
     }
 
-    /// Returns the inner [`CircuitVanilla`], or `None` if this is a `Circuit::OrchardZSA`.
-    fn as_vanilla(&self) -> Option<&CircuitVanilla> {
+    /// Returns the inner [`CircuitNative`], or `None` if this is a `Circuit::OrchardZSA`.
+    fn as_vanilla(&self) -> Option<&CircuitNative> {
         match self {
             Circuit::OrchardVanilla(circuit) => Some(circuit),
             Circuit::OrchardZSA(_) => None,

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -174,7 +174,7 @@ pub enum Circuit {
     OrchardVanilla(CircuitNative),
     /// The ZSA Orchard Action circuit.
     /// It is used only with [`OrchardCircuitVersion::ZSA`].
-    OrchardZSA(CircuitZsa),
+    ZSA(CircuitZsa),
 }
 
 impl Circuit {
@@ -184,7 +184,7 @@ impl Circuit {
     ///
     /// Returns [`plonk::Error::Synthesis`] if the variant and its inner circuit version are
     /// inconsistent: a `Circuit::OrchardVanilla` carrying [`OrchardCircuitVersion::ZSA`], or a
-    /// `Circuit::OrchardZSA` not carrying it.
+    /// `Circuit::ZSA` not carrying it.
     fn circuit_version(&self) -> Result<OrchardCircuitVersion, plonk::Error> {
         match self {
             Circuit::OrchardVanilla(circuit) => {
@@ -193,7 +193,7 @@ impl Circuit {
                 }
                 Ok(circuit.circuit_version)
             }
-            Circuit::OrchardZSA(circuit) => {
+            Circuit::ZSA(circuit) => {
                 if circuit.common_witnesses.circuit_version != OrchardCircuitVersion::ZSA {
                     return Err(plonk::Error::Synthesis);
                 }
@@ -211,7 +211,7 @@ impl Circuit {
     /// selected circuit version still determines the configured constraints.
     fn empty(circuit_version: OrchardCircuitVersion) -> Self {
         match circuit_version {
-            OrchardCircuitVersion::ZSA => Circuit::OrchardZSA(CircuitZsa::empty()),
+            OrchardCircuitVersion::ZSA => Circuit::ZSA(CircuitZsa::empty()),
             OrchardCircuitVersion::InsecurePreNu6_2
             | OrchardCircuitVersion::FixedPostNu6_2
             | OrchardCircuitVersion::PostNu6_3 => {
@@ -256,7 +256,7 @@ impl Circuit {
     ) -> Self {
         match circuit_version {
             OrchardCircuitVersion::ZSA => {
-                Circuit::OrchardZSA(CircuitZsa::from_action_context_unchecked(
+                Circuit::ZSA(CircuitZsa::from_action_context_unchecked(
                     spend,
                     output_note,
                     alpha,
@@ -278,18 +278,18 @@ impl Circuit {
         }
     }
 
-    /// Returns the inner [`CircuitNative`], or `None` if this is a `Circuit::OrchardZSA`.
+    /// Returns the inner [`CircuitNative`], or `None` if this is a `Circuit::ZSA`.
     fn as_vanilla(&self) -> Option<&CircuitNative> {
         match self {
             Circuit::OrchardVanilla(circuit) => Some(circuit),
-            Circuit::OrchardZSA(_) => None,
+            Circuit::ZSA(_) => None,
         }
     }
 
     /// Returns the inner [`CircuitZsa`], or `None` if this is a `Circuit::OrchardVanilla`.
     fn as_zsa(&self) -> Option<&CircuitZsa> {
         match self {
-            Circuit::OrchardZSA(circuit) => Some(circuit),
+            Circuit::ZSA(circuit) => Some(circuit),
             Circuit::OrchardVanilla(_) => None,
         }
     }
@@ -323,7 +323,7 @@ impl VerifyingKey {
         let params = halo2_proofs::poly::commitment::Params::new(K);
         let vk = match Circuit::empty(circuit_version) {
             Circuit::OrchardVanilla(circuit) => plonk::keygen_vk(&params, &circuit).unwrap(),
-            Circuit::OrchardZSA(circuit) => plonk::keygen_vk(&params, &circuit).unwrap(),
+            Circuit::ZSA(circuit) => plonk::keygen_vk(&params, &circuit).unwrap(),
         };
 
         VerifyingKey {
@@ -366,7 +366,7 @@ impl ProvingKey {
                 let vk = plonk::keygen_vk(&params, &circuit).unwrap();
                 plonk::keygen_pk(&params, vk, &circuit).unwrap()
             }
-            Circuit::OrchardZSA(circuit) => {
+            Circuit::ZSA(circuit) => {
                 let vk = plonk::keygen_vk(&params, &circuit).unwrap();
                 plonk::keygen_pk(&params, vk, &circuit).unwrap()
             }

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -171,7 +171,7 @@ impl OrchardCircuitVersion {
 pub enum Circuit {
     /// The Vanilla Orchard Action circuit.
     /// It is used with all [`OrchardCircuitVersion`] except [`OrchardCircuitVersion::ZSA`].
-    OrchardVanilla(CircuitNative),
+    Native(CircuitNative),
     /// The ZSA Orchard Action circuit.
     /// It is used only with [`OrchardCircuitVersion::ZSA`].
     ZSA(CircuitZsa),
@@ -183,11 +183,11 @@ impl Circuit {
     /// # Errors
     ///
     /// Returns [`plonk::Error::Synthesis`] if the variant and its inner circuit version are
-    /// inconsistent: a `Circuit::OrchardVanilla` carrying [`OrchardCircuitVersion::ZSA`], or a
+    /// inconsistent: a `Circuit::Native` carrying [`OrchardCircuitVersion::ZSA`], or a
     /// `Circuit::ZSA` not carrying it.
     fn circuit_version(&self) -> Result<OrchardCircuitVersion, plonk::Error> {
         match self {
-            Circuit::OrchardVanilla(circuit) => {
+            Circuit::Native(circuit) => {
                 if circuit.circuit_version == OrchardCircuitVersion::ZSA {
                     return Err(plonk::Error::Synthesis);
                 }
@@ -215,7 +215,7 @@ impl Circuit {
             OrchardCircuitVersion::InsecurePreNu6_2
             | OrchardCircuitVersion::FixedPostNu6_2
             | OrchardCircuitVersion::PostNu6_3 => {
-                Circuit::OrchardVanilla(CircuitNative::empty(circuit_version))
+                Circuit::Native(CircuitNative::empty(circuit_version))
             }
         }
     }
@@ -267,7 +267,7 @@ impl Circuit {
             OrchardCircuitVersion::InsecurePreNu6_2
             | OrchardCircuitVersion::FixedPostNu6_2
             | OrchardCircuitVersion::PostNu6_3 => {
-                Circuit::OrchardVanilla(CircuitNative::from_action_context_unchecked(
+                Circuit::Native(CircuitNative::from_action_context_unchecked(
                     spend,
                     output_note,
                     alpha,
@@ -281,16 +281,16 @@ impl Circuit {
     /// Returns the inner [`CircuitNative`], or `None` if this is a `Circuit::ZSA`.
     fn as_vanilla(&self) -> Option<&CircuitNative> {
         match self {
-            Circuit::OrchardVanilla(circuit) => Some(circuit),
+            Circuit::Native(circuit) => Some(circuit),
             Circuit::ZSA(_) => None,
         }
     }
 
-    /// Returns the inner [`CircuitZsa`], or `None` if this is a `Circuit::OrchardVanilla`.
+    /// Returns the inner [`CircuitZsa`], or `None` if this is a `Circuit::Native`.
     fn as_zsa(&self) -> Option<&CircuitZsa> {
         match self {
             Circuit::ZSA(circuit) => Some(circuit),
-            Circuit::OrchardVanilla(_) => None,
+            Circuit::Native(_) => None,
         }
     }
 }
@@ -322,7 +322,7 @@ impl VerifyingKey {
     pub fn build(circuit_version: OrchardCircuitVersion) -> Self {
         let params = halo2_proofs::poly::commitment::Params::new(K);
         let vk = match Circuit::empty(circuit_version) {
-            Circuit::OrchardVanilla(circuit) => plonk::keygen_vk(&params, &circuit).unwrap(),
+            Circuit::Native(circuit) => plonk::keygen_vk(&params, &circuit).unwrap(),
             Circuit::ZSA(circuit) => plonk::keygen_vk(&params, &circuit).unwrap(),
         };
 
@@ -362,7 +362,7 @@ impl ProvingKey {
     pub fn build(circuit_version: OrchardCircuitVersion) -> Self {
         let params = halo2_proofs::poly::commitment::Params::new(K);
         let pk = match Circuit::empty(circuit_version) {
-            Circuit::OrchardVanilla(circuit) => {
+            Circuit::Native(circuit) => {
                 let vk = plonk::keygen_vk(&params, &circuit).unwrap();
                 plonk::keygen_pk(&params, vk, &circuit).unwrap()
             }

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -271,7 +271,7 @@ impl Circuit {
     }
 
     /// Returns the inner [`CircuitNative`], or `None` if this is a `Circuit::ZSA`.
-    fn as_vanilla(&self) -> Option<&CircuitNative> {
+    fn as_native(&self) -> Option<&CircuitNative> {
         match self {
             Circuit::Native(circuit) => Some(circuit),
             Circuit::ZSA(_) => None,
@@ -591,7 +591,7 @@ impl Proof {
         } else {
             let circuits: Vec<_> = circuits
                 .iter()
-                .map(|c| c.as_vanilla().expect("checked above").clone())
+                .map(|c| c.as_native().expect("checked above").clone())
                 .collect();
             plonk::create_proof(
                 &pk.params,

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -188,13 +188,13 @@ impl Circuit {
     fn circuit_version(&self) -> Result<OrchardCircuitVersion, plonk::Error> {
         match self {
             Circuit::Native(circuit) => {
-                if circuit.circuit_version == OrchardCircuitVersion::ZSA {
+                if circuit.circuit_version.is_zsa() {
                     return Err(plonk::Error::Synthesis);
                 }
                 Ok(circuit.circuit_version)
             }
             Circuit::ZSA(circuit) => {
-                if circuit.common_witnesses.circuit_version != OrchardCircuitVersion::ZSA {
+                if !circuit.common_witnesses.circuit_version.is_zsa() {
                     return Err(plonk::Error::Synthesis);
                 }
                 Ok(circuit.common_witnesses.circuit_version)
@@ -210,13 +210,10 @@ impl Circuit {
     /// or rendering the circuit layout, where witness values are not required but the
     /// selected circuit version still determines the configured constraints.
     fn empty(circuit_version: OrchardCircuitVersion) -> Self {
-        match circuit_version {
-            OrchardCircuitVersion::ZSA => Circuit::ZSA(CircuitZsa::empty()),
-            OrchardCircuitVersion::InsecurePreNu6_2
-            | OrchardCircuitVersion::FixedPostNu6_2
-            | OrchardCircuitVersion::PostNu6_3 => {
-                Circuit::Native(CircuitNative::empty(circuit_version))
-            }
+        if circuit_version.is_zsa() {
+            Circuit::ZSA(CircuitZsa::empty())
+        } else {
+            Circuit::Native(CircuitNative::empty(circuit_version))
         }
     }
 
@@ -254,27 +251,22 @@ impl Circuit {
         rcv: ValueCommitTrapdoor,
         circuit_version: OrchardCircuitVersion,
     ) -> Self {
-        match circuit_version {
-            OrchardCircuitVersion::ZSA => {
-                Circuit::ZSA(CircuitZsa::from_action_context_unchecked(
-                    spend,
-                    output_note,
-                    alpha,
-                    rcv,
-                    circuit_version,
-                ))
-            }
-            OrchardCircuitVersion::InsecurePreNu6_2
-            | OrchardCircuitVersion::FixedPostNu6_2
-            | OrchardCircuitVersion::PostNu6_3 => {
-                Circuit::Native(CircuitNative::from_action_context_unchecked(
-                    spend,
-                    output_note,
-                    alpha,
-                    rcv,
-                    circuit_version,
-                ))
-            }
+        if circuit_version.is_zsa() {
+            Circuit::ZSA(CircuitZsa::from_action_context_unchecked(
+                spend,
+                output_note,
+                alpha,
+                rcv,
+                circuit_version,
+            ))
+        } else {
+            Circuit::Native(CircuitNative::from_action_context_unchecked(
+                spend,
+                output_note,
+                alpha,
+                rcv,
+                circuit_version,
+            ))
         }
     }
 

--- a/src/circuit/circuit_vanilla.rs
+++ b/src/circuit/circuit_vanilla.rs
@@ -1205,7 +1205,7 @@ mod tests {
         let mock_verify = |circuit: &Circuit, instance: &Instance| {
             MockProver::run(
                 K,
-                circuit.as_vanilla().unwrap(),
+                circuit.as_native().unwrap(),
                 instance
                     .to_halo2_instance()
                     .iter()
@@ -1276,7 +1276,7 @@ mod tests {
         super::plonk::create_proof(
             &pk.params,
             &pk.pk,
-            core::slice::from_ref(circuit.as_vanilla().unwrap()),
+            core::slice::from_ref(circuit.as_native().unwrap()),
             &raw_instances,
             &mut rng,
             &mut transcript,
@@ -1347,7 +1347,7 @@ mod tests {
             let circuit_cost =
                 halo2_proofs::dev::CircuitCost::<pasta_curves::vesta::Point, _>::measure(
                     K,
-                    circuits[0].as_vanilla().unwrap(),
+                    circuits[0].as_native().unwrap(),
                 );
             // These sizes are identical for every circuit version: the post-NU 6.3 circuit reuses the
             // existing Orchard checks gate on spare rows and adds no columns or
@@ -1375,7 +1375,7 @@ mod tests {
             assert_eq!(
                 MockProver::run(
                     K,
-                    circuit.as_vanilla().unwrap(),
+                    circuit.as_native().unwrap(),
                     instance
                         .to_halo2_instance()
                         .iter()

--- a/src/circuit/circuit_vanilla.rs
+++ b/src/circuit/circuit_vanilla.rs
@@ -53,7 +53,7 @@ use crate::{
 ///
 /// This structure is embedded in `CircuitZsa` for the ZSA variation.
 #[derive(Clone, Debug)]
-pub struct CircuitVanilla {
+pub struct CircuitNative {
     pub(crate) path: Value<[MerkleHashOrchard; MERKLE_DEPTH_ORCHARD]>,
     pub(crate) pos: Value<u32>,
     pub(crate) g_d_old: Value<NonIdentityPallasPoint>,
@@ -77,14 +77,14 @@ pub struct CircuitVanilla {
     pub(crate) circuit_version: OrchardCircuitVersion,
 }
 
-impl CircuitVanilla {
+impl CircuitNative {
     /// Returns an empty circuit with all private witnesses unknown.
     ///
     /// This is used for circuit shape-dependent operations, such as generating keys
     /// or rendering the circuit layout, where witness values are not required but the
     /// selected circuit version still determines the configured constraints.
     pub(crate) fn empty(circuit_version: OrchardCircuitVersion) -> Self {
-        CircuitVanilla {
+        CircuitNative {
             path: Value::unknown(),
             pos: Value::unknown(),
             g_d_old: Value::unknown(),
@@ -108,7 +108,7 @@ impl CircuitVanilla {
         }
     }
 
-    /// Constructs a `CircuitVanilla` for the given `circuit_version` from the following components:
+    /// Constructs a `CircuitNative` for the given `circuit_version` from the following components:
     /// - `spend`: [`SpendInfo`] of the note spent in scope of the action
     /// - `output_note`: a note created in scope of the action
     /// - `alpha`: a scalar used for randomization of the action spend validating key
@@ -140,7 +140,7 @@ impl CircuitVanilla {
         let psi_nf = nf_rseed.psi(&rho_old);
 
         (
-            CircuitVanilla {
+            CircuitNative {
                 path: Value::known(spend.merkle_path.auth_path()),
                 pos: Value::known(spend.merkle_path.position()),
                 g_d_old: Value::known(sender_address.g_d()),
@@ -166,7 +166,7 @@ impl CircuitVanilla {
         )
     }
 
-    /// Constructs a `CircuitVanilla` for the given `circuit_version` from the following
+    /// Constructs a `CircuitNative` for the given `circuit_version` from the following
     /// components:
     /// - `spend`: [`SpendInfo`] of the note spent in scope of the action
     /// - `output_note`: a note created in scope of the action
@@ -202,12 +202,12 @@ impl CircuitVanilla {
     }
 }
 
-impl plonk::Circuit<pallas::Base> for CircuitVanilla {
+impl plonk::Circuit<pallas::Base> for CircuitNative {
     type Config = Config<PallasLookupRangeCheckConfig>;
     type FloorPlanner = floor_planner::V1;
 
     fn without_witnesses(&self) -> Self {
-        CircuitVanilla::empty(self.circuit_version)
+        CircuitNative::empty(self.circuit_version)
     }
 
     fn configure(meta: &mut plonk::ConstraintSystem<pallas::Base>) -> Self::Config {
@@ -415,14 +415,14 @@ impl plonk::Circuit<pallas::Base> for CircuitVanilla {
         let addrs = self.synthesize_base(&config, &mut layouter)?;
 
         if self.circuit_version.supports_cross_address_restriction() {
-            CircuitVanilla::synthesize_cross_address_checks(&config, &mut layouter, &addrs)?;
+            CircuitNative::synthesize_cross_address_checks(&config, &mut layouter, &addrs)?;
         }
 
         Ok(())
     }
 }
 
-impl CircuitVanilla {
+impl CircuitNative {
     /// Synthesizes the Orchard Action checks common to every circuit version,
     /// parameterized by `self.circuit_version`, returning the cells carrying the old
     /// and new note addresses so that circuit versions can impose additional
@@ -971,7 +971,7 @@ mod tests {
     use crate::{
         bundle::{BundleVersion, Flags},
         circuit::{
-            Circuit, CircuitVanilla, Instance, OrchardCircuitVersion, Proof, ProvingKey,
+            Circuit, CircuitNative, Instance, OrchardCircuitVersion, Proof, ProvingKey,
             SingleVerifier, VerifyingKey, K,
         },
         keys::SpendValidatingKey,
@@ -1043,7 +1043,7 @@ mod tests {
         let anchor = path.root(spent_note.commitment().into());
 
         (
-            Circuit::OrchardVanilla(CircuitVanilla {
+            Circuit::OrchardVanilla(CircuitNative {
                 circuit_version,
                 path: Value::known(path.auth_path()),
                 pos: Value::known(path.position()),
@@ -1621,7 +1621,7 @@ mod tests {
             .titled("Orchard Action Circuit", ("sans-serif", 60))
             .unwrap();
 
-        let circuit = CircuitVanilla::empty(OrchardCircuitVersion::FixedPostNu6_2);
+        let circuit = CircuitNative::empty(OrchardCircuitVersion::FixedPostNu6_2);
         halo2_proofs::dev::CircuitLayout::default()
             .show_labels(false)
             .view_height(0..(1 << 11))

--- a/src/circuit/circuit_vanilla.rs
+++ b/src/circuit/circuit_vanilla.rs
@@ -1043,7 +1043,7 @@ mod tests {
         let anchor = path.root(spent_note.commitment().into());
 
         (
-            Circuit::OrchardVanilla(CircuitNative {
+            Circuit::Native(CircuitNative {
                 circuit_version,
                 path: Value::known(path.auth_path()),
                 pos: Value::known(path.position()),

--- a/src/circuit/circuit_zsa.rs
+++ b/src/circuit/circuit_zsa.rs
@@ -1303,7 +1303,7 @@ mod tests {
         let psi_old = spent_note.rseed().psi(&spent_note.rho());
 
         (
-            Circuit::OrchardZSA(CircuitZsa {
+            Circuit::ZSA(CircuitZsa {
                 common_witnesses: CircuitNative {
                     path: Value::known(path.auth_path()),
                     pos: Value::known(path.position()),
@@ -1769,7 +1769,7 @@ mod tests {
 
             // Set cm_old to be a random NoteCommitment
             // The proof should fail
-            let circuit_wrong_cm_old = Circuit::OrchardZSA(CircuitZsa {
+            let circuit_wrong_cm_old = Circuit::ZSA(CircuitZsa {
                 common_witnesses: CircuitNative {
                     cm_old: Value::known(random_note_commitment(&mut rng)),
                     ..circuit.as_zsa().unwrap().common_witnesses.clone()
@@ -1811,7 +1811,7 @@ mod tests {
             // If split_flag = 0 , set psi_nf to be a random Pallas base element
             // The proof should fail
             if !split_flag {
-                let circuit_wrong_psi_nf = Circuit::OrchardZSA(CircuitZsa {
+                let circuit_wrong_psi_nf = Circuit::ZSA(CircuitZsa {
                     additional_zsa_witnesses: circuit
                         .as_zsa()
                         .unwrap()

--- a/src/circuit/circuit_zsa.rs
+++ b/src/circuit/circuit_zsa.rs
@@ -64,7 +64,7 @@ fn unpack(
     )
 }
 
-/// The OrchardZSA Action circuit.
+/// The ZSA Action circuit.
 #[derive(Clone, Debug)]
 pub struct CircuitZsa {
     pub(crate) common_witnesses: CircuitNative,
@@ -102,7 +102,7 @@ impl CircuitZsa {
         circuit_version: OrchardCircuitVersion,
     ) -> Self {
         if !circuit_version.is_zsa() {
-            panic!("circuit version must be ZSA in OrchardZSA circuit");
+            panic!("circuit version must be ZSA in ZSA circuit");
         }
 
         let (common_witnesses, psi_nf) = CircuitNative::from_action_context_common(
@@ -147,10 +147,10 @@ impl plonk::Circuit<pallas::Base> for CircuitZsa {
             meta.advice_column(),
         ];
 
-        // The new or updated constraints for OrchardZSA are explained in
+        // The new or updated constraints for ZSA are explained in
         // [ZIP-226: Transfer and Burn of Zcash Shielded Assets][circuitstatement].
         //
-        // All OrchardZSA constraints:
+        // All ZSA constraints:
         // Constrain split_flag to be boolean
         // Constrain v_old * (1 - split_flag) - v_new = magnitude * sign
         // Constrain (v_old = 0 and is_zatoshi_asset = 1) or (calculated root = anchor)

--- a/src/circuit/circuit_zsa.rs
+++ b/src/circuit/circuit_zsa.rs
@@ -37,7 +37,7 @@ use crate::{
         },
         note_commit::{gadgets::note_commit, NoteCommitChip, ZsaNoteCommitParams},
         value_commit_orchard::{gadgets::value_commit_orchard, ZsaValueCommitParams},
-        AddressPoints, CircuitVanilla, Config, OrchardCircuitVersion, ANCHOR, CMX, CV_NET_X,
+        AddressPoints, CircuitNative, Config, OrchardCircuitVersion, ANCHOR, CMX, CV_NET_X,
         CV_NET_Y, DISABLE_CROSS_ADDRESS, ENABLE_OUTPUT, ENABLE_SPEND, ENABLE_ZSA, NF_OLD, RK_X,
         RK_Y,
     },
@@ -67,7 +67,7 @@ fn unpack(
 /// The OrchardZSA Action circuit.
 #[derive(Clone, Debug)]
 pub struct CircuitZsa {
-    pub(crate) common_witnesses: CircuitVanilla,
+    pub(crate) common_witnesses: CircuitNative,
 
     // The ZSA-specific witnesses.
     pub(crate) additional_zsa_witnesses: Value<AdditionalZsaWitnesses>,
@@ -80,7 +80,7 @@ impl CircuitZsa {
     /// or rendering the circuit layout, where witness values are not required.
     pub(crate) fn empty() -> Self {
         CircuitZsa {
-            common_witnesses: CircuitVanilla::empty(OrchardCircuitVersion::ZSA),
+            common_witnesses: CircuitNative::empty(OrchardCircuitVersion::ZSA),
             additional_zsa_witnesses: Value::unknown(),
         }
     }
@@ -105,7 +105,7 @@ impl CircuitZsa {
             panic!("circuit version must be ZSA in OrchardZSA circuit");
         }
 
-        let (common_witnesses, psi_nf) = CircuitVanilla::from_action_context_common(
+        let (common_witnesses, psi_nf) = CircuitNative::from_action_context_common(
             &spend,
             &output_note,
             alpha,
@@ -1265,7 +1265,7 @@ mod tests {
         builder::SpendInfo,
         bundle::{BundleVersion, Flags},
         circuit::{
-            circuit_zsa::AdditionalZsaWitnesses, Circuit, CircuitVanilla, CircuitZsa, Instance,
+            circuit_zsa::AdditionalZsaWitnesses, Circuit, CircuitNative, CircuitZsa, Instance,
             OrchardCircuitVersion, Proof, ProvingKey, VerifyingKey, K,
         },
         keys::{FullViewingKey, Scope, SpendValidatingKey, SpendingKey},
@@ -1304,7 +1304,7 @@ mod tests {
 
         (
             Circuit::OrchardZSA(CircuitZsa {
-                common_witnesses: CircuitVanilla {
+                common_witnesses: CircuitNative {
                     path: Value::known(path.auth_path()),
                     pos: Value::known(path.position()),
                     g_d_old: Value::known(sender_address.g_d()),
@@ -1770,7 +1770,7 @@ mod tests {
             // Set cm_old to be a random NoteCommitment
             // The proof should fail
             let circuit_wrong_cm_old = Circuit::OrchardZSA(CircuitZsa {
-                common_witnesses: CircuitVanilla {
+                common_witnesses: CircuitNative {
                     cm_old: Value::known(random_note_commitment(&mut rng)),
                     ..circuit.as_zsa().unwrap().common_witnesses.clone()
                 },

--- a/tests/builder.rs
+++ b/tests/builder.rs
@@ -84,9 +84,10 @@ pub fn build_merkle_path(note: &Note) -> (MerklePath, Anchor) {
 }
 
 /// Marker type selecting the Vanilla flavor for the flavor-parameterized tests in this file.
-struct OrchardVanilla;
+struct OrchardV2;
 /// Marker type selecting the ZSA flavor for the flavor-parameterized tests in this file.
-struct OrchardZSA;
+#[allow(clippy::upper_case_acronyms)]
+struct ZSA;
 
 trait BundleOrchardFlavor {
     const DEFAULT_BUNDLE_VERSION: BundleVersion;
@@ -95,14 +96,14 @@ trait BundleOrchardFlavor {
     type DomainVersion: DomainVersion;
 }
 
-impl BundleOrchardFlavor for OrchardVanilla {
+impl BundleOrchardFlavor for OrchardV2 {
     const DEFAULT_BUNDLE_VERSION: BundleVersion = BundleVersion::orchard_v2();
     const TX_VERSION: TxVersion = TxVersion::V5;
     const SPENDS_DISABLED_FLAGS: Flags = Flags::SPENDS_DISABLED;
     type DomainVersion = OrchardVersion;
 }
 
-impl BundleOrchardFlavor for OrchardZSA {
+impl BundleOrchardFlavor for ZSA {
     const DEFAULT_BUNDLE_VERSION: BundleVersion = BundleVersion::zsa();
     const TX_VERSION: TxVersion = TxVersion::ZSA;
     const SPENDS_DISABLED_FLAGS: Flags = Flags::SPENDS_DISABLED_WITH_ZSA;
@@ -274,7 +275,7 @@ fn bundle_chain<FL: BundleOrchardFlavor>() -> ([u8; 32], [u8; 32]) {
 
 #[test]
 fn bundle_chain_vanilla() {
-    let (orchard_digest_1, orchard_digest_2) = bundle_chain::<OrchardVanilla>();
+    let (orchard_digest_1, orchard_digest_2) = bundle_chain::<OrchardV2>();
     assert_eq!(
         orchard_digest_1,
         // Locks the `orchard_digest` for OrchardVanilla
@@ -295,10 +296,10 @@ fn bundle_chain_vanilla() {
 
 #[test]
 fn bundle_chain_zsa() {
-    let (orchard_digest_1, orchard_digest_2) = bundle_chain::<OrchardZSA>();
+    let (orchard_digest_1, orchard_digest_2) = bundle_chain::<ZSA>();
     assert_eq!(
         orchard_digest_1,
-        // Locks the `orchard_digest` for OrchardZSA
+        // Locks the `orchard_digest` for ZSA
         [
             51, 125, 219, 53, 244, 237, 140, 156, 133, 175, 230, 45, 156, 75, 11, 151, 151, 34,
             245, 84, 208, 196, 248, 187, 20, 54, 111, 230, 69, 34, 114, 72
@@ -306,7 +307,7 @@ fn bundle_chain_zsa() {
     );
     assert_eq!(
         orchard_digest_2,
-        // Locks the `orchard_digest` for OrchardZSA
+        // Locks the `orchard_digest` for ZSA
         [
             134, 103, 36, 170, 193, 49, 193, 89, 199, 73, 231, 32, 135, 130, 9, 119, 224, 62, 101,
             240, 132, 164, 83, 61, 147, 47, 159, 94, 172, 105, 132, 82


### PR DESCRIPTION
- Rename CircuitVanilla to CircuitNative
- Rename Circuit::OrchardZSA to Circuit::ZSA
- Rename Circuit::OrchardVanilla to Circuit::Native
- Rename as_vanilla to as_native
- Replace OrchardZSA with ZSA in comments in circuit files