### PR TITLE
Remove orchard primitives fixes 260824

### DIFF
--- a/benches/utils/mod.rs
+++ b/benches/utils/mod.rs
@@ -46,7 +46,7 @@ impl OrchardFlavorBench for IronwoodV3 {
         c: &'a mut Criterion<M>,
         group_name: &str,
     ) -> BenchmarkGroup<'a, M> {
-        c.benchmark_group(format!("[OrchardVanilla] {}", group_name))
+        c.benchmark_group(format!("[Ironwood] {}", group_name))
     }
 }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -205,6 +205,8 @@ pub enum BuildError {
     UnrepresentableFlags,
     /// A coinbase bundle was requested with flags that enable spends.
     CoinbaseSpendsEnabled,
+    /// A burn was added under a [`BundleVersion`] that does not permit ZSA.
+    BurnNotPermitted,
 }
 
 impl fmt::Display for BuildError {
@@ -248,6 +250,9 @@ impl fmt::Display for BuildError {
             ),
             CoinbaseSpendsEnabled => {
                 f.write_str("A coinbase bundle was requested with flags that enable spends.")
+            }
+            BurnNotPermitted => {
+                f.write_str("A burn was added under a bundle version that does not permit ZSA.")
             }
         }
     }
@@ -1047,7 +1052,7 @@ impl Builder {
         use alloc::collections::btree_map::Entry;
 
         if !self.bundle_version.permits_zsa() {
-            return Err(BuildError::Burn(BurnError::BurnNotPermitted));
+            return Err(BuildError::BurnNotPermitted);
         }
 
         if asset.is_zatoshi().into() {
@@ -2471,6 +2476,27 @@ mod tests {
                 EMPTY_ROOTS[MERKLE_DEPTH_ORCHARD].into(),
             ),
             Err(BuildError::UnrepresentableFlags)
+        ));
+    }
+
+    #[test]
+    fn add_burn_rejects_non_zsa_version() {
+        // Burn is only encoded in the ZSA transaction format, so a non-ZSA builder must not
+        // accept one -- otherwise `derive_bvk` would fold in a burn that a wire-reparsed copy
+        // of the same bundle could not reproduce.
+        let mut rng = OsRng;
+        let bundle_version = BundleVersion::ironwood_v3();
+        let mut builder = Builder::new(
+            BundleType::DEFAULT,
+            bundle_version,
+            bundle_version.default_flags(),
+            EMPTY_ROOTS[MERKLE_DEPTH_ORCHARD].into(),
+        )
+        .unwrap();
+
+        assert!(matches!(
+            builder.add_burn(AssetBase::random(&mut rng), NoteValue::from_raw(1)),
+            Err(BuildError::BurnNotPermitted)
         ));
     }
 

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -1455,7 +1455,12 @@ pub mod testing {
             acts in vec(arb_unauthorized_action_n(bundle_version.note_version(), n_actions, flags), n_actions),
             anchor in arb_base().prop_map(Anchor::from),
             flags in Just(flags),
-            burn in vec(arb_asset_to_burn(), 1usize..10),
+            // `from_parts` rejects a burn under a version that does not permit ZSA.
+            burn in if bundle_version.permits_zsa() {
+                vec(arb_asset_to_burn(), 1usize..10).boxed()
+            } else {
+                Just(Vec::<(AssetBase, NoteValue)>::new()).boxed()
+            },
             bundle_version in Just(bundle_version),
         ) -> Bundle<Unauthorized, ValueSum> {
             let (balances, actions): (Vec<ValueSum>, Vec<Action<_>>) = acts.into_iter().unzip();
@@ -1470,7 +1475,7 @@ pub mod testing {
                 super::EffectsOnly,
                 bundle_version,
             )
-            .expect("flags are normalized to be representable under bundle_version")
+            .expect("flags are normalized and burn is empty unless the version permits ZSA")
         }
     }
 

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -1475,12 +1475,15 @@ pub mod testing {
     }
 
     prop_compose! {
-        /// Generate an arbitrary bundle with fake authorization data. This bundle does not
-        /// necessarily respect consensus rules; for that use
-        /// [`crate::builder::testing::arb_bundle`]
-        pub fn arb_bundle(n_actions: usize)
+        /// Generate an arbitrary bundle with fake authorization data, for a `bundle_version`
+        /// drawn from `versions`.
+        ///
+        /// `burn` is derived from the drawn version rather than drawn independently: it is
+        /// non-empty only when the version permits ZSA, since `try_from_parts` rejects a burn
+        /// under any other version as `BurnNotPermitted`.
+        fn arb_bundle_for_versions(n_actions: usize, versions: impl Strategy<Value = BundleVersion>)
         (
-            bundle_version in arb_bundle_version(),
+            bundle_version in versions,
             flags in arb_flags(),
         )
         (
@@ -1495,12 +1498,10 @@ pub mod testing {
             ),
             fake_sighash in prop::array::uniform32(prop::num::u8::ANY),
             flags in Just(flags),
-            // Burn is only permitted under a `bundle_version` that permits ZSA; keep it empty
-            // otherwise, so `try_from_parts` doesn't reject it as `BurnNotPermitted`.
             burn in if bundle_version.permits_zsa() {
                 vec(arb_asset_to_burn(), 1usize..10).boxed()
             } else {
-                Just(alloc::vec![]).boxed()
+                Just(Vec::<(AssetBase, NoteValue)>::new()).boxed()
             },
             bundle_version in Just(bundle_version),
         ) -> Bundle<Authorized, ValueSum> {
@@ -1524,87 +1525,23 @@ pub mod testing {
         }
     }
 
-    prop_compose! {
-        /// Like [`arb_bundle`], but never draws the ZSA `BundleVersion`.
-        pub fn arb_bundle_vanilla(n_actions: usize)
-        (
-            bundle_version in arb_bundle_version_vanilla(),
-            flags in arb_flags(),
-        )
-        (
-            acts in vec(arb_action_n(bundle_version.note_version(), n_actions, flags), n_actions),
-            anchor in arb_base().prop_map(Anchor::from),
-            sk in arb_binding_signing_key(),
-            rng_seed in prop::array::uniform32(prop::num::u8::ANY),
-            // A fake proof of the canonical length, so the bundle passes `try_from_parts`.
-            fake_proof in vec(
-                prop::num::u8::ANY,
-                Proof::expected_proof_size(bundle_version, n_actions),
-            ),
-            fake_sighash in prop::array::uniform32(prop::num::u8::ANY),
-            flags in Just(flags),
-            bundle_version in Just(bundle_version),
-        ) -> Bundle<Authorized, ValueSum> {
-            let (balances, actions): (Vec<ValueSum>, Vec<Action<_>>) = acts.into_iter().unzip();
-            let rng = StdRng::from_seed(rng_seed);
-            let flags = flags_for_version(bundle_version, flags);
-
-            Bundle::try_from_parts(
-                NonEmpty::from_vec(actions).unwrap(),
-                flags,
-                balances.into_iter().sum::<Result<ValueSum, _>>().unwrap(),
-                vec![], // No burn for non-ZSA bundle
-                anchor,
-                Authorized {
-                    proof: Proof::new(fake_proof),
-                    binding_signature: OrchardBindingSig::new(OrchardSighashKind::AllEffecting, sk.sign(rng, &fake_sighash)),
-                },
-                bundle_version,
-            )
-            .expect("fake proof has the canonical length and flags are representable")
-        }
+    /// Generate an arbitrary bundle with fake authorization data. This bundle does not
+    /// necessarily respect consensus rules; for that use
+    /// [`crate::builder::testing::arb_bundle`]
+    pub fn arb_bundle(n_actions: usize) -> impl Strategy<Value = Bundle<Authorized, ValueSum>> {
+        arb_bundle_for_versions(n_actions, arb_bundle_version())
     }
 
-    prop_compose! {
-        /// Like [`arb_bundle`], but always draws the ZSA `BundleVersion`.
-        pub fn arb_bundle_zsa(n_actions: usize)
-        (
-            bundle_version in Just(BundleVersion::zsa()),
-            flags in arb_flags(),
-        )
-        (
-            acts in vec(arb_action_n(bundle_version.note_version(), n_actions, flags), n_actions),
-            anchor in arb_base().prop_map(Anchor::from),
-            sk in arb_binding_signing_key(),
-            rng_seed in prop::array::uniform32(prop::num::u8::ANY),
-            // A fake proof of the canonical length, so the bundle passes `try_from_parts`.
-            fake_proof in vec(
-                prop::num::u8::ANY,
-                Proof::expected_proof_size(bundle_version, n_actions),
-            ),
-            fake_sighash in prop::array::uniform32(prop::num::u8::ANY),
-            flags in Just(flags),
-            burn in vec(arb_asset_to_burn(), 1usize..10),
-            bundle_version in Just(bundle_version),
-        ) -> Bundle<Authorized, ValueSum> {
-            let (balances, actions): (Vec<ValueSum>, Vec<Action<_>>) = acts.into_iter().unzip();
-            let rng = StdRng::from_seed(rng_seed);
-            let flags = flags_for_version(bundle_version, flags);
+    /// Like [`arb_bundle`], but never draws the ZSA `BundleVersion`.
+    pub fn arb_bundle_vanilla(
+        n_actions: usize,
+    ) -> impl Strategy<Value = Bundle<Authorized, ValueSum>> {
+        arb_bundle_for_versions(n_actions, arb_bundle_version_vanilla())
+    }
 
-            Bundle::try_from_parts(
-                NonEmpty::from_vec(actions).unwrap(),
-                flags,
-                balances.into_iter().sum::<Result<ValueSum, _>>().unwrap(),
-                burn,
-                anchor,
-                Authorized {
-                    proof: Proof::new(fake_proof),
-                    binding_signature: OrchardBindingSig::new(OrchardSighashKind::AllEffecting, sk.sign(rng, &fake_sighash)),
-                },
-                bundle_version,
-            )
-            .expect("fake proof has the canonical length and flags are representable")
-        }
+    /// Like [`arb_bundle`], but always draws the ZSA `BundleVersion`.
+    pub fn arb_bundle_zsa(n_actions: usize) -> impl Strategy<Value = Bundle<Authorized, ValueSum>> {
+        arb_bundle_for_versions(n_actions, Just(BundleVersion::zsa()))
     }
 }
 

--- a/src/bundle/burn_validation.rs
+++ b/src/bundle/burn_validation.rs
@@ -23,6 +23,7 @@ pub const MAX_BURN_VALUE: u64 = (1u64 << 63) - 1;
 
 /// Possible errors that can occur during bundle burn validation.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[non_exhaustive]
 pub enum BurnError {
     /// Encountered a duplicate asset to burn.
     DuplicateAsset,
@@ -36,11 +37,6 @@ pub enum BurnError {
     AssetNotFoundInState,
     /// Insufficient supply for burn.
     InsufficientSupply,
-    /// A non-empty burn was provided for a bundle whose version does not permit ZSA.
-    ///
-    /// Burn instructions are only meaningful for the ZSA protocol; a bundle for a
-    /// version that does not permit ZSA must not carry any burn.
-    BurnNotPermitted,
 }
 
 impl fmt::Display for BurnError {
@@ -58,9 +54,6 @@ impl fmt::Display for BurnError {
                 write!(f, "Asset not found in global issuance state")
             }
             BurnError::InsufficientSupply => write!(f, "Insufficient supply for burn"),
-            BurnError::BurnNotPermitted => f.write_str(
-                "a non-empty burn was provided for a bundle version that does not permit ZSA",
-            ),
         }
     }
 }

--- a/src/bundle/commitments.rs
+++ b/src/bundle/commitments.rs
@@ -32,6 +32,11 @@ const ZCASH_IRONWOOD_ACTIONS_MEMOS_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxIdIrnA
 const ZCASH_IRONWOOD_ACTIONS_NONCOMPACT_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxIdIrnActNH_v6";
 const ZCASH_IRONWOOD_SIGS_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxAuthIrnwdH_v6";
 
+// These are this fork's own strings, not ZIP-246's: ZIP-246 is withdrawn, and ZIP-229 does not
+// include the ZSA values yet.
+//
+// TODO Re-derive these from the ZSA digest spec once published, and add its test vectors.
+// Changing any string here changes consensus-visible digests.
 const ZCASH_ZSA_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxIdOrchardZsaH";
 const ZCASH_ZSA_ACTION_GROUPS_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxIdZsaActGHash";
 const ZCASH_ZSA_ACTIONS_COMPACT_HASH_PERSONALIZATION: &[u8; 16] = b"ZTxIdZsaActCHash";
@@ -256,7 +261,7 @@ fn hash_bundle_txid_data_vanilla<A: Authorization, V: Copy + Into<i64>>(
 }
 
 /// Evaluate `orchard_digest` for the ZSA bundle as defined in
-/// [ZIP-246: Digests for the Version 6 Transaction Format][zip246]
+/// [ZIP-246: Digests for the Withdrawn Version 6 Transaction Format][zip246]
 ///
 /// [zip246]: https://zips.z.cash/zip-0246
 fn hash_bundle_txid_data_zsa<A: Authorization, V: Copy + Into<i64>>(
@@ -320,7 +325,7 @@ fn hash_bundle_txid_data_zsa<A: Authorization, V: Copy + Into<i64>>(
 /// Evaluate `orchard_digest` for the bundle as defined in
 /// [ZIP-244: Transaction Identifier Non-Malleability][zip244] for Orchard, as defined in
 /// [ZIP-229: Version 6 Transaction Format][zip229] for Ironwood, and as defined in
-/// [ZIP-246: Digests for the Version 6 Transaction Format][zip246] for ZSA.
+/// [ZIP-246: Digests for the Withdrawn Version 6 Transaction Format][zip246] for ZSA.
 ///
 /// [zip244]: https://zips.z.cash/zip-0244
 /// [zip229]: https://zips.z.cash/zip-0229
@@ -341,7 +346,7 @@ pub(crate) fn hash_bundle_txid_data<A: Authorization, V: Copy + Into<i64>>(
 /// Construct the commitment for the absent bundle as defined in
 /// [ZIP-244: Transaction Identifier Non-Malleability][zip244] for Orchard V5, as defined in
 /// [ZIP-229: Version 6 Transaction Format][zip229] for Orchard V6 and Ironwood V6, and as defined in
-/// [ZIP-246: Digests for the Version 6 Transaction Format][zip246] for ZSA, according to the
+/// [ZIP-246: Digests for the Withdrawn Version 6 Transaction Format][zip246] for ZSA, according to the
 /// (value_pool, tx_version) pair.
 ///
 /// [zip244]: https://zips.z.cash/zip-0244
@@ -403,7 +408,7 @@ fn hash_bundle_auth_data_vanilla<V>(
 }
 
 /// Evaluate `orchard_auth_digest` for the ZSA bundle as defined in
-/// [ZIP-246: Digests for the Version 6 Transaction Format][zip246]
+/// [ZIP-246: Digests for the Withdrawn Version 6 Transaction Format][zip246]
 ///
 /// The `sighash_info_for_kind` closure returns the `SighashInfo` encoding
 /// for a given [`OrchardSighashKind`].
@@ -460,7 +465,7 @@ fn hash_bundle_auth_data_zsa<V>(
 /// Evaluate `orchard_auth_digest` for the bundle as defined in
 /// [ZIP-244: Transaction Identifier Non-Malleability][zip244] for Orchard, as defined in
 /// [ZIP-229: Version 6 Transaction Format][zip229] for Ironwood, and as defined in
-/// [ZIP-246: Digests for the Version 6 Transaction Format][zip246] for ZSA.
+/// [ZIP-246: Digests for the Withdrawn Version 6 Transaction Format][zip246] for ZSA.
 ///
 /// The `sighash_info_for_kind` closure returns the `SighashInfo` encoding
 /// for a given [`OrchardSighashKind`].
@@ -487,7 +492,7 @@ pub(crate) fn hash_bundle_auth_data<V>(
 /// Construct the commitment for the absent bundle as defined in
 /// [ZIP-244: Transaction Identifier Non-Malleability][zip244] for Orchard V5, as defined in
 /// [ZIP-229: Version 6 Transaction Format][zip229] for Orchard V6 and Ironwood V6, and as defined in
-/// [ZIP-246: Digests for the Version 6 Transaction Format][zip246] for ZSA, according to the
+/// [ZIP-246: Digests for the Withdrawn Version 6 Transaction Format][zip246] for ZSA, according to the
 /// (value_pool, tx_version) pair.
 ///
 /// [zip244]: https://zips.z.cash/zip-0244

--- a/src/bundle/commitments.rs
+++ b/src/bundle/commitments.rs
@@ -175,9 +175,8 @@ impl BundleCommitmentFormat {
     /// Returns `true` if the anchor should be included in the authorizing digest
     /// for this bundle commitment format.
     ///
-    /// Note: for `ZSA`, this function is not used in `hash_bundle_auth_data_zsa`, since
-    /// the format is already known to be `ZSA` there, so the anchor is always
-    /// included unconditionally.
+    /// Only `hash_bundle_auth_data_vanilla` branches on this. `hash_bundle_auth_data_zsa`
+    /// appends the anchor unconditionally and just asserts this flag agrees.
     fn includes_anchor_in_authorizing_digest(self) -> bool {
         matches!(
             self,

--- a/src/note_encryption.rs
+++ b/src/note_encryption.rs
@@ -35,13 +35,13 @@ const NOTE_VALUE_OFFSET: usize = NOTE_DIVERSIFIER_OFFSET + NOTE_DIVERSIFIER_SIZE
 const NOTE_RSEED_OFFSET: usize = NOTE_VALUE_OFFSET + NOTE_VALUE_SIZE;
 
 /// The size of a Vanilla compact note.
-pub(crate) const COMPACT_NOTE_SIZE_VANILLA: usize = NOTE_RSEED_OFFSET + NOTE_RSEED_SIZE;
+pub const COMPACT_NOTE_SIZE_VANILLA: usize = NOTE_RSEED_OFFSET + NOTE_RSEED_SIZE;
 
 /// The size of the encoding of a ZSA asset.
 const ZSA_ASSET_SIZE: usize = 32;
 
 /// The size of a ZSA compact note.
-pub(crate) const COMPACT_NOTE_SIZE_ZSA: usize = COMPACT_NOTE_SIZE_VANILLA + ZSA_ASSET_SIZE;
+pub const COMPACT_NOTE_SIZE_ZSA: usize = COMPACT_NOTE_SIZE_VANILLA + ZSA_ASSET_SIZE;
 
 /// The size of the memo.
 pub(crate) const MEMO_SIZE: usize = 512;


### PR DESCRIPTION
Follow-up review fixes on top of `remove_orchard_primitives`.

- Give the Ironwood benches their own criterion prefix. `OrchardV2` and `IronwoodV3` both
  emitted `"[OrchardVanilla]"`, and the bench IDs carry no flavor information, so the Ironwood
  results silently overwrote the Orchard ones. Now `"[Ironwood]"`.
- Correct the `includes_anchor_in_authorizing_digest` doc comment. It claimed the function is
  not used in `hash_bundle_auth_data_zsa`, which calls it in an `assert!`.
- Collapse `arb_bundle`, `arb_bundle_vanilla` and `arb_bundle_zsa` into one shared strategy plus
  three wrappers. Burn is derived from the drawn version, so the two special cases fall out of
  the same rule. Draws unchanged; net -63 lines.
- Make `COMPACT_NOTE_SIZE_VANILLA`/`ZSA` public. They were `pub(crate)` while appearing in the
  `pub` variant types of `CompactNoteCiphertextBytes` / `NotePlaintextBytes`.
- Derive burn from the version in `arb_unauthorized_bundle`. Adding `validate_burn` to
  `from_parts` made it panic on every non-ZSA draw. It is unused in-tree, so CI stayed green
  while downstream proptests broke.
- Document that the ZSA personalizations are this fork's own rather than ZIP-246's, correct the
  six doc comments that cited ZIP-246 under a title it no longer has, and add a TODO to
  re-derive them once the ZSA digest spec is published. Comments only.
- Move the burn-not-permitted builder error onto `BuildError`. `BurnNotPermitted` existed on
  both `BurnError` and `BundleError`; the `BurnError` copy had one caller. Also marks
  `BurnError` `#[non_exhaustive]` and adds the missing test for the `add_burn` gate.

#### impact

- Added `BuildError::BurnNotPermitted`. `BuildError` is `#[non_exhaustive]`, so not a break.
- Removed `BurnError::BurnNotPermitted`, which was introduced earlier on this branch and never
  released, so it is not a break against `zsa1`.
- `BurnError` is now `#[non_exhaustive]`; breaks downstream exhaustive matches on it.
- `COMPACT_NOTE_SIZE_VANILLA` / `COMPACT_NOTE_SIZE_ZSA` are now `pub`.
- `arb_bundle`, `arb_bundle_vanilla`, `arb_bundle_zsa` return `impl Strategy<Value = ...>`
  instead of the `prop_compose!`-generated opaque type. Same bound; callers unaffected.
