### PR TITLE
Circuit configure unify

### DIFF
--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -103,31 +103,15 @@ pub struct Config<Lookup: PallasLookupRangeCheck> {
     new_note_commit_config: NoteCommitConfig<Lookup>,
 }
 
-/// The lookup argument used by an Orchard circuit variation.
-///
-/// At configuration time, the two circuit variations differ only in their lookup
-/// argument and in the contents of the `q_orchard` gate; this trait carries both, so
-/// that [`configure_circuit`] can express the shared structure once.
-trait OrchardLookup: PallasLookupRangeCheck {
-    /// Whether this is the lookup argument of the ZSA circuit variation, which the
-    /// Sinsemilla and NoteCommit chips extend with ZSA-specific configuration.
-    const IS_ZSA: bool;
-
-    /// Creates the `q_orchard` gate checking this circuit variation's Orchard Action
-    /// statement, on the given selector.
-    fn configure_orchard_gate(
-        meta: &mut plonk::ConstraintSystem<pallas::Base>,
-        advices: [Column<Advice>; 10],
-        q_orchard: Selector,
-    );
-}
-
 /// Configures the Orchard Action circuit in the given constraint system.
 ///
-/// Shared by both circuit variations; everything variation-specific comes from the
-/// [`OrchardLookup`] implementation.
-fn configure_circuit<Lookup: OrchardLookup>(
+/// Shared by both circuit variations; `is_zsa` selects both the `q_orchard` gate
+/// ([`circuit_vanilla::configure_vanilla_orchard_gate`] or
+/// [`circuit_zsa::configure_zsa_orchard_gate`]) and the ZSA-specific configuration
+/// of the Sinsemilla and NoteCommit chips.
+fn configure_circuit<Lookup: PallasLookupRangeCheck>(
     meta: &mut plonk::ConstraintSystem<pallas::Base>,
+    is_zsa: bool,
 ) -> Config<Lookup> {
     // Advice columns used in the Orchard circuit.
     let advices = [
@@ -144,7 +128,11 @@ fn configure_circuit<Lookup: OrchardLookup>(
     ];
 
     let q_orchard = meta.selector();
-    Lookup::configure_orchard_gate(meta, advices, q_orchard);
+    if is_zsa {
+        circuit_zsa::configure_zsa_orchard_gate(meta, advices, q_orchard);
+    } else {
+        circuit_vanilla::configure_vanilla_orchard_gate(meta, advices, q_orchard);
+    }
 
     // Addition of two field elements.
     let add_config = AddChip::configure(meta, advices[7], advices[8], advices[6]);
@@ -225,7 +213,7 @@ fn configure_circuit<Lookup: OrchardLookup>(
             lagrange_coeffs[0],
             lookup,
             range_check,
-            Lookup::IS_ZSA,
+            is_zsa,
         );
         let merkle_config_1 = MerkleChip::configure(meta, sinsemilla_config_1.clone());
 
@@ -244,7 +232,7 @@ fn configure_circuit<Lookup: OrchardLookup>(
             lagrange_coeffs[1],
             lookup,
             range_check,
-            Lookup::IS_ZSA,
+            is_zsa,
         );
         let merkle_config_2 = MerkleChip::configure(meta, sinsemilla_config_2.clone());
 
@@ -258,12 +246,12 @@ fn configure_circuit<Lookup: OrchardLookup>(
     // Configuration to handle decomposition and canonicity checking
     // for NoteCommit_old.
     let old_note_commit_config =
-        NoteCommitChip::configure(meta, advices, sinsemilla_config_1.clone(), Lookup::IS_ZSA);
+        NoteCommitChip::configure(meta, advices, sinsemilla_config_1.clone(), is_zsa);
 
     // Configuration to handle decomposition and canonicity checking
     // for NoteCommit_new.
     let new_note_commit_config =
-        NoteCommitChip::configure(meta, advices, sinsemilla_config_2.clone(), Lookup::IS_ZSA);
+        NoteCommitChip::configure(meta, advices, sinsemilla_config_2.clone(), is_zsa);
 
     Config {
         primary,

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -7,6 +7,7 @@ use alloc::vec::Vec;
 
 use group::{Curve, GroupEncoding};
 use halo2_proofs::{
+    circuit::Value,
     plonk::{
         self, Advice, BatchVerifier, Column, Instance as InstanceColumn, Selector, SingleVerifier,
     },
@@ -42,7 +43,7 @@ mod circuit_vanilla;
 mod circuit_zsa;
 
 use circuit_vanilla::CircuitVanilla;
-use circuit_zsa::CircuitZsa;
+use circuit_zsa::{AdditionalZsaWitnesses, CircuitZsa};
 
 #[cfg(not(feature = "unstable-voting-circuits"))]
 pub(in crate::circuit) mod commit_ivk;
@@ -131,53 +132,32 @@ impl OrchardCircuitVersion {
 }
 
 /// The Orchard Action circuit.
+///
+/// Carries the private witnesses of a single action for any [`OrchardCircuitVersion`].
+/// The ZSA-specific witnesses are populated only for [`OrchardCircuitVersion::ZSA`];
+/// the Vanilla circuit versions leave them unknown and do not prove them.
 #[derive(Clone, Debug)]
-pub enum Circuit {
-    /// The Vanilla Orchard Action circuit.
-    /// It is used with all [`OrchardCircuitVersion`] except [`OrchardCircuitVersion::ZSA`].
-    OrchardVanilla(CircuitVanilla),
-    /// The ZSA Orchard Action circuit.
-    /// It is used only with [`OrchardCircuitVersion::ZSA`].
-    OrchardZSA(CircuitZsa),
+pub struct Circuit {
+    pub(crate) common_witnesses: CircuitVanilla,
+    pub(crate) additional_zsa_witnesses: Value<AdditionalZsaWitnesses>,
 }
 
 impl Circuit {
     /// Returns the [`OrchardCircuitVersion`] this circuit instance is configured for.
-    ///
-    /// # Errors
-    ///
-    /// Returns [`plonk::Error::Synthesis`] if the variant and its inner circuit version are
-    /// inconsistent: a `Circuit::OrchardVanilla` carrying [`OrchardCircuitVersion::ZSA`], or a
-    /// `Circuit::OrchardZSA` not carrying it.
-    fn circuit_version(&self) -> Result<OrchardCircuitVersion, plonk::Error> {
-        match self {
-            Circuit::OrchardVanilla(circuit) => {
-                if circuit.circuit_version == OrchardCircuitVersion::ZSA {
-                    return Err(plonk::Error::Synthesis);
-                }
-                Ok(circuit.circuit_version)
-            }
-            Circuit::OrchardZSA(circuit) => {
-                if circuit.common_witnesses.circuit_version != OrchardCircuitVersion::ZSA {
-                    return Err(plonk::Error::Synthesis);
-                }
-                Ok(circuit.common_witnesses.circuit_version)
-            }
-        }
+    fn circuit_version(&self) -> OrchardCircuitVersion {
+        self.common_witnesses.circuit_version
     }
-}
 
-impl Circuit {
-    /// Returns an empty circuit with all private witnesses unknown.
-    ///
-    /// This is used for circuit shape-dependent operations, such as generating keys
-    /// or rendering the circuit layout, where witness values are not required but the
-    /// selected circuit version still determines the configured constraints.
-    fn empty(circuit_version: OrchardCircuitVersion) -> Self {
-        if circuit_version.is_zsa() {
-            Circuit::OrchardZSA(CircuitZsa::empty())
-        } else {
-            Circuit::OrchardVanilla(CircuitVanilla::empty(circuit_version))
+    /// Returns the witnesses proved by the Vanilla circuit versions.
+    fn to_vanilla(&self) -> CircuitVanilla {
+        self.common_witnesses.clone()
+    }
+
+    /// Returns the witnesses proved by the ZSA circuit version.
+    fn to_zsa(&self) -> CircuitZsa {
+        CircuitZsa {
+            common_witnesses: self.common_witnesses.clone(),
+            additional_zsa_witnesses: self.additional_zsa_witnesses.clone(),
         }
     }
 
@@ -208,6 +188,11 @@ impl Circuit {
         })
     }
 
+    /// # Panics
+    ///
+    /// Panics for a Vanilla `circuit_version` if the spent note's asset is not zatoshi,
+    /// or if `spend.split_flag` is true: those statements exist only in the ZSA circuit,
+    /// so a Vanilla version cannot attest to them.
     pub(crate) fn from_action_context_unchecked(
         spend: SpendInfo,
         output_note: Note,
@@ -215,38 +200,38 @@ impl Circuit {
         rcv: ValueCommitTrapdoor,
         circuit_version: OrchardCircuitVersion,
     ) -> Circuit {
-        if circuit_version.is_zsa() {
-            Circuit::OrchardZSA(CircuitZsa::from_action_context_unchecked(
-                spend,
-                output_note,
-                alpha,
-                rcv,
-                circuit_version,
-            ))
+        if !circuit_version.is_zsa() {
+            assert!(
+                bool::from(spend.note.asset().is_zatoshi()),
+                "asset must be zatoshi in OrchardVanilla circuit"
+            );
+            assert!(
+                !spend.split_flag,
+                "split_flag must be false in OrchardVanilla circuit"
+            );
+        }
+
+        let (common_witnesses, psi_nf) = CircuitVanilla::from_action_context_common(
+            &spend,
+            &output_note,
+            alpha,
+            rcv,
+            circuit_version,
+        );
+
+        let additional_zsa_witnesses = if circuit_version.is_zsa() {
+            Value::known(AdditionalZsaWitnesses {
+                psi_nf,
+                asset: spend.note.asset(),
+                split_flag: spend.split_flag,
+            })
         } else {
-            Circuit::OrchardVanilla(CircuitVanilla::from_action_context_unchecked(
-                spend,
-                output_note,
-                alpha,
-                rcv,
-                circuit_version,
-            ))
-        }
-    }
+            Value::unknown()
+        };
 
-    /// Returns the inner [`CircuitVanilla`], or `None` if this is a `Circuit::OrchardZSA`.
-    fn as_vanilla(&self) -> Option<&CircuitVanilla> {
-        match self {
-            Circuit::OrchardVanilla(circuit) => Some(circuit),
-            Circuit::OrchardZSA(_) => None,
-        }
-    }
-
-    /// Returns the inner [`CircuitZsa`], or `None` if this is a `Circuit::OrchardVanilla`.
-    fn as_zsa(&self) -> Option<&CircuitZsa> {
-        match self {
-            Circuit::OrchardZSA(circuit) => Some(circuit),
-            Circuit::OrchardVanilla(_) => None,
+        Circuit {
+            common_witnesses,
+            additional_zsa_witnesses,
         }
     }
 }
@@ -277,9 +262,10 @@ impl VerifyingKey {
     /// See [`OrchardCircuitVersion`] for which version to use.
     pub fn build(circuit_version: OrchardCircuitVersion) -> Self {
         let params = halo2_proofs::poly::commitment::Params::new(K);
-        let vk = match Circuit::empty(circuit_version) {
-            Circuit::OrchardVanilla(circuit) => plonk::keygen_vk(&params, &circuit).unwrap(),
-            Circuit::OrchardZSA(circuit) => plonk::keygen_vk(&params, &circuit).unwrap(),
+        let vk = if circuit_version.is_zsa() {
+            plonk::keygen_vk(&params, &CircuitZsa::empty()).unwrap()
+        } else {
+            plonk::keygen_vk(&params, &CircuitVanilla::empty(circuit_version)).unwrap()
         };
 
         VerifyingKey {
@@ -317,15 +303,14 @@ impl ProvingKey {
     /// See [`OrchardCircuitVersion`] for which version to use.
     pub fn build(circuit_version: OrchardCircuitVersion) -> Self {
         let params = halo2_proofs::poly::commitment::Params::new(K);
-        let pk = match Circuit::empty(circuit_version) {
-            Circuit::OrchardVanilla(circuit) => {
-                let vk = plonk::keygen_vk(&params, &circuit).unwrap();
-                plonk::keygen_pk(&params, vk, &circuit).unwrap()
-            }
-            Circuit::OrchardZSA(circuit) => {
-                let vk = plonk::keygen_vk(&params, &circuit).unwrap();
-                plonk::keygen_pk(&params, vk, &circuit).unwrap()
-            }
+        let pk = if circuit_version.is_zsa() {
+            let circuit = CircuitZsa::empty();
+            let vk = plonk::keygen_vk(&params, &circuit).unwrap();
+            plonk::keygen_pk(&params, vk, &circuit).unwrap()
+        } else {
+            let circuit = CircuitVanilla::empty(circuit_version);
+            let vk = plonk::keygen_vk(&params, &circuit).unwrap();
+            plonk::keygen_pk(&params, vk, &circuit).unwrap()
         };
 
         ProvingKey {
@@ -518,10 +503,11 @@ impl Proof {
         instances: &[Instance],
         mut rng: impl RngCore,
     ) -> Result<Self, plonk::Error> {
-        for circuit in circuits {
-            if circuit.circuit_version()? != pk.circuit_version {
-                return Err(plonk::Error::Synthesis);
-            }
+        if circuits
+            .iter()
+            .any(|circuit| circuit.circuit_version() != pk.circuit_version)
+        {
+            return Err(plonk::Error::Synthesis);
         }
 
         if instances.iter().any(Instance::cross_address_disabled)
@@ -540,10 +526,7 @@ impl Proof {
         let mut transcript = Blake2bWrite::<_, vesta::Affine, _>::init(vec![]);
 
         if pk.circuit_version.is_zsa() {
-            let circuits: Vec<_> = circuits
-                .iter()
-                .map(|c| c.as_zsa().expect("checked above").clone())
-                .collect();
+            let circuits: Vec<_> = circuits.iter().map(Circuit::to_zsa).collect();
             plonk::create_proof(
                 &pk.params,
                 &pk.pk,
@@ -553,10 +536,7 @@ impl Proof {
                 &mut transcript,
             )?;
         } else {
-            let circuits: Vec<_> = circuits
-                .iter()
-                .map(|c| c.as_vanilla().expect("checked above").clone())
-                .collect();
+            let circuits: Vec<_> = circuits.iter().map(Circuit::to_vanilla).collect();
             plonk::create_proof(
                 &pk.params,
                 &pk.pk,

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -20,7 +20,9 @@ use crate::{
     builder::SpendInfo,
     bundle::Flags,
     circuit::{
-        commit_ivk::CommitIvkConfig, gadget::add_chip::AddConfig, note_commit::NoteCommitConfig,
+        commit_ivk::{CommitIvkChip, CommitIvkConfig},
+        gadget::add_chip::{AddChip, AddConfig},
+        note_commit::{NoteCommitChip, NoteCommitConfig},
     },
     circuit_version::OrchardCircuitVersion,
     constants::{OrchardCommitDomains, OrchardFixedBases, OrchardHashDomains},
@@ -34,8 +36,11 @@ use halo2_gadgets::{
         chip::{EccChip, EccConfig},
         CircuitVersion, NonIdentityPoint,
     },
-    poseidon::Pow5Config as PoseidonConfig,
-    sinsemilla::{chip::SinsemillaConfig, merkle::chip::MerkleConfig},
+    poseidon::{primitives as poseidon, Pow5Chip as PoseidonChip, Pow5Config as PoseidonConfig},
+    sinsemilla::{
+        chip::{SinsemillaChip, SinsemillaConfig},
+        merkle::chip::{MerkleChip, MerkleConfig},
+    },
     utilities::lookup_range_check::PallasLookupRangeCheck,
 };
 
@@ -96,6 +101,185 @@ pub struct Config<Lookup: PallasLookupRangeCheck> {
     commit_ivk_config: CommitIvkConfig,
     old_note_commit_config: NoteCommitConfig<Lookup>,
     new_note_commit_config: NoteCommitConfig<Lookup>,
+}
+
+/// The lookup argument used by an Orchard circuit variation.
+///
+/// At configuration time, the two circuit variations differ only in their lookup
+/// argument and in the contents of the `q_orchard` gate; this trait carries both, so
+/// that [`configure_circuit`] can express the shared structure once.
+trait OrchardLookup: PallasLookupRangeCheck {
+    /// Whether this is the lookup argument of the ZSA circuit variation, which the
+    /// Sinsemilla and NoteCommit chips extend with ZSA-specific configuration.
+    const IS_ZSA: bool;
+
+    /// Creates the `q_orchard` gate checking this circuit variation's Orchard Action
+    /// statement, on the given selector.
+    fn configure_orchard_gate(
+        meta: &mut plonk::ConstraintSystem<pallas::Base>,
+        advices: [Column<Advice>; 10],
+        q_orchard: Selector,
+    );
+}
+
+/// Configures the Orchard Action circuit in the given constraint system.
+///
+/// Shared by both circuit variations; everything variation-specific comes from the
+/// [`OrchardLookup`] implementation.
+fn configure_circuit<Lookup: OrchardLookup>(
+    meta: &mut plonk::ConstraintSystem<pallas::Base>,
+) -> Config<Lookup> {
+    // Advice columns used in the Orchard circuit.
+    let advices = [
+        meta.advice_column(),
+        meta.advice_column(),
+        meta.advice_column(),
+        meta.advice_column(),
+        meta.advice_column(),
+        meta.advice_column(),
+        meta.advice_column(),
+        meta.advice_column(),
+        meta.advice_column(),
+        meta.advice_column(),
+    ];
+
+    let q_orchard = meta.selector();
+    Lookup::configure_orchard_gate(meta, advices, q_orchard);
+
+    // Addition of two field elements.
+    let add_config = AddChip::configure(meta, advices[7], advices[8], advices[6]);
+
+    // Fixed columns for the Sinsemilla generator lookup table
+    let table_idx = meta.lookup_table_column();
+    let lookup = (
+        table_idx,
+        meta.lookup_table_column(),
+        meta.lookup_table_column(),
+    );
+
+    // Instance column used for public inputs
+    let primary = meta.instance_column();
+    meta.enable_equality(primary);
+
+    // Permutation over all advice columns.
+    for advice in advices.iter() {
+        meta.enable_equality(*advice);
+    }
+
+    // Poseidon requires four advice columns, while ECC incomplete addition requires
+    // six, so we could choose to configure them in parallel. However, we only use a
+    // single Poseidon invocation, and we have the rows to accommodate it serially.
+    // Instead, we reduce the proof size by sharing fixed columns between the ECC and
+    // Poseidon chips.
+    let lagrange_coeffs = [
+        meta.fixed_column(),
+        meta.fixed_column(),
+        meta.fixed_column(),
+        meta.fixed_column(),
+        meta.fixed_column(),
+        meta.fixed_column(),
+        meta.fixed_column(),
+        meta.fixed_column(),
+    ];
+    let rc_a = lagrange_coeffs[2..5].try_into().unwrap();
+    let rc_b = lagrange_coeffs[5..8].try_into().unwrap();
+
+    // Also use the first Lagrange coefficient column for loading global constants.
+    // It's free real estate :)
+    meta.enable_constant(lagrange_coeffs[0]);
+
+    // We have a lot of free space in the right-most advice columns; use one of them
+    // for all of our range checks. (The ZSA lookup argument also allocates its
+    // extra tag table column here.)
+    let range_check = Lookup::configure(meta, advices[9], table_idx);
+
+    // Configuration for curve point operations.
+    // This uses 10 advice columns and spans the whole circuit.
+    let ecc_config = EccChip::<OrchardFixedBases, Lookup>::configure(
+        meta,
+        advices,
+        lagrange_coeffs,
+        range_check,
+    );
+
+    // Configuration for the Poseidon hash.
+    let poseidon_config = PoseidonChip::configure::<poseidon::P128Pow5T3>(
+        meta,
+        // We place the state columns after the partial_sbox column so that the
+        // pad-and-add region can be laid out more efficiently.
+        advices[6..9].try_into().unwrap(),
+        advices[5],
+        rc_a,
+        rc_b,
+    );
+
+    // Configuration for a Sinsemilla hash instantiation and a
+    // Merkle hash instantiation using this Sinsemilla instance.
+    // Since the Sinsemilla config uses only 5 advice columns,
+    // we can fit two instances side-by-side.
+    let (sinsemilla_config_1, merkle_config_1) = {
+        let sinsemilla_config_1 = SinsemillaChip::configure(
+            meta,
+            advices[..5].try_into().unwrap(),
+            advices[6],
+            lagrange_coeffs[0],
+            lookup,
+            range_check,
+            Lookup::IS_ZSA,
+        );
+        let merkle_config_1 = MerkleChip::configure(meta, sinsemilla_config_1.clone());
+
+        (sinsemilla_config_1, merkle_config_1)
+    };
+
+    // Configuration for a Sinsemilla hash instantiation and a
+    // Merkle hash instantiation using this Sinsemilla instance.
+    // Since the Sinsemilla config uses only 5 advice columns,
+    // we can fit two instances side-by-side.
+    let (sinsemilla_config_2, merkle_config_2) = {
+        let sinsemilla_config_2 = SinsemillaChip::configure(
+            meta,
+            advices[5..].try_into().unwrap(),
+            advices[7],
+            lagrange_coeffs[1],
+            lookup,
+            range_check,
+            Lookup::IS_ZSA,
+        );
+        let merkle_config_2 = MerkleChip::configure(meta, sinsemilla_config_2.clone());
+
+        (sinsemilla_config_2, merkle_config_2)
+    };
+
+    // Configuration to handle decomposition and canonicity checking
+    // for CommitIvk.
+    let commit_ivk_config = CommitIvkChip::configure(meta, advices);
+
+    // Configuration to handle decomposition and canonicity checking
+    // for NoteCommit_old.
+    let old_note_commit_config =
+        NoteCommitChip::configure(meta, advices, sinsemilla_config_1.clone(), Lookup::IS_ZSA);
+
+    // Configuration to handle decomposition and canonicity checking
+    // for NoteCommit_new.
+    let new_note_commit_config =
+        NoteCommitChip::configure(meta, advices, sinsemilla_config_2.clone(), Lookup::IS_ZSA);
+
+    Config {
+        primary,
+        q_orchard,
+        advices,
+        add_config,
+        ecc_config,
+        poseidon_config,
+        merkle_config_1,
+        merkle_config_2,
+        sinsemilla_config_1,
+        sinsemilla_config_2,
+        commit_ivk_config,
+        old_note_commit_config,
+        new_note_commit_config,
+    }
 }
 
 impl OrchardCircuitVersion {

--- a/src/circuit.rs
+++ b/src/circuit.rs
@@ -321,7 +321,13 @@ impl Circuit {
     }
 
     /// Returns the witnesses proved by the Vanilla circuit versions.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `additional_zsa_witnesses` is known: the Vanilla circuit versions must
+    /// never be asked to prove ZSA-specific witnesses.
     fn to_vanilla(&self) -> CircuitVanilla {
+        self.additional_zsa_witnesses.assert_if_known(|_| false);
         self.common_witnesses.clone()
     }
 
@@ -845,6 +851,46 @@ mod tests {
                 Instance::from_parts(anchor, cv_net, nf_old, rk.clone(), cmx, Flags::ENABLED)
                     .expect("non-identity rk must be accepted");
             assert_eq!(instance.rk(), &rk);
+        }
+    }
+
+    mod to_vanilla_zsa_witnesses_invariant {
+        use ff::Field;
+        use halo2_proofs::circuit::Value;
+        use pasta_curves::pallas;
+
+        use super::super::{
+            AdditionalZsaWitnesses, Circuit, CircuitVanilla, OrchardCircuitVersion,
+        };
+        use crate::note::AssetBase;
+
+        /// `Circuit::to_vanilla` must reject any `Circuit` that carries known ZSA-specific
+        /// witnesses for a non-ZSA `circuit_version`: the Vanilla circuit versions have no
+        /// way to prove them, so their presence indicates a construction bug rather than a
+        /// provable statement.
+        #[test]
+        #[should_panic]
+        fn panics_if_zsa_witnesses_are_known() {
+            let circuit = Circuit {
+                common_witnesses: CircuitVanilla::empty(OrchardCircuitVersion::FixedPostNu6_2),
+                additional_zsa_witnesses: Value::known(AdditionalZsaWitnesses {
+                    psi_nf: pallas::Base::ZERO,
+                    asset: AssetBase::zatoshi(),
+                    split_flag: false,
+                }),
+            };
+
+            circuit.to_vanilla();
+        }
+
+        #[test]
+        fn accepts_unknown_zsa_witnesses() {
+            let circuit = Circuit {
+                common_witnesses: CircuitVanilla::empty(OrchardCircuitVersion::FixedPostNu6_2),
+                additional_zsa_witnesses: Value::unknown(),
+            };
+
+            circuit.to_vanilla();
         }
     }
 }

--- a/src/circuit/circuit_vanilla.rs
+++ b/src/circuit/circuit_vanilla.rs
@@ -23,8 +23,8 @@ use crate::{
         commit_ivk::gadgets::commit_ivk, configure_circuit,
         derive_nullifier::gadgets::derive_nullifier, gadget::assign_free_advice,
         note_commit::gadgets::note_commit, value_commit_orchard::gadgets::value_commit_orchard,
-        AddressPoints, Config, OrchardCircuitVersion, OrchardLookup, ANCHOR, CMX, CV_NET_X,
-        CV_NET_Y, DISABLE_CROSS_ADDRESS, ENABLE_OUTPUT, ENABLE_SPEND, NF_OLD, RK_X, RK_Y,
+        AddressPoints, Config, OrchardCircuitVersion, ANCHOR, CMX, CV_NET_X, CV_NET_Y,
+        DISABLE_CROSS_ADDRESS, ENABLE_OUTPUT, ENABLE_SPEND, NF_OLD, RK_X, RK_Y,
     },
     constants::{OrchardFixedBasesFull, OrchardHashDomains, MERKLE_DEPTH_ORCHARD},
     keys::{
@@ -165,59 +165,57 @@ impl CircuitVanilla {
     }
 }
 
-impl OrchardLookup for PallasLookupRangeCheckConfig {
-    const IS_ZSA: bool = false;
+/// Creates the `q_orchard` gate checking the OrchardVanilla Action statement, on the
+/// given selector.
+pub(super) fn configure_vanilla_orchard_gate(
+    meta: &mut plonk::ConstraintSystem<pallas::Base>,
+    advices: [Column<Advice>; 10],
+    q_orchard: Selector,
+) {
+    // Constrain v_old - v_new = magnitude * sign    (https://p.z.cash/ZKS:action-cv-net-integrity?partial).
+    // Either v_old = 0, or calculated root = anchor (https://p.z.cash/ZKS:action-merkle-path-validity?partial).
+    // Constrain v_old = 0 or enable_spend = 1       (https://p.z.cash/ZKS:action-enable-spend).
+    // Constrain v_new = 0 or enable_output = 1      (https://p.z.cash/ZKS:action-enable-output).
+    //
+    // This gate is also reused for the same-address check; see
+    // [`CircuitVanilla::synthesize_cross_address_checks`].
+    meta.create_gate("Orchard circuit checks", |meta| {
+        let q_orchard = meta.query_selector(q_orchard);
+        let v_old = meta.query_advice(advices[0], Rotation::cur());
+        let v_new = meta.query_advice(advices[1], Rotation::cur());
+        let magnitude = meta.query_advice(advices[2], Rotation::cur());
+        let sign = meta.query_advice(advices[3], Rotation::cur());
 
-    fn configure_orchard_gate(
-        meta: &mut plonk::ConstraintSystem<pallas::Base>,
-        advices: [Column<Advice>; 10],
-        q_orchard: Selector,
-    ) {
-        // Constrain v_old - v_new = magnitude * sign    (https://p.z.cash/ZKS:action-cv-net-integrity?partial).
-        // Either v_old = 0, or calculated root = anchor (https://p.z.cash/ZKS:action-merkle-path-validity?partial).
-        // Constrain v_old = 0 or enable_spend = 1       (https://p.z.cash/ZKS:action-enable-spend).
-        // Constrain v_new = 0 or enable_output = 1      (https://p.z.cash/ZKS:action-enable-output).
-        //
-        // This gate is also reused for the same-address check; see
-        // [`CircuitVanilla::synthesize_cross_address_checks`].
-        meta.create_gate("Orchard circuit checks", |meta| {
-            let q_orchard = meta.query_selector(q_orchard);
-            let v_old = meta.query_advice(advices[0], Rotation::cur());
-            let v_new = meta.query_advice(advices[1], Rotation::cur());
-            let magnitude = meta.query_advice(advices[2], Rotation::cur());
-            let sign = meta.query_advice(advices[3], Rotation::cur());
+        let root = meta.query_advice(advices[4], Rotation::cur());
+        let anchor = meta.query_advice(advices[5], Rotation::cur());
 
-            let root = meta.query_advice(advices[4], Rotation::cur());
-            let anchor = meta.query_advice(advices[5], Rotation::cur());
+        let enable_spend = meta.query_advice(advices[6], Rotation::cur());
+        let enable_output = meta.query_advice(advices[7], Rotation::cur());
 
-            let enable_spend = meta.query_advice(advices[6], Rotation::cur());
-            let enable_output = meta.query_advice(advices[7], Rotation::cur());
+        let one = Expression::Constant(pallas::Base::one());
 
-            let one = Expression::Constant(pallas::Base::one());
-
-            Constraints::with_selector(
-                q_orchard,
-                [
-                    (
-                        "v_old - v_new = magnitude * sign",
-                        v_old.clone() - v_new.clone() - magnitude * sign,
-                    ),
-                    (
-                        "Either v_old = 0, or root = anchor",
-                        v_old.clone() * (root - anchor),
-                    ),
-                    (
-                        "v_old = 0 or enable_spend = 1",
-                        v_old * (one.clone() - enable_spend),
-                    ),
-                    (
-                        "v_new = 0 or enable_output = 1",
-                        v_new * (one - enable_output),
-                    ),
-                ],
-            )
-        });
-    }
+        Constraints::with_selector(
+            q_orchard,
+            [
+                (
+                    "v_old - v_new = magnitude * sign",
+                    v_old.clone() - v_new.clone() - magnitude * sign,
+                ),
+                (
+                    "Either v_old = 0, or root = anchor",
+                    v_old.clone() * (root - anchor),
+                ),
+                (
+                    "v_old = 0 or enable_spend = 1",
+                    v_old * (one.clone() - enable_spend),
+                ),
+                (
+                    "v_new = 0 or enable_output = 1",
+                    v_new * (one - enable_output),
+                ),
+            ],
+        )
+    });
 }
 
 impl plonk::Circuit<pallas::Base> for CircuitVanilla {
@@ -229,7 +227,7 @@ impl plonk::Circuit<pallas::Base> for CircuitVanilla {
     }
 
     fn configure(meta: &mut plonk::ConstraintSystem<pallas::Base>) -> Self::Config {
-        configure_circuit(meta)
+        configure_circuit(meta, false)
     }
 
     #[allow(non_snake_case)]

--- a/src/circuit/circuit_vanilla.rs
+++ b/src/circuit/circuit_vanilla.rs
@@ -115,11 +115,12 @@ impl CircuitVanilla {
     /// - `rcv`: trapdoor for the action value commitment
     /// - `circuit_version`: the [`OrchardCircuitVersion`] selected for the circuit
     ///
-    /// This function returns also `psi_nf` which is only consumed by
-    /// [`CircuitZsa`], for its split-note handling.
+    /// This function returns also `psi_nf` which is only consumed by the ZSA-specific
+    /// witnesses of [`Circuit`], for the split-note handling of [`CircuitZsa`].
     ///
     /// [`SpendInfo`]: crate::builder::SpendInfo
     /// [`OrchardCircuitVersion`]: crate::circuit::OrchardCircuitVersion
+    /// [`Circuit`]: crate::circuit::Circuit
     /// [`CircuitZsa`]: crate::circuit::circuit_zsa::CircuitZsa
     pub(crate) fn from_action_context_common(
         spend: &SpendInfo,
@@ -171,41 +172,6 @@ impl CircuitVanilla {
             },
             psi_nf,
         )
-    }
-
-    /// Constructs a `CircuitVanilla` for the given `circuit_version` from the following
-    /// components:
-    /// - `spend`: [`SpendInfo`] of the note spent in scope of the action
-    /// - `output_note`: a note created in scope of the action
-    /// - `alpha`: a scalar used for randomization of the action spend validating key
-    /// - `rcv`: trapdoor for the action value commitment
-    ///
-    /// # Panics
-    ///
-    /// Panics if
-    /// - if the spent note's asset is not zatoshi,
-    /// - if`spend.split_flag` is true, or
-    /// - if `circuit_version` is ZSA.
-    pub(crate) fn from_action_context_unchecked(
-        spend: SpendInfo,
-        output_note: Note,
-        alpha: pallas::Scalar,
-        rcv: ValueCommitTrapdoor,
-        circuit_version: OrchardCircuitVersion,
-    ) -> Self {
-        if !(bool::from(spend.note.asset().is_zatoshi())) {
-            panic!("asset must be zatoshi in OrchardVanilla circuit");
-        }
-        if spend.split_flag {
-            panic!("split_flag must be false in OrchardVanilla circuit");
-        }
-        if circuit_version.is_zsa() {
-            panic!("circuit version must not be ZSA in OrchardVanilla circuit");
-        }
-
-        let (circuit, _) =
-            Self::from_action_context_common(&spend, &output_note, alpha, rcv, circuit_version);
-        circuit
     }
 }
 
@@ -1049,28 +1015,31 @@ mod tests {
         let anchor = path.root(spent_note.commitment().into());
 
         (
-            Circuit::OrchardVanilla(CircuitVanilla {
-                circuit_version,
-                path: Value::known(path.auth_path()),
-                pos: Value::known(path.position()),
-                g_d_old: Value::known(sender_address.g_d()),
-                pk_d_old: Value::known(*sender_address.pk_d()),
-                v_old: Value::known(spent_note.value()),
-                rho_old: Value::known(spent_note.rho()),
-                psi_old: Value::known(spent_note.psi()),
-                rcm_old: Value::known(spent_note.rcm()),
-                cm_old: Value::known(spent_note.commitment()),
-                alpha: Value::known(alpha),
-                ak: Value::known(ak),
-                nk: Value::known(nk),
-                rivk: Value::known(rivk),
-                g_d_new: Value::known(output_note.recipient().g_d()),
-                pk_d_new: Value::known(*output_note.recipient().pk_d()),
-                v_new: Value::known(output_note.value()),
-                psi_new: Value::known(output_note.psi()),
-                rcm_new: Value::known(output_note.rcm()),
-                rcv: Value::known(rcv),
-            }),
+            Circuit {
+                common_witnesses: CircuitVanilla {
+                    circuit_version,
+                    path: Value::known(path.auth_path()),
+                    pos: Value::known(path.position()),
+                    g_d_old: Value::known(sender_address.g_d()),
+                    pk_d_old: Value::known(*sender_address.pk_d()),
+                    v_old: Value::known(spent_note.value()),
+                    rho_old: Value::known(spent_note.rho()),
+                    psi_old: Value::known(spent_note.psi()),
+                    rcm_old: Value::known(spent_note.rcm()),
+                    cm_old: Value::known(spent_note.commitment()),
+                    alpha: Value::known(alpha),
+                    ak: Value::known(ak),
+                    nk: Value::known(nk),
+                    rivk: Value::known(rivk),
+                    g_d_new: Value::known(output_note.recipient().g_d()),
+                    pk_d_new: Value::known(*output_note.recipient().pk_d()),
+                    v_new: Value::known(output_note.value()),
+                    psi_new: Value::known(output_note.psi()),
+                    rcm_new: Value::known(output_note.rcm()),
+                    rcv: Value::known(rcv),
+                },
+                additional_zsa_witnesses: Value::unknown(),
+            },
             Instance {
                 anchor,
                 cv_net,
@@ -1211,7 +1180,7 @@ mod tests {
         let mock_verify = |circuit: &Circuit, instance: &Instance| {
             MockProver::run(
                 K,
-                circuit.as_vanilla().unwrap(),
+                &circuit.common_witnesses,
                 instance
                     .to_halo2_instance()
                     .iter()
@@ -1282,7 +1251,7 @@ mod tests {
         super::plonk::create_proof(
             &pk.params,
             &pk.pk,
-            core::slice::from_ref(circuit.as_vanilla().unwrap()),
+            core::slice::from_ref(&circuit.common_witnesses),
             &raw_instances,
             &mut rng,
             &mut transcript,
@@ -1353,7 +1322,7 @@ mod tests {
             let circuit_cost =
                 halo2_proofs::dev::CircuitCost::<pasta_curves::vesta::Point, _>::measure(
                     K,
-                    circuits[0].as_vanilla().unwrap(),
+                    &circuits[0].common_witnesses,
                 );
             // These sizes are identical for every circuit version: the post-NU 6.3 circuit reuses the
             // existing Orchard checks gate on spare rows and adds no columns or
@@ -1376,7 +1345,7 @@ mod tests {
             assert_eq!(
                 MockProver::run(
                     K,
-                    circuit.as_vanilla().unwrap(),
+                    &circuit.common_witnesses,
                     instance
                         .to_halo2_instance()
                         .iter()

--- a/src/circuit/circuit_vanilla.rs
+++ b/src/circuit/circuit_vanilla.rs
@@ -7,36 +7,26 @@ use group::Curve;
 use pasta_curves::pallas;
 
 use halo2_gadgets::{
-    ecc::{chip::EccChip, FixedPoint, NonIdentityPoint, Point, ScalarFixed, ScalarVar},
-    poseidon::{primitives as poseidon, Pow5Chip as PoseidonChip},
-    sinsemilla::{
-        chip::SinsemillaChip,
-        merkle::{chip::MerkleChip, MerklePath},
-    },
-    utilities::lookup_range_check::{
-        LookupRangeCheck, LookupRangeCheckConfig, PallasLookupRangeCheckConfig,
-    },
+    ecc::{FixedPoint, NonIdentityPoint, Point, ScalarFixed, ScalarVar},
+    sinsemilla::{chip::SinsemillaChip, merkle::MerklePath},
+    utilities::lookup_range_check::PallasLookupRangeCheckConfig,
 };
 use halo2_proofs::{
     circuit::{floor_planner, Layouter, Value},
-    plonk::{self, Constraints, Expression},
+    plonk::{self, Advice, Column, Constraints, Expression, Selector},
     poly::Rotation,
 };
 
 use crate::{
     builder::SpendInfo,
     circuit::{
-        commit_ivk::{gadgets::commit_ivk, CommitIvkChip},
-        derive_nullifier::gadgets::derive_nullifier,
-        gadget::{add_chip::AddChip, assign_free_advice},
-        note_commit::{gadgets::note_commit, NoteCommitChip},
-        value_commit_orchard::gadgets::value_commit_orchard,
-        AddressPoints, Config, OrchardCircuitVersion, ANCHOR, CMX, CV_NET_X, CV_NET_Y,
-        DISABLE_CROSS_ADDRESS, ENABLE_OUTPUT, ENABLE_SPEND, NF_OLD, RK_X, RK_Y,
+        commit_ivk::gadgets::commit_ivk, configure_circuit,
+        derive_nullifier::gadgets::derive_nullifier, gadget::assign_free_advice,
+        note_commit::gadgets::note_commit, value_commit_orchard::gadgets::value_commit_orchard,
+        AddressPoints, Config, OrchardCircuitVersion, OrchardLookup, ANCHOR, CMX, CV_NET_X,
+        CV_NET_Y, DISABLE_CROSS_ADDRESS, ENABLE_OUTPUT, ENABLE_SPEND, NF_OLD, RK_X, RK_Y,
     },
-    constants::{
-        OrchardFixedBases, OrchardFixedBasesFull, OrchardHashDomains, MERKLE_DEPTH_ORCHARD,
-    },
+    constants::{OrchardFixedBasesFull, OrchardHashDomains, MERKLE_DEPTH_ORCHARD},
     keys::{
         CommitIvkRandomness, DiversifiedTransmissionKey, NullifierDerivingKey, SpendValidatingKey,
     },
@@ -175,37 +165,21 @@ impl CircuitVanilla {
     }
 }
 
-impl plonk::Circuit<pallas::Base> for CircuitVanilla {
-    type Config = Config<PallasLookupRangeCheckConfig>;
-    type FloorPlanner = floor_planner::V1;
+impl OrchardLookup for PallasLookupRangeCheckConfig {
+    const IS_ZSA: bool = false;
 
-    fn without_witnesses(&self) -> Self {
-        CircuitVanilla::empty(self.circuit_version)
-    }
-
-    fn configure(meta: &mut plonk::ConstraintSystem<pallas::Base>) -> Self::Config {
-        // Advice columns used in the Orchard circuit.
-        let advices = [
-            meta.advice_column(),
-            meta.advice_column(),
-            meta.advice_column(),
-            meta.advice_column(),
-            meta.advice_column(),
-            meta.advice_column(),
-            meta.advice_column(),
-            meta.advice_column(),
-            meta.advice_column(),
-            meta.advice_column(),
-        ];
-
+    fn configure_orchard_gate(
+        meta: &mut plonk::ConstraintSystem<pallas::Base>,
+        advices: [Column<Advice>; 10],
+        q_orchard: Selector,
+    ) {
         // Constrain v_old - v_new = magnitude * sign    (https://p.z.cash/ZKS:action-cv-net-integrity?partial).
         // Either v_old = 0, or calculated root = anchor (https://p.z.cash/ZKS:action-merkle-path-validity?partial).
         // Constrain v_old = 0 or enable_spend = 1       (https://p.z.cash/ZKS:action-enable-spend).
         // Constrain v_new = 0 or enable_output = 1      (https://p.z.cash/ZKS:action-enable-output).
         //
         // This gate is also reused for the same-address check; see
-        // [`Circuit::synthesize_cross_address_checks`].
-        let q_orchard = meta.selector();
+        // [`CircuitVanilla::synthesize_cross_address_checks`].
         meta.create_gate("Orchard circuit checks", |meta| {
             let q_orchard = meta.query_selector(q_orchard);
             let v_old = meta.query_advice(advices[0], Rotation::cur());
@@ -243,136 +217,19 @@ impl plonk::Circuit<pallas::Base> for CircuitVanilla {
                 ],
             )
         });
+    }
+}
 
-        // Addition of two field elements.
-        let add_config = AddChip::configure(meta, advices[7], advices[8], advices[6]);
+impl plonk::Circuit<pallas::Base> for CircuitVanilla {
+    type Config = Config<PallasLookupRangeCheckConfig>;
+    type FloorPlanner = floor_planner::V1;
 
-        // Fixed columns for the Sinsemilla generator lookup table
-        let table_idx = meta.lookup_table_column();
-        let lookup = (
-            table_idx,
-            meta.lookup_table_column(),
-            meta.lookup_table_column(),
-        );
+    fn without_witnesses(&self) -> Self {
+        CircuitVanilla::empty(self.circuit_version)
+    }
 
-        // Instance column used for public inputs
-        let primary = meta.instance_column();
-        meta.enable_equality(primary);
-
-        // Permutation over all advice columns.
-        for advice in advices.iter() {
-            meta.enable_equality(*advice);
-        }
-
-        // Poseidon requires four advice columns, while ECC incomplete addition requires
-        // six, so we could choose to configure them in parallel. However, we only use a
-        // single Poseidon invocation, and we have the rows to accommodate it serially.
-        // Instead, we reduce the proof size by sharing fixed columns between the ECC and
-        // Poseidon chips.
-        let lagrange_coeffs = [
-            meta.fixed_column(),
-            meta.fixed_column(),
-            meta.fixed_column(),
-            meta.fixed_column(),
-            meta.fixed_column(),
-            meta.fixed_column(),
-            meta.fixed_column(),
-            meta.fixed_column(),
-        ];
-        let rc_a = lagrange_coeffs[2..5].try_into().unwrap();
-        let rc_b = lagrange_coeffs[5..8].try_into().unwrap();
-
-        // Also use the first Lagrange coefficient column for loading global constants.
-        // It's free real estate :)
-        meta.enable_constant(lagrange_coeffs[0]);
-
-        // We have a lot of free space in the right-most advice columns; use one of them
-        // for all of our range checks.
-        let range_check = LookupRangeCheckConfig::configure(meta, advices[9], table_idx);
-
-        // Configuration for curve point operations.
-        // This uses 10 advice columns and spans the whole circuit.
-        let ecc_config =
-            EccChip::<OrchardFixedBases>::configure(meta, advices, lagrange_coeffs, range_check);
-
-        // Configuration for the Poseidon hash.
-        let poseidon_config = PoseidonChip::configure::<poseidon::P128Pow5T3>(
-            meta,
-            // We place the state columns after the partial_sbox column so that the
-            // pad-and-add region can be laid out more efficiently.
-            advices[6..9].try_into().unwrap(),
-            advices[5],
-            rc_a,
-            rc_b,
-        );
-
-        // Configuration for a Sinsemilla hash instantiation and a
-        // Merkle hash instantiation using this Sinsemilla instance.
-        // Since the Sinsemilla config uses only 5 advice columns,
-        // we can fit two instances side-by-side.
-        let (sinsemilla_config_1, merkle_config_1) = {
-            let sinsemilla_config_1 = SinsemillaChip::configure(
-                meta,
-                advices[..5].try_into().unwrap(),
-                advices[6],
-                lagrange_coeffs[0],
-                lookup,
-                range_check,
-                false,
-            );
-            let merkle_config_1 = MerkleChip::configure(meta, sinsemilla_config_1.clone());
-
-            (sinsemilla_config_1, merkle_config_1)
-        };
-
-        // Configuration for a Sinsemilla hash instantiation and a
-        // Merkle hash instantiation using this Sinsemilla instance.
-        // Since the Sinsemilla config uses only 5 advice columns,
-        // we can fit two instances side-by-side.
-        let (sinsemilla_config_2, merkle_config_2) = {
-            let sinsemilla_config_2 = SinsemillaChip::configure(
-                meta,
-                advices[5..].try_into().unwrap(),
-                advices[7],
-                lagrange_coeffs[1],
-                lookup,
-                range_check,
-                false,
-            );
-            let merkle_config_2 = MerkleChip::configure(meta, sinsemilla_config_2.clone());
-
-            (sinsemilla_config_2, merkle_config_2)
-        };
-
-        // Configuration to handle decomposition and canonicity checking
-        // for CommitIvk.
-        let commit_ivk_config = CommitIvkChip::configure(meta, advices);
-
-        // Configuration to handle decomposition and canonicity checking
-        // for NoteCommit_old.
-        let old_note_commit_config =
-            NoteCommitChip::configure(meta, advices, sinsemilla_config_1.clone(), false);
-
-        // Configuration to handle decomposition and canonicity checking
-        // for NoteCommit_new.
-        let new_note_commit_config =
-            NoteCommitChip::configure(meta, advices, sinsemilla_config_2.clone(), false);
-
-        Config {
-            primary,
-            q_orchard,
-            advices,
-            add_config,
-            ecc_config,
-            poseidon_config,
-            merkle_config_1,
-            merkle_config_2,
-            sinsemilla_config_1,
-            sinsemilla_config_2,
-            commit_ivk_config,
-            old_note_commit_config,
-            new_note_commit_config,
-        }
+    fn configure(meta: &mut plonk::ConstraintSystem<pallas::Base>) -> Self::Config {
+        configure_circuit(meta)
     }
 
     #[allow(non_snake_case)]

--- a/src/circuit/circuit_zsa.rs
+++ b/src/circuit/circuit_zsa.rs
@@ -28,7 +28,6 @@ use halo2_proofs::{
 };
 
 use crate::{
-    builder::SpendInfo,
     circuit::{
         commit_ivk::{gadgets::commit_ivk, CommitIvkChip},
         derive_nullifier::{gadgets::derive_nullifier, ZsaNullifierParams},
@@ -42,8 +41,7 @@ use crate::{
         RK_Y,
     },
     constants::{OrchardFixedBases, OrchardFixedBasesFull, OrchardHashDomains},
-    note::{AssetBase, Note},
-    value::ValueCommitTrapdoor,
+    note::AssetBase,
 };
 
 /// The ZSA-specific witnesses.
@@ -85,43 +83,6 @@ impl CircuitZsa {
         }
     }
 
-    /// Constructs a `CircuitZsa` from the following components:
-    /// - `spend`: [`SpendInfo`] of the note spent in scope of the action
-    /// - `output_note`: a note created in scope of the action
-    /// - `alpha`: a scalar used for randomization of the action spend validating key
-    /// - `rcv`: trapdoor for the action value commitment
-    ///
-    /// # Panics
-    ///
-    /// Panics if `circuit_version` is not ZSA.
-    pub(crate) fn from_action_context_unchecked(
-        spend: SpendInfo,
-        output_note: Note,
-        alpha: pallas::Scalar,
-        rcv: ValueCommitTrapdoor,
-        circuit_version: OrchardCircuitVersion,
-    ) -> Self {
-        if !circuit_version.is_zsa() {
-            panic!("circuit version must be ZSA in OrchardZSA circuit");
-        }
-
-        let (common_witnesses, psi_nf) = CircuitVanilla::from_action_context_common(
-            &spend,
-            &output_note,
-            alpha,
-            rcv,
-            circuit_version,
-        );
-
-        CircuitZsa {
-            common_witnesses,
-            additional_zsa_witnesses: Value::known(AdditionalZsaWitnesses {
-                psi_nf,
-                asset: spend.note.asset(),
-                split_flag: spend.split_flag,
-            }),
-        }
-    }
 }
 
 impl plonk::Circuit<pallas::Base> for CircuitZsa {

--- a/src/circuit/circuit_zsa.rs
+++ b/src/circuit/circuit_zsa.rs
@@ -9,38 +9,30 @@ use group::Curve;
 use pasta_curves::{arithmetic::CurveAffine, pallas};
 
 use halo2_gadgets::{
-    ecc::{chip::EccChip, FixedPoint, NonIdentityPoint, Point, ScalarFixed, ScalarVar},
-    poseidon::{primitives as poseidon, Pow5Chip as PoseidonChip},
-    sinsemilla::{
-        chip::SinsemillaChip,
-        merkle::{chip::MerkleChip, MerklePath},
-    },
-    utilities::{
-        bool_check,
-        lookup_range_check::{LookupRangeCheck4_5BConfig, PallasLookupRangeCheck4_5BConfig},
-    },
+    ecc::{FixedPoint, NonIdentityPoint, Point, ScalarFixed, ScalarVar},
+    sinsemilla::{chip::SinsemillaChip, merkle::MerklePath},
+    utilities::{bool_check, lookup_range_check::PallasLookupRangeCheck4_5BConfig},
 };
 
 use halo2_proofs::{
     circuit::{floor_planner, Layouter, Value},
-    plonk::{self, Constraints, Expression},
+    plonk::{self, Advice, Column, Constraints, Expression, Selector},
     poly::Rotation,
 };
 
 use crate::{
     circuit::{
-        commit_ivk::{gadgets::commit_ivk, CommitIvkChip},
+        commit_ivk::gadgets::commit_ivk,
+        configure_circuit,
         derive_nullifier::{gadgets::derive_nullifier, ZsaNullifierParams},
-        gadget::{
-            add_chip::AddChip, assign_free_advice, assign_is_zatoshi_asset, assign_split_flag,
-        },
-        note_commit::{gadgets::note_commit, NoteCommitChip, ZsaNoteCommitParams},
+        gadget::{assign_free_advice, assign_is_zatoshi_asset, assign_split_flag},
+        note_commit::{gadgets::note_commit, ZsaNoteCommitParams},
         value_commit_orchard::{gadgets::value_commit_orchard, ZsaValueCommitParams},
-        AddressPoints, CircuitVanilla, Config, OrchardCircuitVersion, ANCHOR, CMX, CV_NET_X,
-        CV_NET_Y, DISABLE_CROSS_ADDRESS, ENABLE_OUTPUT, ENABLE_SPEND, ENABLE_ZSA, NF_OLD, RK_X,
-        RK_Y,
+        AddressPoints, CircuitVanilla, Config, OrchardCircuitVersion, OrchardLookup, ANCHOR, CMX,
+        CV_NET_X, CV_NET_Y, DISABLE_CROSS_ADDRESS, ENABLE_OUTPUT, ENABLE_SPEND, ENABLE_ZSA, NF_OLD,
+        RK_X, RK_Y,
     },
-    constants::{OrchardFixedBases, OrchardFixedBasesFull, OrchardHashDomains},
+    constants::{OrchardFixedBasesFull, OrchardHashDomains},
     note::AssetBase,
 };
 
@@ -82,32 +74,16 @@ impl CircuitZsa {
             additional_zsa_witnesses: Value::unknown(),
         }
     }
-
 }
 
-impl plonk::Circuit<pallas::Base> for CircuitZsa {
-    type Config = Config<PallasLookupRangeCheck4_5BConfig>;
-    type FloorPlanner = floor_planner::V1;
+impl OrchardLookup for PallasLookupRangeCheck4_5BConfig {
+    const IS_ZSA: bool = true;
 
-    fn without_witnesses(&self) -> Self {
-        CircuitZsa::empty()
-    }
-
-    fn configure(meta: &mut plonk::ConstraintSystem<pallas::Base>) -> Self::Config {
-        // Advice columns used in the Orchard circuit.
-        let advices = [
-            meta.advice_column(),
-            meta.advice_column(),
-            meta.advice_column(),
-            meta.advice_column(),
-            meta.advice_column(),
-            meta.advice_column(),
-            meta.advice_column(),
-            meta.advice_column(),
-            meta.advice_column(),
-            meta.advice_column(),
-        ];
-
+    fn configure_orchard_gate(
+        meta: &mut plonk::ConstraintSystem<pallas::Base>,
+        advices: [Column<Advice>; 10],
+        q_orchard: Selector,
+    ) {
         // The new or updated constraints for OrchardZSA are explained in
         // [ZIP-226: Transfer and Burn of Zcash Shielded Assets][circuitstatement].
         //
@@ -125,7 +101,6 @@ impl plonk::Circuit<pallas::Base> for CircuitZsa {
         // Constrain if disable_cross_address = 1, then split_flag = 0
         //
         // [circuitstatement]: https://zips.z.cash/zip-0226#circuit-statement
-        let q_orchard = meta.selector();
         meta.create_gate("Orchard circuit checks", |meta| {
             let q_orchard = meta.query_selector(q_orchard);
             let v_old = meta.query_advice(advices[0], Rotation::cur());
@@ -235,146 +210,19 @@ impl plonk::Circuit<pallas::Base> for CircuitZsa {
                 ],
             )
         });
+    }
+}
 
-        // Addition of two field elements.
-        let add_config = AddChip::configure(meta, advices[7], advices[8], advices[6]);
+impl plonk::Circuit<pallas::Base> for CircuitZsa {
+    type Config = Config<PallasLookupRangeCheck4_5BConfig>;
+    type FloorPlanner = floor_planner::V1;
 
-        // Fixed columns for the Sinsemilla generator lookup table
-        let table_idx = meta.lookup_table_column();
-        let table_range_check_tag = meta.lookup_table_column();
-        let lookup = (
-            table_idx,
-            meta.lookup_table_column(),
-            meta.lookup_table_column(),
-        );
+    fn without_witnesses(&self) -> Self {
+        CircuitZsa::empty()
+    }
 
-        // Instance column used for public inputs
-        let primary = meta.instance_column();
-        meta.enable_equality(primary);
-
-        // Permutation over all advice columns.
-        for advice in advices.iter() {
-            meta.enable_equality(*advice);
-        }
-
-        // Poseidon requires four advice columns, while ECC incomplete addition requires
-        // six, so we could choose to configure them in parallel. However, we only use a
-        // single Poseidon invocation, and we have the rows to accommodate it serially.
-        // Instead, we reduce the proof size by sharing fixed columns between the ECC and
-        // Poseidon chips.
-        let lagrange_coeffs = [
-            meta.fixed_column(),
-            meta.fixed_column(),
-            meta.fixed_column(),
-            meta.fixed_column(),
-            meta.fixed_column(),
-            meta.fixed_column(),
-            meta.fixed_column(),
-            meta.fixed_column(),
-        ];
-        let rc_a = lagrange_coeffs[2..5].try_into().unwrap();
-        let rc_b = lagrange_coeffs[5..8].try_into().unwrap();
-
-        // Also use the first Lagrange coefficient column for loading global constants.
-        // It's free real estate :)
-        meta.enable_constant(lagrange_coeffs[0]);
-
-        // We have a lot of free space in the right-most advice columns; use one of them
-        // for all of our range checks.
-        let range_check = LookupRangeCheck4_5BConfig::configure_with_tag(
-            meta,
-            advices[9],
-            table_idx,
-            table_range_check_tag,
-        );
-
-        // Configuration for curve point operations.
-        // This uses 10 advice columns and spans the whole circuit.
-        let ecc_config = EccChip::<OrchardFixedBases, PallasLookupRangeCheck4_5BConfig>::configure(
-            meta,
-            advices,
-            lagrange_coeffs,
-            range_check,
-        );
-
-        // Configuration for the Poseidon hash.
-        let poseidon_config = PoseidonChip::configure::<poseidon::P128Pow5T3>(
-            meta,
-            // We place the state columns after the partial_sbox column so that the
-            // pad-and-add region can be laid out more efficiently.
-            advices[6..9].try_into().unwrap(),
-            advices[5],
-            rc_a,
-            rc_b,
-        );
-
-        // Configuration for a Sinsemilla hash instantiation and a
-        // Merkle hash instantiation using this Sinsemilla instance.
-        // Since the Sinsemilla config uses only 5 advice columns,
-        // we can fit two instances side-by-side.
-        let (sinsemilla_config_1, merkle_config_1) = {
-            let sinsemilla_config_1 = SinsemillaChip::configure(
-                meta,
-                advices[..5].try_into().unwrap(),
-                advices[6],
-                lagrange_coeffs[0],
-                lookup,
-                range_check,
-                true,
-            );
-            let merkle_config_1 = MerkleChip::configure(meta, sinsemilla_config_1.clone());
-
-            (sinsemilla_config_1, merkle_config_1)
-        };
-
-        // Configuration for a Sinsemilla hash instantiation and a
-        // Merkle hash instantiation using this Sinsemilla instance.
-        // Since the Sinsemilla config uses only 5 advice columns,
-        // we can fit two instances side-by-side.
-        let (sinsemilla_config_2, merkle_config_2) = {
-            let sinsemilla_config_2 = SinsemillaChip::configure(
-                meta,
-                advices[5..].try_into().unwrap(),
-                advices[7],
-                lagrange_coeffs[1],
-                lookup,
-                range_check,
-                true,
-            );
-            let merkle_config_2 = MerkleChip::configure(meta, sinsemilla_config_2.clone());
-
-            (sinsemilla_config_2, merkle_config_2)
-        };
-
-        // Configuration to handle decomposition and canonicity checking
-        // for CommitIvk.
-        let commit_ivk_config = CommitIvkChip::configure(meta, advices);
-
-        // Configuration to handle decomposition and canonicity checking
-        // for NoteCommit_old.
-        let old_note_commit_config =
-            NoteCommitChip::configure(meta, advices, sinsemilla_config_1.clone(), true);
-
-        // Configuration to handle decomposition and canonicity checking
-        // for NoteCommit_new.
-        let new_note_commit_config =
-            NoteCommitChip::configure(meta, advices, sinsemilla_config_2.clone(), true);
-
-        Config {
-            primary,
-            q_orchard,
-            advices,
-            add_config,
-            ecc_config,
-            poseidon_config,
-            merkle_config_1,
-            merkle_config_2,
-            sinsemilla_config_1,
-            sinsemilla_config_2,
-            commit_ivk_config,
-            old_note_commit_config,
-            new_note_commit_config,
-        }
+    fn configure(meta: &mut plonk::ConstraintSystem<pallas::Base>) -> Self::Config {
+        configure_circuit(meta)
     }
 
     #[allow(non_snake_case)]

--- a/src/circuit/circuit_zsa.rs
+++ b/src/circuit/circuit_zsa.rs
@@ -28,9 +28,9 @@ use crate::{
         gadget::{assign_free_advice, assign_is_zatoshi_asset, assign_split_flag},
         note_commit::{gadgets::note_commit, ZsaNoteCommitParams},
         value_commit_orchard::{gadgets::value_commit_orchard, ZsaValueCommitParams},
-        AddressPoints, CircuitVanilla, Config, OrchardCircuitVersion, OrchardLookup, ANCHOR, CMX,
-        CV_NET_X, CV_NET_Y, DISABLE_CROSS_ADDRESS, ENABLE_OUTPUT, ENABLE_SPEND, ENABLE_ZSA, NF_OLD,
-        RK_X, RK_Y,
+        AddressPoints, CircuitVanilla, Config, OrchardCircuitVersion, ANCHOR, CMX, CV_NET_X,
+        CV_NET_Y, DISABLE_CROSS_ADDRESS, ENABLE_OUTPUT, ENABLE_SPEND, ENABLE_ZSA, NF_OLD, RK_X,
+        RK_Y,
     },
     constants::{OrchardFixedBasesFull, OrchardHashDomains},
     note::AssetBase,
@@ -76,141 +76,139 @@ impl CircuitZsa {
     }
 }
 
-impl OrchardLookup for PallasLookupRangeCheck4_5BConfig {
-    const IS_ZSA: bool = true;
+/// Creates the `q_orchard` gate checking the OrchardZSA Action statement, on the given
+/// selector.
+pub(super) fn configure_zsa_orchard_gate(
+    meta: &mut plonk::ConstraintSystem<pallas::Base>,
+    advices: [Column<Advice>; 10],
+    q_orchard: Selector,
+) {
+    // The new or updated constraints for OrchardZSA are explained in
+    // [ZIP-226: Transfer and Burn of Zcash Shielded Assets][circuitstatement].
+    //
+    // All OrchardZSA constraints:
+    // Constrain split_flag to be boolean
+    // Constrain v_old * (1 - split_flag) - v_new = magnitude * sign
+    // Constrain (v_old = 0 and is_zatoshi_asset = 1) or (calculated root = anchor)
+    // Constrain v_old = 0 or enable_spend = 1
+    // Constrain v_new = 0 or enable_output = 1
+    // Constrain is_zatoshi_asset to be boolean
+    // Constrain if is_zatoshi_asset = 1 then asset = zatoshi_asset else asset != zatoshi_asset
+    // Constrain if split_flag = 0 then psi_old = psi_nf
+    // Constrain if split_flag = 1, then is_zatoshi_asset = 0
+    // Constrain if enable_zsa = 0, then is_zatoshi_asset = 1
+    // Constrain if disable_cross_address = 1, then split_flag = 0
+    //
+    // [circuitstatement]: https://zips.z.cash/zip-0226#circuit-statement
+    meta.create_gate("Orchard circuit checks", |meta| {
+        let q_orchard = meta.query_selector(q_orchard);
+        let v_old = meta.query_advice(advices[0], Rotation::cur());
+        let v_new = meta.query_advice(advices[1], Rotation::cur());
+        let magnitude = meta.query_advice(advices[2], Rotation::cur());
+        let sign = meta.query_advice(advices[3], Rotation::cur());
 
-    fn configure_orchard_gate(
-        meta: &mut plonk::ConstraintSystem<pallas::Base>,
-        advices: [Column<Advice>; 10],
-        q_orchard: Selector,
-    ) {
-        // The new or updated constraints for OrchardZSA are explained in
-        // [ZIP-226: Transfer and Burn of Zcash Shielded Assets][circuitstatement].
-        //
-        // All OrchardZSA constraints:
-        // Constrain split_flag to be boolean
-        // Constrain v_old * (1 - split_flag) - v_new = magnitude * sign
-        // Constrain (v_old = 0 and is_zatoshi_asset = 1) or (calculated root = anchor)
-        // Constrain v_old = 0 or enable_spend = 1
-        // Constrain v_new = 0 or enable_output = 1
-        // Constrain is_zatoshi_asset to be boolean
-        // Constrain if is_zatoshi_asset = 1 then asset = zatoshi_asset else asset != zatoshi_asset
-        // Constrain if split_flag = 0 then psi_old = psi_nf
-        // Constrain if split_flag = 1, then is_zatoshi_asset = 0
-        // Constrain if enable_zsa = 0, then is_zatoshi_asset = 1
-        // Constrain if disable_cross_address = 1, then split_flag = 0
-        //
-        // [circuitstatement]: https://zips.z.cash/zip-0226#circuit-statement
-        meta.create_gate("Orchard circuit checks", |meta| {
-            let q_orchard = meta.query_selector(q_orchard);
-            let v_old = meta.query_advice(advices[0], Rotation::cur());
-            let v_new = meta.query_advice(advices[1], Rotation::cur());
-            let magnitude = meta.query_advice(advices[2], Rotation::cur());
-            let sign = meta.query_advice(advices[3], Rotation::cur());
+        let root = meta.query_advice(advices[4], Rotation::cur());
+        let anchor = meta.query_advice(advices[5], Rotation::cur());
 
-            let root = meta.query_advice(advices[4], Rotation::cur());
-            let anchor = meta.query_advice(advices[5], Rotation::cur());
+        let enable_spend = meta.query_advice(advices[6], Rotation::cur());
+        let enable_output = meta.query_advice(advices[7], Rotation::cur());
 
-            let enable_spend = meta.query_advice(advices[6], Rotation::cur());
-            let enable_output = meta.query_advice(advices[7], Rotation::cur());
+        let split_flag = meta.query_advice(advices[8], Rotation::cur());
 
-            let split_flag = meta.query_advice(advices[8], Rotation::cur());
+        let is_zatoshi_asset = meta.query_advice(advices[9], Rotation::cur());
+        let asset_x = meta.query_advice(advices[0], Rotation::next());
+        let asset_y = meta.query_advice(advices[1], Rotation::next());
+        let diff_asset_x_inv = meta.query_advice(advices[2], Rotation::next());
+        let diff_asset_y_inv = meta.query_advice(advices[3], Rotation::next());
 
-            let is_zatoshi_asset = meta.query_advice(advices[9], Rotation::cur());
-            let asset_x = meta.query_advice(advices[0], Rotation::next());
-            let asset_y = meta.query_advice(advices[1], Rotation::next());
-            let diff_asset_x_inv = meta.query_advice(advices[2], Rotation::next());
-            let diff_asset_y_inv = meta.query_advice(advices[3], Rotation::next());
+        let one = Expression::Constant(pallas::Base::one());
 
-            let one = Expression::Constant(pallas::Base::one());
+        let zatoshi_asset = AssetBase::zatoshi()
+            .cv_base()
+            .to_affine()
+            .coordinates()
+            .unwrap();
 
-            let zatoshi_asset = AssetBase::zatoshi()
-                .cv_base()
-                .to_affine()
-                .coordinates()
-                .unwrap();
+        let diff_asset_x = asset_x - Expression::Constant(*zatoshi_asset.x());
+        let diff_asset_y = asset_y - Expression::Constant(*zatoshi_asset.y());
 
-            let diff_asset_x = asset_x - Expression::Constant(*zatoshi_asset.x());
-            let diff_asset_y = asset_y - Expression::Constant(*zatoshi_asset.y());
+        let psi_old = meta.query_advice(advices[4], Rotation::next());
+        let psi_nf = meta.query_advice(advices[5], Rotation::next());
 
-            let psi_old = meta.query_advice(advices[4], Rotation::next());
-            let psi_nf = meta.query_advice(advices[5], Rotation::next());
+        let enable_zsa = meta.query_advice(advices[6], Rotation::next());
+        let disable_cross_address = meta.query_advice(advices[7], Rotation::next());
 
-            let enable_zsa = meta.query_advice(advices[6], Rotation::next());
-            let disable_cross_address = meta.query_advice(advices[7], Rotation::next());
-
-            Constraints::with_selector(
-                q_orchard,
-                [
-                    ("bool_check split_flag", bool_check(split_flag.clone())),
-                    (
-                        "v_old * (1 - split_flag) - v_new = magnitude * sign",
-                        v_old.clone() * (one.clone() - split_flag.clone())
-                            - v_new.clone()
-                            - magnitude * sign,
-                    ),
-                    // We already checked that
-                    // * is_zatoshi_asset is boolean (just below), and
-                    // * v_old is a 64 bit unsigned integer (in the note commitment evaluation).
-                    // So, 1 - is_zatoshi_asset + v_old = 0 only when (is_zatoshi_asset = 1 and v_old = 0), no overflow can occur.
-                    (
-                        "(v_old = 0 and is_zatoshi_asset = 1) or (root = anchor)",
-                        (v_old.clone() + one.clone() - is_zatoshi_asset.clone()) * (root - anchor),
-                    ),
-                    (
-                        "v_old = 0 or enable_spend = 1",
-                        v_old * (one.clone() - enable_spend),
-                    ),
-                    (
-                        "v_new = 0 or enable_output = 1",
-                        v_new * (one.clone() - enable_output),
-                    ),
-                    (
-                        "bool_check is_zatoshi_asset",
-                        bool_check(is_zatoshi_asset.clone()),
-                    ),
-                    (
-                        "(is_zatoshi_asset = 1) =>  (asset_x = zatoshi_asset_x)",
-                        is_zatoshi_asset.clone() * diff_asset_x.clone(),
-                    ),
-                    (
-                        "(is_zatoshi_asset = 1) => (asset_y = zatoshi_asset_y)",
-                        is_zatoshi_asset.clone() * diff_asset_y.clone(),
-                    ),
-                    // To prove that `asset` is not equal to `zatoshi_asset`, we will prove that at
-                    // least one of `x(asset) - x(zatoshi_asset)` or `y(asset) - y(zatoshi_asset)` is
-                    // not equal to zero.
-                    // To prove that `x(asset) - x(zatoshi_asset)` (resp `y(asset) - y(zatoshi_asset)`)
-                    // is not equal to zero, we will prove that it is invertible.
-                    (
-                        "(is_zatoshi_asset = 0) => (asset != zatoshi_asset)",
-                        (one.clone() - is_zatoshi_asset.clone())
-                            * (diff_asset_x * diff_asset_x_inv - one.clone())
-                            * (diff_asset_y * diff_asset_y_inv - one.clone()),
-                    ),
-                    (
-                        "(split_flag = 0) => (psi_old = psi_nf)",
-                        (one.clone() - split_flag.clone()) * (psi_old - psi_nf),
-                    ),
-                    (
-                        "(split_flag = 1) => (is_zatoshi_asset = 0)",
-                        split_flag.clone() * is_zatoshi_asset.clone(),
-                    ),
-                    (
-                        "(enable_zsa = 0) => (is_zatoshi_asset = 1)",
-                        (one.clone() - enable_zsa) * (one - is_zatoshi_asset),
-                    ),
-                    // `split_flag` and `cross_address_disabled` cannot both be enabled at the
-                    // same time. A split note's output is forced to a negative net value, which
-                    // is not a meaningful self-transfer.
-                    (
-                        "(disable_cross_address = 1) => (split_flag = 0)",
-                        split_flag * disable_cross_address,
-                    ),
-                ],
-            )
-        });
-    }
+        Constraints::with_selector(
+            q_orchard,
+            [
+                ("bool_check split_flag", bool_check(split_flag.clone())),
+                (
+                    "v_old * (1 - split_flag) - v_new = magnitude * sign",
+                    v_old.clone() * (one.clone() - split_flag.clone())
+                        - v_new.clone()
+                        - magnitude * sign,
+                ),
+                // We already checked that
+                // * is_zatoshi_asset is boolean (just below), and
+                // * v_old is a 64 bit unsigned integer (in the note commitment evaluation).
+                // So, 1 - is_zatoshi_asset + v_old = 0 only when (is_zatoshi_asset = 1 and v_old = 0), no overflow can occur.
+                (
+                    "(v_old = 0 and is_zatoshi_asset = 1) or (root = anchor)",
+                    (v_old.clone() + one.clone() - is_zatoshi_asset.clone()) * (root - anchor),
+                ),
+                (
+                    "v_old = 0 or enable_spend = 1",
+                    v_old * (one.clone() - enable_spend),
+                ),
+                (
+                    "v_new = 0 or enable_output = 1",
+                    v_new * (one.clone() - enable_output),
+                ),
+                (
+                    "bool_check is_zatoshi_asset",
+                    bool_check(is_zatoshi_asset.clone()),
+                ),
+                (
+                    "(is_zatoshi_asset = 1) =>  (asset_x = zatoshi_asset_x)",
+                    is_zatoshi_asset.clone() * diff_asset_x.clone(),
+                ),
+                (
+                    "(is_zatoshi_asset = 1) => (asset_y = zatoshi_asset_y)",
+                    is_zatoshi_asset.clone() * diff_asset_y.clone(),
+                ),
+                // To prove that `asset` is not equal to `zatoshi_asset`, we will prove that at
+                // least one of `x(asset) - x(zatoshi_asset)` or `y(asset) - y(zatoshi_asset)` is
+                // not equal to zero.
+                // To prove that `x(asset) - x(zatoshi_asset)` (resp `y(asset) - y(zatoshi_asset)`)
+                // is not equal to zero, we will prove that it is invertible.
+                (
+                    "(is_zatoshi_asset = 0) => (asset != zatoshi_asset)",
+                    (one.clone() - is_zatoshi_asset.clone())
+                        * (diff_asset_x * diff_asset_x_inv - one.clone())
+                        * (diff_asset_y * diff_asset_y_inv - one.clone()),
+                ),
+                (
+                    "(split_flag = 0) => (psi_old = psi_nf)",
+                    (one.clone() - split_flag.clone()) * (psi_old - psi_nf),
+                ),
+                (
+                    "(split_flag = 1) => (is_zatoshi_asset = 0)",
+                    split_flag.clone() * is_zatoshi_asset.clone(),
+                ),
+                (
+                    "(enable_zsa = 0) => (is_zatoshi_asset = 1)",
+                    (one.clone() - enable_zsa) * (one - is_zatoshi_asset),
+                ),
+                // `split_flag` and `cross_address_disabled` cannot both be enabled at the
+                // same time. A split note's output is forced to a negative net value, which
+                // is not a meaningful self-transfer.
+                (
+                    "(disable_cross_address = 1) => (split_flag = 0)",
+                    split_flag * disable_cross_address,
+                ),
+            ],
+        )
+    });
 }
 
 impl plonk::Circuit<pallas::Base> for CircuitZsa {
@@ -222,7 +220,7 @@ impl plonk::Circuit<pallas::Base> for CircuitZsa {
     }
 
     fn configure(meta: &mut plonk::ConstraintSystem<pallas::Base>) -> Self::Config {
-        configure_circuit(meta)
+        configure_circuit(meta, true)
     }
 
     #[allow(non_snake_case)]

--- a/src/circuit/circuit_zsa.rs
+++ b/src/circuit/circuit_zsa.rs
@@ -1059,3 +1059,16 @@ fn synthesize_cross_address_checks(
 }
 
 // TODO ZSA: add tests once ZSA bundle is implemented
+
+#[cfg(test)]
+mod tests {
+    use crate::circuit::VerifyingKey;
+    use crate::circuit_version::OrchardCircuitVersion;
+
+    #[test]
+    fn zsa_keygen() {
+        // Exercises `CircuitZsa`'s full `configure` path, the only coverage of ZSA
+        // keygen until the round-trip tests above exist.
+        let _vk = VerifyingKey::build(OrchardCircuitVersion::ZSA);
+    }
+}


### PR DESCRIPTION
#### Simplify the Circuit type and unify circuit configuration

Net -200 lines, no new public API breakage.

- Make `Circuit` a struct again instead of an enum: the common witnesses plus optional ZSA witnesses (`Value::unknown()` for Vanilla versions). This removes a breaking API change, the variant/version consistency checks, and the `as_zsa().expect(...)` pattern. The circuit version is a single field, and `CircuitVanilla`/`CircuitZsa` are built internally at keygen/prove time.
- Share `configure` between the two circuit variations via a single `configure_circuit(meta, is_zsa)` which builds everything common and dispatches the `q_orchard` gate to `configure_vanilla_orchard_gate` or `configure_zsa_orchard_gate`.
- Add a `zsa_keygen` test, the first coverage of `VerifyingKey::build(ZSA)` and `CircuitZsa::configure`.
